### PR TITLE
Add powderfall simulation with dune-aware bonuses

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1024,6 +1024,27 @@ body::before {
   text-align: center;
 }
 
+.powder-simulation {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+}
+
+.powder-simulation canvas {
+  width: 100%;
+  max-width: 320px;
+  aspect-ratio: 3 / 4;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+  background: linear-gradient(180deg, rgba(15, 16, 24, 0.96) 0%, rgba(22, 25, 37, 0.96) 100%);
+}
+
+.powder-simulation .powder-footnote {
+  text-align: center;
+}
+
 .tower-header {
   display: flex;
   align-items: center;

--- a/index.html
+++ b/index.html
@@ -440,6 +440,19 @@
                 Stabilize Flow
               </button>
             </article>
+            <article class="card powder-simulation">
+              <h3>Powderfall Basin</h3>
+              <canvas
+                id="powder-canvas"
+                width="240"
+                height="320"
+                role="img"
+                aria-label="Powderfall basin simulation"
+              ></canvas>
+              <p class="powder-footnote" id="powder-simulation-note">
+                Captured crest: 0.0% full · dune height h = 1.00 · largest grain —.
+              </p>
+            </article>
             <article class="card">
               <h3>Dune Height</h3>
               <p>


### PR DESCRIPTION
## Summary
- implement a lightweight PowderSimulation canvas that models falling grains of multiple sizes and tracks dune height
- surface the powderfall basin in the powder panel and stream dune status text to the ritual UI
- fold the simulated dune gain into powder bonus calculations and refresh styling for the new canvas

## Testing
- not run (project uses static assets)

------
https://chatgpt.com/codex/tasks/task_e_68f983167ba8832a9c15283a23c55577