### PR TITLE
Handle missing Supabase configuration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,6 +74,13 @@ function App() {
   }, []);
 
   const loadGame = async () => {
+    if (!supabase) {
+      if (import.meta.env.DEV) {
+        console.info('Supabase is not configured. Skipping cloud save restore.');
+      }
+      return;
+    }
+
     try {
       const { data, error } = await supabase
         .from('game_saves')
@@ -102,6 +109,12 @@ function App() {
   };
 
   const saveGame = async () => {
+    if (!supabase) {
+      setSaveMessage('⚠ Cloud archives unavailable.');
+      setTimeout(() => setSaveMessage(''), 2000);
+      return;
+    }
+
     try {
       const saveData = {
         game_state: {

--- a/src/utils/supabase.ts
+++ b/src/utils/supabase.ts
@@ -1,10 +1,15 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
-if (!supabaseUrl || !supabaseAnonKey) {
-  throw new Error('Missing Supabase environment variables');
+let supabaseClient: SupabaseClient | null = null;
+
+if (supabaseUrl && supabaseAnonKey) {
+  supabaseClient = createClient(supabaseUrl, supabaseAnonKey);
+} else {
+  console.warn('Supabase environment variables are missing. Cloud persistence is disabled.');
 }
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export const supabase = supabaseClient;
+export const isSupabaseConfigured = supabaseClient !== null;


### PR DESCRIPTION
## Summary
- guard Supabase client creation so the app still mounts without environment variables
- skip cloud load when Supabase is unavailable and surface a toast when saving would fail

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f867706560832ab0f64f8bffcf6c9b