### PR TITLE
Add interactive first level playfield

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -175,6 +175,135 @@ body::before {
   text-transform: uppercase;
 }
 
+.playfield-wrapper {
+  display: grid;
+  gap: 16px;
+  padding: clamp(16px, 4vw, 24px);
+  border-radius: 22px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(8, 9, 14, 0.7);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+
+.playfield-header {
+  text-align: center;
+  display: grid;
+  gap: 6px;
+}
+
+.playfield-header h3 {
+  margin: 0;
+  font-size: clamp(1.2rem, 2.3vw, 1.6rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.playfield-header p {
+  margin: 0;
+  font-size: 0.96rem;
+  color: var(--muted);
+}
+
+.playfield-shell {
+  display: grid;
+  justify-items: center;
+}
+
+.playfield {
+  position: relative;
+  width: min(560px, 100%);
+  aspect-ratio: 560 / 360;
+  border-radius: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  overflow: hidden;
+  background: radial-gradient(circle at 30% 70%, rgba(139, 247, 255, 0.1), transparent 60%),
+    radial-gradient(circle at 70% 25%, rgba(255, 125, 235, 0.12), transparent 65%),
+    rgba(5, 6, 12, 0.9);
+  box-shadow: inset 0 0 30px rgba(139, 247, 255, 0.12), 0 18px 36px rgba(0, 0, 0, 0.5);
+}
+
+.playfield canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.tower-slot {
+  position: absolute;
+  left: calc(var(--slot-x) * 1%);
+  top: calc(var(--slot-y) * 1%);
+  transform: translate(-50%, -50%);
+  width: clamp(42px, 8vw, 54px);
+  height: clamp(42px, 8vw, 54px);
+  border-radius: 50%;
+  border: 1px solid rgba(139, 247, 255, 0.45);
+  background: rgba(10, 12, 20, 0.72);
+  color: var(--text);
+  font-family: "Space Mono", monospace;
+  font-size: 1.1rem;
+  letter-spacing: 0.06em;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: transform var(--transition), border-color var(--transition), box-shadow var(--transition);
+}
+
+.tower-slot span {
+  pointer-events: none;
+}
+
+.tower-slot:hover:not(:disabled),
+.tower-slot:focus-visible {
+  transform: translate(-50%, -50%) scale(1.06);
+  border-color: rgba(255, 228, 120, 0.85);
+  box-shadow: 0 12px 26px rgba(139, 247, 255, 0.25);
+}
+
+.tower-slot:disabled,
+.tower-slot:disabled:hover {
+  cursor: not-allowed;
+  opacity: 0.45;
+  transform: translate(-50%, -50%);
+  border-color: rgba(255, 255, 255, 0.14);
+  box-shadow: none;
+}
+
+.tower-slot.tower-built {
+  border-color: rgba(255, 228, 120, 0.85);
+  background: radial-gradient(circle, rgba(255, 228, 120, 0.32), transparent 70%);
+  box-shadow: 0 0 22px rgba(255, 228, 120, 0.4);
+}
+
+.playfield-hud {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  padding: clamp(12px, 3vw, 18px);
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(5, 6, 12, 0.78);
+  font-family: "Space Mono", monospace;
+}
+
+.playfield-hud div {
+  display: grid;
+  gap: 6px;
+  text-align: center;
+}
+
+.playfield-hud dt {
+  margin: 0;
+  font-size: 0.78rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.playfield-hud dd {
+  margin: 0;
+  font-size: clamp(1rem, 2vw, 1.2rem);
+}
+
 .subsection-title {
   font-size: clamp(1.3rem, 2.3vw, 1.8rem);
   letter-spacing: 0.06em;
@@ -269,6 +398,16 @@ body::before {
 
 .level-card.entered .level-status-pill {
   background: rgba(255, 228, 120, 0.22);
+  color: var(--text);
+}
+
+.level-card.completed {
+  border-color: rgba(139, 247, 255, 0.35);
+  box-shadow: 0 0 0 1px rgba(139, 247, 255, 0.22), var(--shadow);
+}
+
+.level-card.completed .level-status-pill {
+  background: rgba(139, 247, 255, 0.24);
   color: var(--text);
 }
 
@@ -438,6 +577,13 @@ body::before {
 
 .play-button:hover {
   background: rgba(255, 255, 255, 0.22);
+}
+
+.play-button:disabled,
+.play-button:disabled:hover {
+  cursor: not-allowed;
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(247, 247, 245, 0.55);
 }
 
 .stage-footer {

--- a/index.html
+++ b/index.html
@@ -91,6 +91,88 @@
               </p>
             </div>
           </div>
+          <section class="playfield-wrapper" aria-live="polite">
+            <header class="playfield-header">
+              <h3>Active Defense Simulation</h3>
+              <p id="playfield-message">Select a level to command the defense.</p>
+            </header>
+            <div class="playfield-shell">
+              <div
+                class="playfield"
+                id="playfield"
+                role="img"
+                aria-label="Interactive glyph defense lane"
+              >
+                <canvas id="playfield-canvas" width="560" height="360"></canvas>
+                <button
+                  class="tower-slot"
+                  type="button"
+                  data-slot-id="slot-a"
+                  data-slot-x="0.24"
+                  data-slot-y="0.68"
+                  aria-pressed="false"
+                  aria-label="Anchor α tower at western loop"
+                  style="--slot-x: 24; --slot-y: 68"
+                  disabled
+                >
+                  <span>α</span>
+                </button>
+                <button
+                  class="tower-slot"
+                  type="button"
+                  data-slot-id="slot-b"
+                  data-slot-x="0.44"
+                  data-slot-y="0.36"
+                  aria-pressed="false"
+                  aria-label="Anchor α tower at northern pinch"
+                  style="--slot-x: 44; --slot-y: 36"
+                  disabled
+                >
+                  <span>α</span>
+                </button>
+                <button
+                  class="tower-slot"
+                  type="button"
+                  data-slot-id="slot-c"
+                  data-slot-x="0.62"
+                  data-slot-y="0.70"
+                  aria-pressed="false"
+                  aria-label="Anchor α tower at eastern ribbon"
+                  style="--slot-x: 62; --slot-y: 70"
+                  disabled
+                >
+                  <span>α</span>
+                </button>
+                <button
+                  class="tower-slot"
+                  type="button"
+                  data-slot-id="slot-d"
+                  data-slot-x="0.78"
+                  data-slot-y="0.38"
+                  aria-pressed="false"
+                  aria-label="Anchor α tower at summit bend"
+                  style="--slot-x: 78; --slot-y: 38"
+                  disabled
+                >
+                  <span>α</span>
+                </button>
+              </div>
+            </div>
+            <dl class="playfield-hud">
+              <div>
+                <dt>Wave</dt>
+                <dd id="playfield-wave">—</dd>
+              </div>
+              <div>
+                <dt>Core Integrity</dt>
+                <dd id="playfield-health">—</dd>
+              </div>
+              <div>
+                <dt>Glyph Energy</dt>
+                <dd id="playfield-energy">—</dd>
+              </div>
+            </dl>
+          </section>
           <section class="level-section">
             <header class="subsection-title">Conjecture Set</header>
             <p class="level-intro">
@@ -184,9 +266,11 @@
             <button class="action-button" type="button">Prysmatic!</button>
           </aside>
           <div class="stage-footer">
-            <button class="play-button" type="button">Play</button>
+            <button class="play-button" type="button" id="playfield-start" disabled>
+              Commence Wave
+            </button>
             <div class="progress">
-              <span>Progress to Infinity 58.8%</span>
+              <span id="playfield-progress">No active level.</span>
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- add an interactive playfield with tower placement, waves, and combat resolution for the Lemniscate Hypothesis stage
- extend the stage UI with HUD elements, play controls, and updated level status handling
- update styling to support the playfield layout and completed level states

## Testing
- Not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68f9405fba0c832a9a7d60b15958b574