### PR TITLE
Improve keyboard tab navigation and make menu bar sticky

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -65,18 +65,6 @@ const tabHotkeys = new Map([
   ['5', 'options'],
 ]);
 
-function isDesktopEnvironment() {
-  if (typeof window === 'undefined') {
-    return false;
-  }
-
-  if (window.matchMedia) {
-    return window.matchMedia('(hover: hover) and (pointer: fine)').matches;
-  }
-
-  return !(navigator.maxTouchPoints && navigator.maxTouchPoints > 0);
-}
-
 function isTextInput(element) {
   if (!element) return false;
   const tagName = element.tagName ? element.tagName.toLowerCase() : '';
@@ -275,9 +263,8 @@ function updateActiveLevelBanner() {
 document.addEventListener('keydown', (event) => {
   if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') return;
   if (!tabs.length) return;
-  const activeElement = document.activeElement;
-  if (!activeElement || !activeElement.closest('.tab-bar')) return;
   if (overlay && overlay.classList.contains('active')) return;
+  if (isTextInput(event.target)) return;
 
   const direction = event.key === 'ArrowRight' ? 1 : -1;
   event.preventDefault();
@@ -286,7 +273,6 @@ document.addEventListener('keydown', (event) => {
 
 document.addEventListener('keydown', (event) => {
   if (!tabs.length) return;
-  if (!isDesktopEnvironment()) return;
   if (overlay && overlay.classList.contains('active')) return;
   if (isTextInput(event.target)) return;
 

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -688,6 +688,10 @@ body::before {
   background: rgba(10, 10, 16, 0.85);
   border: 1px solid var(--panel-border);
   box-shadow: var(--shadow);
+  position: sticky;
+  bottom: clamp(12px, 3vw, 24px);
+  z-index: 20;
+  backdrop-filter: blur(18px);
 }
 
 .tab-button {


### PR DESCRIPTION
## Summary
- allow arrow keys and numeric shortcuts to switch tabs without requiring prior focus on the tab bar
- simplify the tab hotkey logic by removing the desktop-environment guard that blocked shortcuts on Chrome
- keep the bottom tab bar visible while scrolling by making it sticky with a blurred backdrop

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68f92eea87ac832aac81cb03cdeddd26