### PR TITLE
Create whimsical stage track and outline alpha/beta tower formulas

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -97,54 +97,76 @@ body::before {
   display: flex;
 }
 
-.glyph-ring {
+.track-stage {
   position: relative;
-  width: min(320px, 70vw);
-  aspect-ratio: 1 / 1;
-  margin: 0 auto;
   display: grid;
-  place-items: center;
+  gap: 18px;
 }
 
-.ring-layer {
-  position: absolute;
-  border-radius: 50%;
-  border: 10px solid transparent;
-  mix-blend-mode: screen;
-  animation: rotate 24s linear infinite;
+.track-canvas {
+  width: min(560px, 100%);
+  justify-self: center;
+  border-radius: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: radial-gradient(circle at 30% 70%, rgba(139, 247, 255, 0.08), transparent 55%),
+    radial-gradient(circle at 70% 25%, rgba(255, 125, 235, 0.1), transparent 60%),
+    rgba(5, 6, 12, 0.75);
+  box-shadow: inset 0 0 30px rgba(139, 247, 255, 0.08), 0 18px 36px rgba(0, 0, 0, 0.45);
 }
 
-.layer-1 {
-  width: 100%;
-  border-color: var(--accent);
+.track-path {
+  fill: none;
+  stroke: url(#pathGradient);
+  stroke-width: 8;
+  filter: url(#glow);
+  opacity: 0.9;
+  stroke-linecap: round;
 }
 
-.layer-2 {
-  width: 75%;
-  border-color: var(--accent-2);
-  animation-duration: 36s;
+.track-path.secondary {
+  stroke-width: 4;
+  opacity: 0.55;
 }
 
-.layer-3 {
-  width: 52%;
-  border-color: var(--accent-3);
-  animation-direction: reverse;
-  animation-duration: 28s;
+.tower-pips circle,
+.enemy-orbs circle {
+  fill: rgba(255, 255, 255, 0.9);
 }
 
-.layer-4 {
-  width: 28%;
-  border-color: rgba(255, 255, 255, 0.6);
-  animation-duration: 48s;
+.tower-pips circle {
+  stroke: rgba(0, 0, 0, 0.65);
+  stroke-width: 2;
 }
 
-@keyframes rotate {
+.enemy-orbs circle {
+  animation: drift 4s ease-in-out infinite alternate;
+}
+
+@keyframes drift {
   from {
-    transform: rotate(0deg);
+    transform: translateY(-4px);
+    opacity: 0.8;
   }
   to {
-    transform: rotate(360deg);
+    transform: translateY(4px);
+    opacity: 1;
   }
+}
+
+.track-caption {
+  text-align: center;
+  max-width: 520px;
+  margin: 0 auto;
+  color: var(--muted);
+  font-size: 1rem;
+}
+
+.track-caption h2 {
+  margin: 0 0 6px;
+  font-size: clamp(1.4rem, 2.5vw, 2rem);
+  color: var(--text);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .prestige-card {
@@ -265,6 +287,90 @@ body::before {
 .card p {
   margin: 0;
   font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.tower-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.tower-header h3 {
+  font-size: 1.35rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.tower-tier {
+  font-family: "Space Mono", monospace;
+  font-size: 0.7rem;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.formula-block {
+  display: grid;
+  gap: 10px;
+  padding: 14px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.formula-line {
+  margin: 0;
+  font-family: "Space Mono", monospace;
+  font-size: 0.95rem;
+  letter-spacing: 0.04em;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.formula-line.result {
+  justify-content: center;
+  font-size: 0.9rem;
+  color: var(--accent-3);
+}
+
+.formula-symbol {
+  font-size: 1.2rem;
+}
+
+.formula-definition {
+  margin: 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 4px;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.upgrade-list {
+  margin: 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 6px;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.card-footer {
+  margin-top: auto;
+  font-size: 0.85rem;
+  color: rgba(247, 247, 245, 0.7);
+  font-style: italic;
+}
+
+.merge-note {
+  margin: 12px 0 18px;
+  font-size: 0.9rem;
   color: var(--muted);
 }
 

--- a/index.html
+++ b/index.html
@@ -31,11 +31,59 @@
 
       <main class="main-stage">
         <section class="panel active" data-panel="tower">
-          <div class="glyph-ring">
-            <div class="ring-layer layer-1"></div>
-            <div class="ring-layer layer-2"></div>
-            <div class="ring-layer layer-3"></div>
-            <div class="ring-layer layer-4"></div>
+          <div class="track-stage">
+            <svg
+              class="track-canvas"
+              viewBox="0 0 560 360"
+              role="img"
+              aria-labelledby="track-title track-desc"
+            >
+              <title id="track-title">Whimsical enemy trajectory</title>
+              <desc id="track-desc">
+                Smooth, ribbon-like path inspired by glyph geometry for tower defense
+              </desc>
+              <defs>
+                <linearGradient id="pathGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+                  <stop offset="0%" stop-color="rgba(139, 247, 255, 0.85)" />
+                  <stop offset="50%" stop-color="rgba(255, 125, 235, 0.85)" />
+                  <stop offset="100%" stop-color="rgba(255, 228, 120, 0.85)" />
+                </linearGradient>
+                <filter id="glow">
+                  <feGaussianBlur stdDeviation="6" result="blur" />
+                  <feMerge>
+                    <feMergeNode in="blur" />
+                    <feMergeNode in="SourceGraphic" />
+                  </feMerge>
+                </filter>
+              </defs>
+              <path
+                class="track-path"
+                d="M30 320 C140 250, 80 120, 200 110 C320 105, 320 260, 420 220 C520 180, 480 60, 340 40"
+              />
+              <path
+                class="track-path secondary"
+                d="M60 300 C150 240, 120 150, 210 140 C320 125, 310 260, 420 230 C520 200, 470 80, 330 70"
+              />
+              <g class="tower-pips">
+                <circle cx="140" cy="210" r="12" />
+                <circle cx="240" cy="150" r="12" />
+                <circle cx="340" cy="200" r="12" />
+                <circle cx="420" cy="150" r="12" />
+              </g>
+              <g class="enemy-orbs">
+                <circle cx="110" cy="250" r="6" />
+                <circle cx="220" cy="190" r="6" />
+                <circle cx="360" cy="160" r="6" />
+              </g>
+            </svg>
+            <div class="track-caption">
+              <h2>Immortal Spiral 01</h2>
+              <p>
+                Each loop is generated from a blended sine and bezier formula,
+                guiding enemies along a silky ribbon of geometry. Merge towers to
+                reshape the curve and bend trajectories.
+              </p>
+            </div>
           </div>
           <aside class="prestige-card">
             <h2>Prestige Window</h2>
@@ -55,19 +103,62 @@
           <header class="panel-header">Towers &amp; Formulae</header>
           <div class="panel-grid">
             <article class="card">
-              <h3>α Apex Tower</h3>
-              <p>Damage formula: <code>D(t) = 3t² + 11</code></p>
-              <button class="action-button ghost" type="button">Upgrade Σ²</button>
+              <header class="tower-header">
+                <span class="tower-tier">Tier I</span>
+                <h3>α alpha tower</h3>
+              </header>
+              <div class="formula-block">
+                <p class="formula-line"><span class="formula-symbol">α</span> = X · Y</p>
+                <ul class="formula-definition">
+                  <li>X → attack power</li>
+                  <li>Y → attack speed</li>
+                </ul>
+                <p class="formula-line result">α = DPS (X × Y)</p>
+              </div>
+              <ul class="upgrade-list">
+                <li>Calibrate X for sharper projectiles (+damage)</li>
+                <li>Accelerate Y through harmonic metronomes (+attack speed)</li>
+              </ul>
+              <footer class="card-footer">Shoots a focused glyph-bullet at the nearest foe.</footer>
             </article>
             <article class="card">
-              <h3>β Harmonic Tower</h3>
-              <p>Damage formula: <code>H(n) = 5 ln(n) + 2</code></p>
-              <button class="action-button ghost" type="button">Amplify ln λ</button>
+              <header class="tower-header">
+                <span class="tower-tier">Tier II</span>
+                <h3>β beta tower</h3>
+              </header>
+              <div class="formula-block">
+                <p class="formula-line"><span class="formula-symbol">β</span> = X · Y · Z</p>
+                <ul class="formula-definition">
+                  <li>X → damage</li>
+                  <li>Y → pulses per second</li>
+                  <li>Z → pierce (targets per beam)</li>
+                </ul>
+                <p class="formula-line result">β = DPS (X × Y × Z)</p>
+              </div>
+              <ul class="upgrade-list">
+                <li>Amplify X with resonance crystals</li>
+                <li>Stabilize Y to extend sustained beams</li>
+                <li>Prism-tune Z to slice through more enemies</li>
+              </ul>
+              <footer class="card-footer">
+                Emits a piercing beam that threads through the ribbon-path.
+              </footer>
             </article>
             <article class="card">
-              <h3>γ Spiral Tower</h3>
-              <p>Damage formula: <code>S(r) = φ · r³</code></p>
-              <button class="action-button ghost" type="button">Imbue φ</button>
+              <header class="tower-header">
+                <span class="tower-tier">Convergence</span>
+                <h3>Merging Logic</h3>
+              </header>
+              <p>
+                Two <strong>α</strong> towers lattice together into a <strong>β</strong> tower,
+                unlocking the beam formula. Prestige into uppercase glyphs to repeat the
+                cycle at higher magnitudes.
+              </p>
+              <p class="merge-note">
+                Upgrades purchased on this tab rewrite the variables above, letting you
+                sculpt each tower's personal equation.
+              </p>
+              <button class="action-button ghost" type="button">Open Upgrade Matrix</button>
             </article>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- replace the tower stage glyph rings with a whimsical bezier-style path inspired scene and descriptive caption
- document alpha and beta tower formulas, DPS relationships, and merge rules within the towers tab
- add supporting styles for the new track canvas, formula blocks, and upgrade lists

## Testing
- Manual - Loaded index.html in a browser

------
https://chatgpt.com/codex/tasks/task_e_68f88048d1dc832a9dcd8b50d8204b03