### PR TITLE
Add powder lab interactions and resource ticker

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -407,6 +407,16 @@ body::before {
   box-shadow: 0 14px 30px rgba(139, 247, 255, 0.25);
 }
 
+.action-button:disabled,
+.action-button:disabled:hover {
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(247, 247, 245, 0.55);
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
 .action-button.ghost {
   background: transparent;
   color: var(--text);
@@ -483,6 +493,13 @@ body::before {
   margin: 0;
   font-size: 0.95rem;
   color: var(--muted);
+}
+
+.powder-footnote {
+  font-family: "Space Mono", monospace;
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  color: rgba(247, 247, 245, 0.65);
 }
 
 .tower-header {

--- a/index.html
+++ b/index.html
@@ -333,18 +333,54 @@
           <div class="panel-grid">
             <article class="card">
               <h3>Sandfall</h3>
-              <p>Grains per tick: <code>Ψ(g) = 2.7 · sin(t)</code></p>
-              <button class="action-button ghost" type="button">Stabilize Flow</button>
+              <p>
+                Grains per tick:
+                <code id="powder-sandfall-formula">Ψ(g) = 2.7 · sin(t)</code>
+              </p>
+              <p class="powder-footnote" id="powder-sandfall-note">
+                Crest is unstable—powder drifts off the board.
+              </p>
+              <button
+                class="action-button ghost"
+                type="button"
+                data-powder-action="sandfall"
+              >
+                Stabilize Flow
+              </button>
             </article>
             <article class="card">
               <h3>Dune Height</h3>
-              <p>Multiplier: <code>Δm = log₂(h + 1)</code></p>
-              <button class="action-button ghost" type="button">Survey Ridge</button>
+              <p>
+                Multiplier:
+                <code id="powder-dune-formula">Δm = log₂(h + 1)</code>
+              </p>
+              <p class="powder-footnote" id="powder-dune-note">
+                Survey ridges to raise <em>h</em> and amplify energy lanes.
+              </p>
+              <button
+                class="action-button ghost"
+                type="button"
+                data-powder-action="dune"
+              >
+                Survey Ridge
+              </button>
             </article>
             <article class="card">
               <h3>Crystal Powder</h3>
-              <p>Powder charge: <code>Q = √(θ · ζ)</code></p>
-              <button class="action-button ghost" type="button">Crystallize</button>
+              <p>
+                Powder charge:
+                <code id="powder-crystal-formula">Q = √(θ · ζ)</code>
+              </p>
+              <p class="powder-footnote" id="powder-crystal-note">
+                Crystal resonance is idle—no pulse prepared.
+              </p>
+              <button
+                class="action-button ghost"
+                type="button"
+                data-powder-action="crystal"
+              >
+                Crystallize (0/3)
+              </button>
             </article>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- add a live resource ticker that grows Σ score while a level is running
- wire the Powder Lab controls to update formulas, bonuses, and resource rates
- style the powder cards with status footnotes and disabled states for maxed upgrades

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68f938bec960832aa69d74f8a4b4c06f