### PR TITLE
Add conjecture level flow and advanced tower tiers

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -1,5 +1,60 @@
 const tabs = document.querySelectorAll('.tab-button');
 const panels = document.querySelectorAll('.panel');
+const levelGrid = document.getElementById('level-grid');
+const activeLevelEl = document.getElementById('active-level');
+const leaveLevelBtn = document.getElementById('leave-level');
+const overlay = document.getElementById('level-overlay');
+const overlayLabel = document.getElementById('overlay-level');
+const overlayTitle = document.getElementById('overlay-title');
+const overlayExample = document.getElementById('overlay-example');
+
+const levelBlueprints = [
+  {
+    id: 'Conjecture - 1',
+    title: 'Lemniscate Hypothesis',
+    path: '∞ loop traced from r² = cos(2θ); mirrored spawn lanes cross twice.',
+    focus: 'Early E glyphs surge with divisor scouts—tempo control is vital.',
+    example:
+      "Goldbach’s Conjecture: Every even integer greater than 2 is the sum of two primes.",
+  },
+  {
+    id: 'Conjecture - 2',
+    title: 'Collatz Cascade',
+    path: 'Stepwise descent generated from the 3n + 1 map with teleport risers.',
+    focus: 'Hit-count enemies appear on odd nodes; summon glyph soldiers to stall.',
+    example:
+      'Collatz Conjecture: Iterate n → n/2 or 3n + 1 and every positive integer reaches 1.',
+  },
+  {
+    id: 'Conjecture - 3',
+    title: 'Riemann Helix',
+    path: 'Logarithmic spiral with harmonic bulges keyed to ζ(s) zero estimates.',
+    focus: 'Divisor elites flank wave bosses—Ω previews excel at splash slows.',
+    example:
+      'Riemann Hypothesis: Every nontrivial zero of ζ(s) lies on the line Re(s) = 1/2.',
+  },
+  {
+    id: 'Conjecture - 4',
+    title: 'Twin Prime Fork',
+    path: 'Dual lattice rails linked by prime gaps; enemies swap lanes unpredictably.',
+    focus: 'Prime counters demand rapid-fire towers—γ chaining resets their count.',
+    example:
+      'Twin Prime Conjecture: Infinitely many primes p exist such that p + 2 is prime.',
+  },
+  {
+    id: 'Conjecture - 5',
+    title: 'Birch Flow',
+    path: 'Cardioid river influenced by elliptic curve rank gradients.',
+    focus: 'Reversal sentinels join late waves—δ soldiers can flip them to your side.',
+    example:
+      'Birch and Swinnerton-Dyer Conjecture: Rational points of elliptic curves link to L-series behavior.',
+  },
+];
+
+const levelLookup = new Map(levelBlueprints.map((level) => [level.id, level]));
+const levelState = new Map();
+let activeLevelId = null;
+let pendingLevel = null;
 
 function setActiveTab(target) {
   tabs.forEach((tab) => {
@@ -11,6 +66,145 @@ function setActiveTab(target) {
   panels.forEach((panel) => {
     panel.classList.toggle('active', panel.dataset.panel === target);
   });
+
+  if (target === 'tower') {
+    updateActiveLevelBanner();
+  }
+}
+
+function buildLevelCards() {
+  if (!levelGrid) return;
+  const fragment = document.createDocumentFragment();
+
+  levelBlueprints.forEach((level) => {
+    const card = document.createElement('article');
+    card.className = 'level-card';
+    card.dataset.level = level.id;
+    card.setAttribute('role', 'button');
+    card.setAttribute('tabindex', '0');
+    card.setAttribute('aria-pressed', 'false');
+    card.setAttribute('aria-label', `${level.id}: ${level.title}`);
+    card.innerHTML = `
+      <header>
+        <span class="level-id">${level.id}</span>
+        <h3>${level.title}</h3>
+      </header>
+      <p class="level-path"><strong>Path:</strong> ${level.path}</p>
+      <p class="level-hazard"><strong>Focus:</strong> ${level.focus}</p>
+      <p class="level-status-pill">New</p>
+    `;
+    card.addEventListener('click', () => handleLevelSelection(level));
+    card.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        handleLevelSelection(level);
+      }
+    });
+    fragment.append(card);
+  });
+
+  levelGrid.append(fragment);
+}
+
+function handleLevelSelection(level) {
+  const state = levelState.get(level.id) || { entered: false, running: false };
+
+  if (!state.entered) {
+    pendingLevel = level;
+    showLevelOverlay(level);
+    return;
+  }
+
+  startLevel(level);
+}
+
+function showLevelOverlay(level) {
+  if (!overlay) return;
+  overlayLabel.textContent = level.id;
+  overlayTitle.textContent = level.title;
+  overlayExample.textContent = level.example;
+  overlay.setAttribute('aria-hidden', 'false');
+  requestAnimationFrame(() => {
+    overlay.classList.add('active');
+  });
+}
+
+function hideLevelOverlay() {
+  if (!overlay) return;
+  overlay.classList.remove('active');
+  overlay.setAttribute('aria-hidden', 'true');
+}
+
+function startLevel(level) {
+  const currentState = levelState.get(level.id) || { entered: false, running: false };
+  currentState.entered = true;
+  currentState.running = true;
+  levelState.set(level.id, currentState);
+
+  levelState.forEach((state, id) => {
+    if (id !== level.id) {
+      state.running = false;
+      levelState.set(id, state);
+    }
+  });
+
+  activeLevelId = level.id;
+  updateActiveLevelBanner();
+  updateLevelCards();
+}
+
+function leaveActiveLevel() {
+  if (!activeLevelId) return;
+  const state = levelState.get(activeLevelId);
+  if (state) {
+    state.running = false;
+    levelState.set(activeLevelId, state);
+  }
+  activeLevelId = null;
+  updateActiveLevelBanner();
+  updateLevelCards();
+}
+
+function updateLevelCards() {
+  if (!levelGrid) return;
+  levelBlueprints.forEach((level) => {
+    const card = levelGrid.querySelector(`[data-level="${level.id}"]`);
+    if (!card) return;
+    const pill = card.querySelector('.level-status-pill');
+    const state = levelState.get(level.id);
+
+    const entered = Boolean(state && state.entered);
+    const running = Boolean(state && state.running);
+
+    card.classList.toggle('entered', entered);
+    card.setAttribute('aria-pressed', running ? 'true' : 'false');
+
+    if (!entered) {
+      pill.textContent = 'New';
+    } else if (running) {
+      pill.textContent = 'Running';
+    } else {
+      pill.textContent = 'Ready';
+    }
+  });
+}
+
+function updateActiveLevelBanner() {
+  if (!activeLevelEl) return;
+  if (!activeLevelId) {
+    activeLevelEl.textContent = 'None selected';
+    return;
+  }
+
+  const level = levelLookup.get(activeLevelId);
+  const state = levelState.get(activeLevelId);
+  if (!level || !state) {
+    activeLevelEl.textContent = 'None selected';
+    return;
+  }
+
+  const descriptor = state.running ? 'Running' : 'Paused';
+  activeLevelEl.textContent = `${level.id} · ${level.title} (${descriptor})`;
 }
 
 tabs.forEach((tab) => {
@@ -43,4 +237,22 @@ tabs.forEach((tab, index) => {
   });
 });
 
