### PR TITLE
Enable scrolling within game menus

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -40,7 +40,7 @@ body::before {
   width: min(960px, 100%);
   min-height: 100vh;
   display: grid;
-  grid-template-rows: auto 1fr auto;
+  grid-template-rows: auto minmax(0, 1fr) auto;
   padding: 24px clamp(16px, 4vw, 36px) 16px;
   gap: 16px;
 }
@@ -78,6 +78,7 @@ body::before {
 .main-stage {
   position: relative;
   display: grid;
+  min-height: 0;
   overflow: hidden;
   border-radius: 24px;
   border: 1px solid var(--panel-border);
@@ -91,6 +92,11 @@ body::before {
   padding: clamp(20px, 4vw, 48px);
   gap: 24px;
   height: 100%;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-gutter: stable both-edge;
 }
 
 .panel.active {


### PR DESCRIPTION
## Summary
- allow the middle grid row to shrink so the active panel can scroll independently of the tab bar
- enable overflow scrolling on each panel for touch and mouse drag interactions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f92c675518832ab247ece60bc55b75