### PR TITLE
Add alpha tower firing sound effect

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -174,6 +174,7 @@
       enemyBreach: { file: 'enemy_breach.wav', volume: 0.75, maxConcurrent: 2 },
       victory: { file: 'victory_sting.wav', volume: 0.8, maxConcurrent: 1 },
       defeat: { file: 'defeat_sting.wav', volume: 0.8, maxConcurrent: 1 },
+      alphaTowerFire: { file: 'alpha_tower_firing.mp3', volume: 0.55, maxConcurrent: 5 },
     },
   };
 
@@ -1885,7 +1886,7 @@
       });
 
       if (this.audio) {
-        this.audio.playSfx('projectile');
+        this.audio.playSfx('alphaTowerFire');
       }
 
       if (enemy.hp <= 0) {


### PR DESCRIPTION
## Summary
- register the new alpha tower firing sound effect in the audio manifest
- trigger the alpha tower firing audio whenever the tower shoots an enemy

## Testing
- not run (web game)


------
https://chatgpt.com/codex/tasks/task_e_68f9713bc400832a8c2017d8d5c38f29