+if (overlay) {
+  overlay.addEventListener('click', () => {
+    hideLevelOverlay();
+    if (pendingLevel) {
+      startLevel(pendingLevel);
+      pendingLevel = null;
+    }
+  });
+}
+
+if (leaveLevelBtn) {
+  leaveLevelBtn.addEventListener('click', () => {
+    leaveActiveLevel();
+  });
+}
+
+buildLevelCards();
+updateLevelCards();
 setActiveTab('tower');

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -169,6 +169,195 @@ body::before {
   text-transform: uppercase;
 }
 
+.subsection-title {
+  font-size: clamp(1.3rem, 2.3vw, 1.8rem);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin: 0;
+  text-align: center;
+}
+
+.level-section {
+  display: grid;
+  gap: 18px;
+  padding: 24px;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(10, 10, 16, 0.6);
+}
+
+.level-intro {
+  margin: 0;
+  font-size: 0.98rem;
+  color: var(--muted);
+  text-align: center;
+}
+
+.level-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.level-card {
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(5, 6, 12, 0.8);
+  padding: 18px;
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 10px;
+  cursor: pointer;
+  transition: transform var(--transition), border-color var(--transition), box-shadow var(--transition);
+}
+
+.level-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(255, 255, 255, 0.3);
+  box-shadow: 0 18px 38px rgba(139, 247, 255, 0.2);
+}
+
+.level-card.entered {
+  border-color: rgba(255, 228, 120, 0.5);
+}
+
+.level-card header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.level-card h3 {
+  margin: 0;
+  font-size: 1.2rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.level-id {
+  font-family: "Space Mono", monospace;
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+  color: var(--muted);
+  text-transform: uppercase;
+}
+
+.level-path,
+.level-hazard {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.level-status-pill {
+  margin: 0;
+  font-family: "Space Mono", monospace;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(139, 247, 255, 0.14);
+  justify-self: start;
+}
+
+.level-card.entered .level-status-pill {
+  background: rgba(255, 228, 120, 0.22);
+  color: var(--text);
+}
+
+.level-legend {
+  padding: 18px;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(5, 6, 12, 0.6);
+  display: grid;
+  gap: 12px;
+}
+
+.level-legend h3 {
+  margin: 0;
+  font-size: 1.2rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-align: center;
+}
+
+.set-timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.set-card {
+  border-radius: 14px;
+  padding: 12px 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(12, 12, 20, 0.7);
+}
+
+.set-card h4 {
+  margin: 0 0 4px;
+  font-size: 1rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.set-card p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.set-card.active-set {
+  border-color: rgba(139, 247, 255, 0.4);
+  box-shadow: inset 0 0 0 1px rgba(139, 247, 255, 0.3);
+}
+
+.level-status {
+  display: grid;
+  gap: 12px;
+  padding: 18px;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(8, 9, 14, 0.7);
+}
+
+.level-status-banner {
+  display: grid;
+  gap: 4px;
+}
+
+.level-status-value {
+  margin: 0;
+  font-size: 1.1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.level-status-note {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.enemy-codex {
+  display: grid;
+  gap: 18px;
+}
+
+.enemy-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.enemy-card {
+  min-height: 180px;
+}
+
 .prestige-card {
   align-self: center;
   max-width: 320px;
@@ -374,6 +563,13 @@ body::before {
   color: var(--muted);
 }
 
+.achievement-note {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--muted);
+  text-align: center;
+}
+
 .achievement-list {
   list-style: none;
   margin: 0;
@@ -416,6 +612,65 @@ body::before {
   margin: 4px 0 0;
   font-size: 0.9rem;
   color: var(--muted);
+}
+
+.level-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.85);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 220ms ease;
+  z-index: 20;
+}
+
+.level-overlay.active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.overlay-panel {
+  text-align: center;
+  max-width: 420px;
+  padding: 36px 28px;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(12, 12, 20, 0.8);
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.55);
+}
+
+.overlay-label {
+  margin: 0 0 10px;
+  font-family: "Space Mono", monospace;
+  font-size: 0.8rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.overlay-title {
+  margin: 0 0 16px;
+  font-size: 1.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.overlay-example {
+  margin: 0 0 18px;
+  font-size: 1rem;
+  color: var(--muted);
+}
+
+.overlay-instruction {
+  margin: 0;
+  font-family: "Space Mono", monospace;
+  font-size: 0.85rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.8);
 }
 
 .tab-bar {
@@ -484,5 +739,15 @@ body::before {
   .tab-bar {
     border-radius: 14px;
     padding: 12px 10px;
+  }
+
+  .level-section,
+  .level-status {
+    padding: 16px;
+  }
+
+  .overlay-panel {
+    margin: 0 16px;
+    padding: 28px 20px;
   }
 }

--- a/docs/PROGRESSION.md
+++ b/docs/PROGRESSION.md
@@ -1,0 +1,35 @@
+# Glyph Defense Idle – Progression Notes
+
+## Level Structure
+- The game now features **30 total levels** grouped into six five-level sets.
+- Sets unlock in reverse proof order: Conjecture (1–5), Corollary (6–10), Lemma (11–15), Proposition (16–20), Theorem (21–25), and Axiom (26–30).
+- Each level is built around an "immortal defense" style lane defined by a math-graph expression (figure-eights, logarithmic spirals, cardioids, etc.).
+- When a level is entered **for the first time** the screen fades to black and displays a hallmark statement for that set (e.g., Goldbach's Conjecture). Subsequent visits skip the fade.
+- Entered levels continue running when the player navigates to other tabs; use "Leave Current Level" on the Stage tab to reset wave flow.
+
+### Conjecture Set (Levels 1–5)
+1. **Conjecture – 1 · Lemniscate Hypothesis** – Figure-eight path generated from `r² = cos(2θ)`; introduces divisor scouts.
+2. **Conjecture – 2 · Collatz Cascade** – Tiered descent inspired by the `3n + 1` map with teleport risers and hit-count enemies.
+3. **Conjecture – 3 · Riemann Helix** – Logarithmic spiral tuned to ζ zero estimates; favors splash slows.
+4. **Conjecture – 4 · Twin Prime Fork** – Dual rails connected by prime gaps; rewards rapid chaining damage.
+5. **Conjecture – 5 · Birch Flow** – Cardioid river influenced by elliptic curve ranks; showcases enemy reversal mechanics.
+
+Future sets escalate enemy modifiers and map complexity but follow the same five-level cadence with new example statements.
+
+## Tower Evolution
+- **α → β → γ → δ → Ω** is the primary merge ladder. α towers provide single-target bursts; two α towers merge into a β beam tower.
+- β towers merge into **γ conductors** (`γ = α^½ · β`) that blend α burst spikes into β beam tempo and apply homing bolts.
+- γ towers merge into **δ commanders** (`δ = γ · ln(β + 1)`) that summon glyph soldiers, slow enemies, and grant aura buffs.
+- High-tier merges culminate in the **Ω keystone** (`Ω = β^(α/10) + δ · β`) which draws stats from every β tower on the field, pushes enemies backward, and adds splash damage.
+- Support variants now include aura boosters, splash glyphs, homing missiles, slow fields, and enemy reversal chants.
+
+## Enemy Archetypes
+- **E-Type Glyphs** – Base enemies labeled by trailing zeros (E1 = 1 HP, E3 = 100 HP, etc.) with logarithmic health scaling.
+- **Divisors** – Take damage equal to `1 / DPS`; encourage precision debuffs and tempo play.
+- **Prime Counters** – Require a fixed number of hits regardless of damage; ideal for soldier swarms and rapid-fire towers.
+- **Reversal Sentinels** – Upon defeat they run backward along the path; captured units fight for the player with inverted health totals.
+
+## Achievements & Powderfall
+- Each achievement seal grants **+1 grain of powder per minute**.
+- Offline/idle time multiplies by the number of unlocked achievements. All stored grains are deposited immediately on return.
+- Powder height etches mystic symbols along the wall. The highest reached symbol acts as an upgrade currency for tower research.

--- a/index.html
+++ b/index.html
@@ -85,6 +85,92 @@
               </p>
             </div>
           </div>
+          <section class="level-section">
+            <header class="subsection-title">Conjecture Set</header>
+            <p class="level-intro">
+              The opening proofs trace immortal-defense style figure-eights,
+              cardioids, and logarithmic spirals. Each path is derived from a
+              math-graph expression and rewards towers that can flex their
+              formulas mid-curve.
+            </p>
+            <div class="level-grid" id="level-grid" aria-live="polite"></div>
+            <aside class="level-legend">
+              <h3>Proof Roadmap</h3>
+              <ul class="set-timeline">
+                <li class="set-card active-set">
+                  <h4>Conjecture Levels 1-5</h4>
+                  <p>Speculative math under siege. Examples highlight famous unsolved ideas.</p>
+                </li>
+                <li class="set-card">
+                  <h4>Corollary Levels 6-10</h4>
+                  <p>Statements that immediately bloom from the conjecture victories.</p>
+                </li>
+                <li class="set-card">
+                  <h4>Lemma Levels 11-15</h4>
+                  <p>Utility proofs and support tactics that bolster the main argument.</p>
+                </li>
+                <li class="set-card">
+                  <h4>Proposition Levels 16-20</h4>
+                  <p>Solid but modest claims—expect compound paths and multi-route assaults.</p>
+                </li>
+                <li class="set-card">
+                  <h4>Theorem Levels 21-25</h4>
+                  <p>Major revelations guarded by elite enemy archetypes.</p>
+                </li>
+                <li class="set-card">
+                  <h4>Axiom Levels 26-30</h4>
+                  <p>Foundational truths; everything loops back to primal glyph geometry.</p>
+                </li>
+              </ul>
+            </aside>
+          </section>
+          <section class="level-status" aria-live="polite">
+            <div class="level-status-banner">
+              <span class="status-label">Active Level</span>
+              <p class="level-status-value" id="active-level">None selected</p>
+            </div>
+            <p class="level-status-note">
+              Levels persist while you browse other tabs. Return to the Stage to
+              continue defending, or leave the level to reset its wave pattern.
+            </p>
+            <button class="action-button ghost" type="button" id="leave-level" aria-live="off">
+              Leave Current Level
+            </button>
+          </section>
+          <section class="enemy-codex">
+            <header class="subsection-title">Enemy Codex</header>
+            <div class="enemy-grid">
+              <article class="card enemy-card">
+                <h3>E-Type Glyphs</h3>
+                <p>
+                  Core foes labeled by trailing zeros. <strong>E1</strong> carries one
+                  hit point, while <strong>E3</strong> arrives with <code>10³</code> life.
+                  Their waves scale logarithmically between sets.
+                </p>
+              </article>
+              <article class="card enemy-card">
+                <h3>Divisors</h3>
+                <p>
+                  Glyphs that punish high DPS. Damage taken equals
+                  <code>1 / DPS</code>, so precision tuning and debuff towers are key.
+                </p>
+              </article>
+              <article class="card enemy-card">
+                <h3>Prime Counters</h3>
+                <p>
+                  Resistant husks that require a fixed number of hits regardless of
+                  damage dealt—perfect sparring partners for swarm summoners.
+                </p>
+              </article>
+              <article class="card enemy-card">
+                <h3>Reversal Sentinels</h3>
+                <p>
+                  Vanguard units that, when defeated, sprint backward along the
+                  path. Capture them to fight for you with inverted health totals.
+                </p>
+              </article>
+            </div>
+          </section>
           <aside class="prestige-card">
             <h2>Prestige Window</h2>
             <p><strong>Ξ Progress:</strong> 10.2 → 17.3</p>
@@ -146,17 +232,76 @@
             </article>
             <article class="card">
               <header class="tower-header">
+                <span class="tower-tier">Tier III</span>
+                <h3>γ gamma tower</h3>
+              </header>
+              <div class="formula-block">
+                <p class="formula-line"><span class="formula-symbol">γ</span> = α<sup>½</sup> · β</p>
+                <ul class="formula-definition">
+                  <li>α → inherited burst damage pulse</li>
+                  <li>β → sustained beam resonance</li>
+                </ul>
+                <p class="formula-line result">Stacks alpha spikes into beta's beam rhythm.</p>
+              </div>
+              <ul class="upgrade-list">
+                <li>Transpose α surges into chaining lightning arcs</li>
+                <li>Use β harmonics to slow enemies caught mid-beam</li>
+              </ul>
+              <footer class="card-footer">Merges α + β into a tempo-shifting conductor with homing bolts.</footer>
+            </article>
+            <article class="card">
+              <header class="tower-header">
+                <span class="tower-tier">Tier IV</span>
+                <h3>δ delta tower</h3>
+              </header>
+              <div class="formula-block">
+                <p class="formula-line"><span class="formula-symbol">δ</span> = γ · ln(β + 1)</p>
+                <ul class="formula-definition">
+                  <li>γ → summoning strength for glyph soldiers</li>
+                  <li>ln(β + 1) → swarm duration scaling</li>
+                </ul>
+                <p class="formula-line result">Summons glyph cohorts that inherit γ's damage.</p>
+              </div>
+              <ul class="upgrade-list">
+                <li>Empower soldiers with slowing sigils</li>
+                <li>Rally boosts: δ soldiers grant +β% damage to nearby towers</li>
+              </ul>
+              <footer class="card-footer">Does not attack directly—commands spectral fighters to guard the lane.</footer>
+            </article>
+            <article class="card">
+              <header class="tower-header">
+                <span class="tower-tier">Tier V</span>
+                <h3>Ω omega tower</h3>
+              </header>
+              <div class="formula-block">
+                <p class="formula-line"><span class="formula-symbol">Ω</span> = β<sup>α∕10</sup> + δ · β</p>
+                <ul class="formula-definition">
+                  <li>β<sup>α∕10</sup> → range oscillates with total β output</li>
+                  <li>δ · β → damage infused by summoned allies</li>
+                </ul>
+                <p class="formula-line result">Ω draws power from every β tower on the field.</p>
+              </div>
+              <ul class="upgrade-list">
+                <li>Orbital glyphs deal splash damage equal to 15% of β</li>
+                <li>Resonant chant pushes enemies backward when Ω overcharges</li>
+              </ul>
+              <footer class="card-footer">Signature tower—buffs allies, repositions foes, and anchors endgame builds.</footer>
+            </article>
+            <article class="card">
+              <header class="tower-header">
                 <span class="tower-tier">Convergence</span>
                 <h3>Merging Logic</h3>
               </header>
               <p>
                 Two <strong>α</strong> towers lattice together into a <strong>β</strong> tower,
-                unlocking the beam formula. Prestige into uppercase glyphs to repeat the
-                cycle at higher magnitudes.
+                fusing burst DPS with piercing beams. Merge β constructs to access
+                <strong>γ</strong> conductors, then braid γ into <strong>δ</strong> summoners.
+                Ascend every branch to awaken the <strong>Ω</strong> keystone.
               </p>
               <p class="merge-note">
-                Upgrades purchased on this tab rewrite the variables above, letting you
-                sculpt each tower's personal equation.
+                Upgrades rewrite variables dynamically—boost towers grant additive buffs
+                in their radius, splash variants scale with β, and soldier-focused builds
+                inherit δ's battlefield control.
               </p>
               <button class="action-button ghost" type="button">Open Upgrade Matrix</button>
             </article>
@@ -186,26 +331,65 @@
 
         <section class="panel" data-panel="achievements">
           <header class="panel-header">Achievements</header>
+          <p class="achievement-note">
+            Each seal increases powderfall by <strong>+1 grain per minute</strong>.
+            Idle minutes are multiplied by unlocked seals and dumped when you return.
+          </p>
           <ul class="achievement-list">
             <li>
               <span class="achievement-badge">∞</span>
               <div>
                 <p class="achievement-title">First Orbit</p>
-                <p class="achievement-sub">Reach loop 10 in the spiral.</p>
+                <p class="achievement-sub">Reach loop 10 in the spiral for +1 grain/min.</p>
               </div>
             </li>
             <li>
               <span class="achievement-badge">π</span>
               <div>
                 <p class="achievement-title">Circle Seer</p>
-                <p class="achievement-sub">Unlock 3 concentric glyph rings.</p>
+                <p class="achievement-sub">Unlock 3 concentric glyph rings for +1 grain/min.</p>
               </div>
             </li>
             <li>
               <span class="achievement-badge">∑</span>
               <div>
                 <p class="achievement-title">Series Summoner</p>
-                <p class="achievement-sub">Gain 1,000 sandfold stacks.</p>
+                <p class="achievement-sub">Gain 1,000 sandfold stacks and earn +1 grain/min.</p>
+              </div>
+            </li>
+            <li>
+              <span class="achievement-badge">ζ</span>
+              <div>
+                <p class="achievement-title">Zero Hunter</p>
+                <p class="achievement-sub">Defeat 100 divisor enemies while under 10 DPS for +1 grain/min.</p>
+              </div>
+            </li>
+            <li>
+              <span class="achievement-badge">Φ</span>
+              <div>
+                <p class="achievement-title">Golden Mentor</p>
+                <p class="achievement-sub">Buff 20 towers at once with support auras for +1 grain/min.</p>
+              </div>
+            </li>
+            <li>
+              <span class="achievement-badge">Ψ</span>
+              <div>
+                <p class="achievement-title">Powder Archivist</p>
+                <p class="achievement-sub">Reach the fifth sand sigil on the wall and gain +1 grain/min.</p>
+              </div>
+            </li>
+            <li>
+              <span class="achievement-badge">Ω</span>
+              <div>
+                <p class="achievement-title">Keystone Keeper</p>
+                <p class="achievement-sub">Merge into your first Ω tower to unlock +1 grain/min.</p>
+              </div>
+            </li>
+            <li>
+              <span class="achievement-badge">Δ</span>
+              <div>
+                <p class="achievement-title">Temporal Sifter</p>
+                <p class="achievement-sub">Idle for 60 minutes and collect the multiplied powder surge.</p>
               </div>
             </li>
           </ul>
@@ -255,6 +439,14 @@
           <span class="tab-label">Codex</span>
         </button>
       </nav>
+    </div>
+    <div class="level-overlay" id="level-overlay" role="dialog" aria-modal="true" aria-hidden="true">
+      <div class="overlay-panel">
+        <p class="overlay-label" id="overlay-level"></p>
+        <h2 class="overlay-title" id="overlay-title"></h2>
+        <p class="overlay-example" id="overlay-example"></p>
+        <p class="overlay-instruction">Tap to enter</p>
+      </div>
     </div>
     <script src="./assets/main.js" type="module"></script>
   </body>


### PR DESCRIPTION
## Summary
- add a level selection grid for the conjecture set with fade-to-black lore overlays and persistent activity state
- expand tower merge tiers, enemy codex entries, and achievement rewards to describe new behaviors and powder bonuses
- document the 30-level proof roadmap, tower evolution formulas, and powderfall rules in a progression reference

## Testing
- no automated tests were run (not applicable for static content)

------
https://chatgpt.com/codex/tasks/task_e_68f88a2471c4832abd0d1eb0f50215ba