### PR TITLE
Refine mobile layout and thematic outline

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,485 @@
+@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@500;700&family=Source+Serif+Pro:wght@400;600&display=swap');
+
+:root {
+  color-scheme: dark;
+  font-family: 'Source Serif Pro', 'Times New Roman', serif;
+  background-color: #050505;
+}
+
+body {
+  margin: 0;
+  background: #050505;
+  color: #e6e6e6;
+}
+
+#root {
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: stretch;
+}
+
+.app-shell {
+  width: min(100%, 420px);
+  min-height: 100vh;
+  background: radial-gradient(circle at top, rgba(20, 20, 20, 0.92) 0%, rgba(5, 5, 5, 0.96) 55%, #030303 100%);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.35);
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+.app-header {
+  padding: 24px 24px 16px;
+  text-align: center;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.app-title {
+  font-family: 'Playfair Display', 'Times New Roman', serif;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  margin: 0;
+  font-size: 1.75rem;
+  color: #f2f2f2;
+}
+
+.app-subtitle {
+  margin: 8px 0 0;
+  font-size: 0.85rem;
+  color: rgba(214, 214, 214, 0.75);
+  letter-spacing: 0.08em;
+}
+
+.main-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px 20px 96px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.tab-section {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.panel {
+  background: rgba(10, 10, 10, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 16px;
+  padding: 16px 18px;
+  box-shadow: inset 0 0 20px rgba(255, 255, 255, 0.02);
+}
+
+.panel-title {
+  font-family: 'Playfair Display', 'Times New Roman', serif;
+  text-transform: uppercase;
+  font-size: 0.9rem;
+  letter-spacing: 0.12em;
+  margin: 0 0 12px;
+  color: #d9d9d9;
+}
+
+.level-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 12px;
+}
+
+.level-card {
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 14px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  transition: border 0.2s ease, background 0.2s ease;
+}
+
+.level-card.is-active {
+  border-color: rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.level-name {
+  font-family: 'Playfair Display';
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  color: #f5f5f5;
+  margin: 0;
+}
+
+.level-formula {
+  font-size: 0.75rem;
+  color: rgba(214, 214, 214, 0.65);
+  font-style: italic;
+}
+
+.level-description {
+  font-size: 0.75rem;
+  line-height: 1.5;
+  color: rgba(214, 214, 214, 0.75);
+}
+
+.board-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  align-items: center;
+}
+
+.board-slate {
+  padding: 12px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  background: rgba(6, 6, 6, 0.95);
+}
+
+.board-stage {
+  position: relative;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  background: rgba(8, 8, 8, 0.92);
+}
+
+.board-cell {
+  position: absolute;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  background: rgba(255, 255, 255, 0.02);
+  transition: background 0.2s ease;
+}
+
+.board-cell.is-path {
+  background: rgba(255, 255, 255, 0.01);
+  border-color: rgba(255, 255, 255, 0.03);
+}
+
+.tower-node {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.16) 0%, rgba(255, 255, 255, 0.05) 65%, rgba(0, 0, 0, 0.8) 100%);
+  font-family: 'Playfair Display';
+  color: #f5f5f5;
+  letter-spacing: 0.06em;
+}
+
+.tower-node small {
+  font-size: 0.55rem;
+  letter-spacing: 0.08em;
+}
+
+.enemy-glyph {
+  position: absolute;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: radial-gradient(circle at 30% 30%, rgba(210, 90, 90, 0.9) 0%, rgba(120, 32, 32, 0.9) 55%, rgba(30, 10, 10, 0.95) 100%);
+  transition: transform 0.1s linear;
+}
+
+.enemy-health-bar {
+  position: absolute;
+  top: -10px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 28px;
+  height: 4px;
+  border-radius: 2px;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.enemy-health-bar span {
+  display: block;
+  height: 100%;
+  border-radius: 2px;
+  background: linear-gradient(90deg, rgba(214, 214, 214, 0.9) 0%, rgba(139, 191, 166, 0.9) 100%);
+  transition: width 0.2s ease;
+}
+
+.board-note {
+  font-size: 0.7rem;
+  color: rgba(214, 214, 214, 0.55);
+  text-align: center;
+  line-height: 1.4;
+}
+
+.tab-bar {
+  position: sticky;
+  bottom: 0;
+  margin-top: auto;
+  background: rgba(5, 5, 5, 0.98);
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  padding: 10px 8px;
+  gap: 8px;
+}
+
+.tab-button {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 12px;
+  color: rgba(225, 225, 225, 0.82);
+  font-family: 'Playfair Display', 'Times New Roman', serif;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  padding: 10px 6px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  cursor: pointer;
+  transition: border 0.2s ease, color 0.2s ease, background 0.2s ease;
+}
+
+.tab-button span {
+  font-size: 0.65rem;
+  text-transform: uppercase;
+}
+
+.tab-button.is-active {
+  color: #f5f5f5;
+  border-color: rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.tab-button:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.2);
+  outline-offset: 2px;
+}
+
+.tower-lexicon {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.tower-card {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  background: rgba(255, 255, 255, 0.03);
+  text-align: left;
+  transition: border 0.2s ease, background 0.2s ease;
+}
+
+.tower-card.is-selected {
+  border-color: rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.07);
+}
+
+.tower-card:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.tower-heading {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+
+.tower-symbol {
+  font-family: 'Playfair Display';
+  font-size: 1.4rem;
+  color: #f5f5f5;
+}
+
+.tower-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 0.7rem;
+  color: rgba(214, 214, 214, 0.7);
+}
+
+.tower-formula {
+  font-size: 0.75rem;
+  color: rgba(214, 214, 214, 0.65);
+  font-style: italic;
+}
+
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.stat-card {
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  background: rgba(255, 255, 255, 0.03);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.stat-label {
+  font-size: 0.7rem;
+  color: rgba(214, 214, 214, 0.6);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.stat-value {
+  font-family: 'Playfair Display';
+  font-size: 1.1rem;
+  letter-spacing: 0.06em;
+}
+
+.control-column {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.control-button {
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  color: rgba(235, 235, 235, 0.86);
+  padding: 12px;
+  font-family: 'Playfair Display';
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: background 0.2s ease, border 0.2s ease;
+}
+
+.control-button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.control-button.primary {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.16);
+}
+
+.control-button.danger {
+  background: rgba(120, 32, 32, 0.2);
+  border-color: rgba(200, 82, 82, 0.25);
+  color: #f2dcdc;
+}
+
+.control-button.safe {
+  background: rgba(26, 71, 53, 0.25);
+  border-color: rgba(76, 138, 112, 0.35);
+  color: #e5f6ea;
+}
+
+.save-toast {
+  position: fixed;
+  top: 24px;
+  right: 16px;
+  padding: 12px 18px;
+  border-radius: 12px;
+  background: rgba(26, 71, 53, 0.9);
+  border: 1px solid rgba(76, 138, 112, 0.45);
+  color: #e6f5eb;
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  z-index: 20;
+}
+
+.powder-grid {
+  display: grid;
+  gap: 12px;
+}
+
+.powder-cell {
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  background: rgba(255, 255, 255, 0.03);
+  padding: 12px 14px;
+}
+
+.powder-title {
+  font-family: 'Playfair Display';
+  letter-spacing: 0.1em;
+  font-size: 0.85rem;
+  margin: 0 0 6px;
+}
+
+.powder-detail {
+  font-size: 0.74rem;
+  color: rgba(214, 214, 214, 0.72);
+  line-height: 1.5;
+}
+
+.option-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.option-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.option-label {
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+}
+
+.toggle {
+  width: 44px;
+  height: 22px;
+  border-radius: 22px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.06);
+  position: relative;
+}
+
+.toggle::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: rgba(245, 245, 245, 0.9);
+  transition: transform 0.2s ease;
+}
+
+.toggle.is-on {
+  background: rgba(76, 138, 112, 0.35);
+  border-color: rgba(76, 138, 112, 0.5);
+}
+
+.toggle.is-on::after {
+  transform: translateX(22px);
+}
+
+.guide-text {
+  font-size: 0.74rem;
+  line-height: 1.6;
+  color: rgba(214, 214, 214, 0.72);
+}
+
+.helper-emphasis {
+  font-style: italic;
+  letter-spacing: 0.06em;
+  color: rgba(235, 235, 235, 0.86);
+}

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -8,6 +8,13 @@ interface GameBoardProps {
   onCellClick: (x: number, y: number) => void;
 }
 
+const TOWER_SIGILS: Record<TowerType, string> = {
+  basic: 'α',
+  sniper: 'λ',
+  cannon: 'θ',
+  lightning: 'ζ',
+};
+
 export const GameBoard: React.FC<GameBoardProps> = ({ gameState, selectedTower, onCellClick }) => {
   const isPathCell = (x: number, y: number): boolean => {
     return PATH_POINTS.some(point => {
@@ -23,19 +30,15 @@ export const GameBoard: React.FC<GameBoardProps> = ({ gameState, selectedTower, 
     });
   };
 
-  const getTowerColor = (type: TowerType): string => {
-    switch (type) {
-      case 'basic': return '#4CAF50';
-      case 'sniper': return '#2196F3';
-      case 'cannon': return '#FF5722';
-      case 'lightning': return '#9C27B0';
-      default: return '#757575';
-    }
-  };
+  const boardWidth = GRID_WIDTH * GRID_SIZE;
+  const boardHeight = GRID_HEIGHT * GRID_SIZE;
 
   return (
-    <div style={{ position: 'relative', width: GRID_WIDTH * GRID_SIZE, height: GRID_HEIGHT * GRID_SIZE, border: '2px solid #333', backgroundColor: '#1a1a1a' }}>
-      <svg width={GRID_WIDTH * GRID_SIZE} height={GRID_HEIGHT * GRID_SIZE} style={{ position: 'absolute', top: 0, left: 0 }}>
+    <div
+      className="board-stage"
+      style={{ width: boardWidth, height: boardHeight }}
+    >
+      <svg width={boardWidth} height={boardHeight} style={{ position: 'absolute', top: 0, left: 0 }}>
         {PATH_POINTS.map((point, index) => {
           const nextPoint = PATH_POINTS[index + 1];
           if (!nextPoint) return null;
@@ -46,8 +49,9 @@ export const GameBoard: React.FC<GameBoardProps> = ({ gameState, selectedTower, 
               y1={point.y * GRID_SIZE + GRID_SIZE / 2}
               x2={nextPoint.x * GRID_SIZE + GRID_SIZE / 2}
               y2={nextPoint.y * GRID_SIZE + GRID_SIZE / 2}
-              stroke="#8B4513"
-              strokeWidth={GRID_SIZE * 0.8}
+              stroke="rgba(255,255,255,0.08)"
+              strokeWidth={GRID_SIZE * 0.7}
+              strokeLinecap="round"
             />
           );
         })}
@@ -62,45 +66,29 @@ export const GameBoard: React.FC<GameBoardProps> = ({ gameState, selectedTower, 
             <div
               key={`${x}-${y}`}
               onClick={() => !isPath && onCellClick(x, y)}
+              className={`board-cell${isPath ? ' is-path' : ''}`}
               style={{
-                position: 'absolute',
                 left: x * GRID_SIZE,
                 top: y * GRID_SIZE,
                 width: GRID_SIZE,
                 height: GRID_SIZE,
-                border: '1px solid #333',
                 cursor: !isPath && selectedTower ? 'pointer' : 'default',
-                backgroundColor: isPath ? 'transparent' : 'rgba(255,255,255,0.05)',
-                transition: 'background-color 0.2s',
               }}
-              onMouseEnter={(e) => {
+              onMouseEnter={event => {
                 if (!isPath && selectedTower) {
-                  e.currentTarget.style.backgroundColor = 'rgba(255,255,255,0.2)';
+                  event.currentTarget.style.backgroundColor = 'rgba(255,255,255,0.08)';
                 }
               }}
-              onMouseLeave={(e) => {
+              onMouseLeave={event => {
                 if (!isPath) {
-                  e.currentTarget.style.backgroundColor = 'rgba(255,255,255,0.05)';
+                  event.currentTarget.style.backgroundColor = 'rgba(255,255,255,0.02)';
                 }
               }}
             >
               {tower && (
-                <div
-                  style={{
-                    width: '100%',
-                    height: '100%',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    backgroundColor: getTowerColor(tower.type),
-                    borderRadius: '50%',
-                    transform: 'scale(0.8)',
-                    fontWeight: 'bold',
-                    color: 'white',
-                    fontSize: '12px',
-                  }}
-                >
-                  {tower.level}
+                <div className="tower-node">
+                  <span>{TOWER_SIGILS[tower.type]}</span>
+                  <small>{`ℓ${tower.level}`}</small>
                 </div>
               )}
             </div>
@@ -111,38 +99,16 @@ export const GameBoard: React.FC<GameBoardProps> = ({ gameState, selectedTower, 
       {gameState.enemies.map(enemy => (
         <div
           key={enemy.id}
+          className="enemy-glyph"
           style={{
-            position: 'absolute',
-            left: enemy.position.x - 10,
-            top: enemy.position.y - 10,
-            width: 20,
-            height: 20,
-            borderRadius: '50%',
-            backgroundColor: '#F44336',
-            border: '2px solid #fff',
-            transition: 'all 0.1s linear',
+            left: enemy.position.x - GRID_SIZE * 0.4,
+            top: enemy.position.y - GRID_SIZE * 0.4,
+            width: GRID_SIZE * 0.8,
+            height: GRID_SIZE * 0.8,
           }}
         >
-          <div
-            style={{
-              position: 'absolute',
-              top: -15,
-              left: -5,
-              width: 30,
-              height: 4,
-              backgroundColor: '#333',
-              borderRadius: 2,
-            }}
-          >
-            <div
-              style={{
-                height: '100%',
-                width: `${(enemy.health / enemy.maxHealth) * 100}%`,
-                backgroundColor: '#4CAF50',
-                borderRadius: 2,
-                transition: 'width 0.2s',
-              }}
-            />
+          <div className="enemy-health-bar">
+            <span style={{ width: `${Math.max(0, (enemy.health / enemy.maxHealth) * 100)}%` }} />
           </div>
         </div>
       ))}

--- a/src/components/GameStats.tsx
+++ b/src/components/GameStats.tsx
@@ -12,90 +12,52 @@ export const GameStats: React.FC<GameStatsProps> = ({ gameState, onStartWave, on
   const canStartWave = gameState.enemies.length === 0 && gameState.isPlaying;
 
   return (
-    <div style={{ padding: '20px', backgroundColor: '#2a2a2a', borderRadius: '8px', minWidth: '250px' }}>
-      <h3 style={{ margin: '0 0 15px 0', color: '#fff', fontSize: '18px', fontWeight: 'bold' }}>Game Stats</h3>
-
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', marginBottom: '20px' }}>
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px', backgroundColor: '#1a1a1a', borderRadius: '6px' }}>
-          <span style={{ color: '#aaa', fontSize: '14px' }}>💰 Gold</span>
-          <span style={{ color: '#FFD700', fontWeight: 'bold', fontSize: '16px' }}>{gameState.gold}</span>
+    <div className="tab-section">
+      <div className="stat-grid">
+        <div className="stat-card">
+          <span className="stat-label">Σ Gold</span>
+          <span className="stat-value">{gameState.gold}</span>
         </div>
-
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px', backgroundColor: '#1a1a1a', borderRadius: '6px' }}>
-          <span style={{ color: '#aaa', fontSize: '14px' }}>🌊 Wave</span>
-          <span style={{ color: '#4CAF50', fontWeight: 'bold', fontSize: '16px' }}>{gameState.wave}</span>
+        <div className="stat-card">
+          <span className="stat-label">λ Wave</span>
+          <span className="stat-value">{gameState.wave}</span>
         </div>
-
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px', backgroundColor: '#1a1a1a', borderRadius: '6px' }}>
-          <span style={{ color: '#aaa', fontSize: '14px' }}>❤️ Lives</span>
-          <span style={{ color: gameState.lives > 5 ? '#4CAF50' : '#F44336', fontWeight: 'bold', fontSize: '16px' }}>{gameState.lives}</span>
+        <div className="stat-card">
+          <span className="stat-label">♥ Lives</span>
+          <span
+            className="stat-value"
+            style={{ color: gameState.lives > 5 ? '#dcefe3' : '#f1c7c7' }}
+          >
+            {gameState.lives}
+          </span>
         </div>
-
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px', backgroundColor: '#1a1a1a', borderRadius: '6px' }}>
-          <span style={{ color: '#aaa', fontSize: '14px' }}>⭐ Score</span>
-          <span style={{ color: '#fff', fontWeight: 'bold', fontSize: '16px' }}>{gameState.score}</span>
+        <div className="stat-card">
+          <span className="stat-label">Ξ Score</span>
+          <span className="stat-value">{gameState.score}</span>
         </div>
       </div>
 
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+      <div className="control-column">
         <button
+          type="button"
           onClick={onStartWave}
+          className="control-button primary"
           disabled={!canStartWave}
-          style={{
-            padding: '12px',
-            backgroundColor: canStartWave ? '#4CAF50' : '#1a1a1a',
-            color: canStartWave ? '#fff' : '#666',
-            border: 'none',
-            borderRadius: '6px',
-            cursor: canStartWave ? 'pointer' : 'not-allowed',
-            fontSize: '14px',
-            fontWeight: 'bold',
-            transition: 'all 0.2s',
-          }}
         >
-          {gameState.enemies.length > 0 ? 'Wave in Progress...' : 'Start Next Wave'}
+          {gameState.enemies.length > 0 ? 'Wave in progress…' : 'Commence Next Wave'}
         </button>
-
-        <button
-          onClick={onSaveGame}
-          style={{
-            padding: '10px',
-            backgroundColor: '#2196F3',
-            color: '#fff',
-            border: 'none',
-            borderRadius: '6px',
-            cursor: 'pointer',
-            fontSize: '13px',
-            fontWeight: 'bold',
-            transition: 'all 0.2s',
-          }}
-        >
-          💾 Save Game
+        <button type="button" onClick={onSaveGame} className="control-button safe">
+          Archive Progress Vector
         </button>
-
-        <button
-          onClick={onResetGame}
-          style={{
-            padding: '10px',
-            backgroundColor: '#F44336',
-            color: '#fff',
-            border: 'none',
-            borderRadius: '6px',
-            cursor: 'pointer',
-            fontSize: '13px',
-            fontWeight: 'bold',
-            transition: 'all 0.2s',
-          }}
-        >
-          🔄 New Game
+        <button type="button" onClick={onResetGame} className="control-button danger">
+          Reset Simulation
         </button>
       </div>
 
       {!gameState.isPlaying && gameState.lives === 0 && (
-        <div style={{ marginTop: '15px', padding: '15px', backgroundColor: '#F44336', borderRadius: '6px', textAlign: 'center' }}>
-          <div style={{ color: '#fff', fontWeight: 'bold', fontSize: '16px', marginBottom: '5px' }}>Game Over!</div>
-          <div style={{ color: '#fff', fontSize: '14px' }}>Final Score: {gameState.score}</div>
-        </div>
+        <p className="guide-text" style={{ color: '#f1c7c7' }}>
+          Simulation collapsed. Reinstate the ledger to attempt a new proof.
+        </p>
       )}
     </div>
   );

--- a/src/components/TowerShop.tsx
+++ b/src/components/TowerShop.tsx
@@ -8,82 +8,62 @@ interface TowerShopProps {
   onSelectTower: (type: TowerType) => void;
 }
 
+const TOWER_SYMBOLS: Record<TowerType, string> = {
+  basic: 'α',
+  sniper: 'λ',
+  cannon: 'θ',
+  lightning: 'ζ',
+};
+
+const TOWER_FORMULAS: Record<TowerType, string> = {
+  basic: 'd(t) = 10 + 5⌊t/3⌋',
+  sniper: 'crit = 0.25 · log₂(range)',
+  cannon: 'AoE = πr² with r = level · 0.6',
+  lightning: 'Δt = 800 · 0.85ˡᵉᵛᵉˡ',
+};
+
 export const TowerShop: React.FC<TowerShopProps> = ({ gold, selectedTower, onSelectTower }) => {
   const towerTypes: TowerType[] = ['basic', 'sniper', 'cannon', 'lightning'];
 
-  const getTowerIcon = (type: TowerType): string => {
-    switch (type) {
-      case 'basic': return '🏹';
-      case 'sniper': return '🎯';
-      case 'cannon': return '💣';
-      case 'lightning': return '⚡';
-      default: return '❓';
-    }
-  };
-
-  const getTowerDescription = (type: TowerType): string => {
-    switch (type) {
-      case 'basic': return 'Balanced tower';
-      case 'sniper': return 'Long range, slow';
-      case 'cannon': return 'Area damage';
-      case 'lightning': return 'Fast attacks';
-      default: return '';
-    }
-  };
-
   return (
-    <div style={{ padding: '20px', backgroundColor: '#2a2a2a', borderRadius: '8px', minWidth: '250px' }}>
-      <h3 style={{ margin: '0 0 15px 0', color: '#fff', fontSize: '18px', fontWeight: 'bold' }}>Tower Shop</h3>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
-        {towerTypes.map(type => {
-          const config = TOWER_CONFIGS[type][0];
-          const canAfford = gold >= config.cost;
-          const isSelected = selectedTower === type;
+    <div className="tower-lexicon">
+      {towerTypes.map(type => {
+        const config = TOWER_CONFIGS[type][0];
+        const canAfford = gold >= config.cost;
+        const isSelected = selectedTower === type;
 
-          return (
-            <button
-              key={type}
-              onClick={() => onSelectTower(type)}
-              disabled={!canAfford}
-              style={{
-                padding: '12px',
-                backgroundColor: isSelected ? '#4CAF50' : canAfford ? '#3a3a3a' : '#1a1a1a',
-                color: canAfford ? '#fff' : '#666',
-                border: isSelected ? '2px solid #66BB6A' : '2px solid #444',
-                borderRadius: '6px',
-                cursor: canAfford ? 'pointer' : 'not-allowed',
-                fontSize: '14px',
-                textAlign: 'left',
-                transition: 'all 0.2s',
-                opacity: canAfford ? 1 : 0.5,
-              }}
-            >
-              <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-                <span style={{ fontSize: '24px' }}>{getTowerIcon(type)}</span>
-                <div style={{ flex: 1 }}>
-                  <div style={{ fontWeight: 'bold', textTransform: 'capitalize', marginBottom: '4px' }}>
-                    {type}
-                  </div>
-                  <div style={{ fontSize: '12px', color: '#aaa', marginBottom: '4px' }}>
-                    {getTowerDescription(type)}
-                  </div>
-                  <div style={{ fontSize: '12px' }}>
-                    <span style={{ color: '#FFD700' }}>💰 {config.cost}</span>
-                    {' | '}
-                    <span>⚔️ {config.damage}</span>
-                    {' | '}
-                    <span>📏 {config.range}</span>
-                  </div>
-                </div>
+        return (
+          <button
+            key={type}
+            type="button"
+            onClick={() => onSelectTower(type)}
+            className={`tower-card${isSelected ? ' is-selected' : ''}`}
+            disabled={!canAfford && !isSelected}
+            title="Select this glyph to prepare placement"
+          >
+            <div className="tower-heading">
+              <span className="tower-symbol">{TOWER_SYMBOLS[type]}</span>
+              <div>
+                <div className="level-name" style={{ fontSize: '0.9rem' }}>{type.toUpperCase()}</div>
+                <div className="tower-formula">{TOWER_FORMULAS[type]}</div>
               </div>
-            </button>
-          );
-        })}
-      </div>
+            </div>
+            <div className="tower-meta">
+              <span>Cost₀ = {config.cost}</span>
+              <span>Damage₀ = {config.damage}</span>
+              <span>Range₀ = {config.range}</span>
+              <span>Tempo₀ = {config.attackSpeed}ms</span>
+            </div>
+            {!canAfford && !isSelected && (
+              <span className="guide-text">Earn more gold to awaken this glyph.</span>
+            )}
+          </button>
+        );
+      })}
       {selectedTower && (
-        <div style={{ marginTop: '15px', padding: '10px', backgroundColor: '#1a1a1a', borderRadius: '6px', fontSize: '13px', color: '#aaa' }}>
-          Click on the board to place your tower
-        </div>
+        <p className="guide-text">
+          {`Selected glyph ${TOWER_SYMBOLS[selectedTower]} • Tap a vacant node in the arena to cast it.`}
+        </p>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- reshape the app into a portrait-oriented shell with arena, tower lexicon, powder simulation, and codex tabs inspired by the glyph defense brief
- apply a monochrome mathematical aesthetic via new shared styling and glyph-driven UI for the board, stats, and tower catalog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f86100cf50832abddc848052d64097