### PR TITLE
Gate tower unlocks and dynamic pricing

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,58 +107,6 @@
                 aria-label="Interactive glyph defense lane"
               >
                 <canvas id="playfield-canvas" width="560" height="360"></canvas>
-                <button
-                  class="tower-slot"
-                  type="button"
-                  data-slot-id="slot-a"
-                  data-slot-x="0.24"
-                  data-slot-y="0.68"
-                  aria-pressed="false"
-                  aria-label="Anchor α tower at western loop"
-                  style="--slot-x: 24; --slot-y: 68"
-                  disabled
-                >
-                  <span>α</span>
-                </button>
-                <button
-                  class="tower-slot"
-                  type="button"
-                  data-slot-id="slot-b"
-                  data-slot-x="0.44"
-                  data-slot-y="0.36"
-                  aria-pressed="false"
-                  aria-label="Anchor α tower at northern pinch"
-                  style="--slot-x: 44; --slot-y: 36"
-                  disabled
-                >
-                  <span>α</span>
-                </button>
-                <button
-                  class="tower-slot"
-                  type="button"
-                  data-slot-id="slot-c"
-                  data-slot-x="0.62"
-                  data-slot-y="0.70"
-                  aria-pressed="false"
-                  aria-label="Anchor α tower at eastern ribbon"
-                  style="--slot-x: 62; --slot-y: 70"
-                  disabled
-                >
-                  <span>α</span>
-                </button>
-                <button
-                  class="tower-slot"
-                  type="button"
-                  data-slot-id="slot-d"
-                  data-slot-x="0.78"
-                  data-slot-y="0.38"
-                  aria-pressed="false"
-                  aria-label="Anchor α tower at summit bend"
-                  style="--slot-x: 78; --slot-y: 38"
-                  disabled
-                >
-                  <span>α</span>
-                </button>
               </div>
             </div>
             <div class="tower-loadout" id="tower-loadout" aria-label="Tower loadout" role="region">


### PR DESCRIPTION
## Summary
- remove the fixed alpha tower slot buttons so the playfield no longer suggests constrained anchors
- gate higher-tier towers behind in-match unlocks and update the loadout UI to reflect availability and costs
- recompute tower pricing from current placements, refresh the loadout after changes, and smooth the arc animation loop

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f974209d10832a8b09021be84652e1