### PR TITLE
Refine powderfall basin presentation

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1024,25 +1024,122 @@ body::before {
   text-align: center;
 }
 
+.powder-stage {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  margin: 0 auto 32px;
+  padding-inline: clamp(12px, 4vw, 36px);
+}
+
 .powder-simulation {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: 14px;
+  align-items: stretch;
+  gap: 18px;
+  width: min(520px, 100%);
+  min-height: clamp(440px, 85vh, 760px);
 }
 
-.powder-simulation canvas {
+.powder-simulation h3 {
+  text-align: center;
+}
+
+.powder-basin {
+  position: relative;
+  flex: 1 1 auto;
   width: 100%;
-  max-width: 320px;
-  aspect-ratio: 3 / 4;
-  border-radius: 14px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
-  background: linear-gradient(180deg, rgba(15, 16, 24, 0.96) 0%, rgba(22, 25, 37, 0.96) 100%);
+  min-height: clamp(360px, 70vh, 640px);
+  border-radius: 20px;
+  overflow: hidden;
+  background: radial-gradient(circle at 50% 10%, rgba(255, 228, 120, 0.08), transparent 60%),
+    linear-gradient(180deg, rgba(15, 16, 24, 0.96) 0%, rgba(22, 25, 37, 0.96) 100%);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12), inset 0 -20px 40px rgba(8, 8, 12, 0.6);
+  --powder-crest: 0;
+}
+
+.powder-basin::before,
+.powder-basin::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.powder-basin::before {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0) 35%);
+  opacity: 0.2;
+}
+
+.powder-basin::after {
+  background: radial-gradient(circle at 50% 10%, rgba(255, 228, 120, 0.2), transparent 55%);
+  opacity: calc(0.12 + var(--powder-crest, 0) * 0.45);
+  transition: opacity var(--transition);
+}
+
+.powder-basin canvas {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.powder-wall {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: clamp(36px, 14%, 68px);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  align-items: center;
+  padding: 32px 10px;
+  background: linear-gradient(180deg, rgba(10, 12, 18, 0.8) 0%, rgba(12, 14, 20, 0.9) 100%);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  transition: box-shadow var(--transition), filter var(--transition);
+}
+
+.powder-wall-left {
+  left: 0;
+  border-right: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.powder-wall-right {
+  right: 0;
+  border-left: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.powder-wall.wall-awake {
+  box-shadow: inset 0 0 0 1px rgba(255, 228, 120, 0.35), 0 0 18px rgba(255, 228, 120, 0.28);
+  filter: saturate(1.2);
+}
+
+.powder-glyph {
+  font-family: "Cormorant Garamond", "Space Mono", serif;
+  font-size: clamp(1.4rem, 3vw, 2.1rem);
+  letter-spacing: 0.18em;
+  color: rgba(255, 255, 255, 0.26);
+  text-shadow: 0 0 10px rgba(255, 255, 255, 0.05);
+  transition: color var(--transition), text-shadow var(--transition), transform var(--transition);
+}
+
+.powder-glyph.glowing {
+  color: var(--accent-3);
+  text-shadow: 0 0 12px rgba(255, 228, 120, 0.75), 0 0 28px rgba(255, 195, 32, 0.45);
+  transform: translateY(-2px);
 }
 
 .powder-simulation .powder-footnote {
   text-align: center;
+}
+
+@media (min-width: 960px) {
+  .powder-stage {
+    padding-inline: clamp(24px, 6vw, 64px);
+  }
+  .powder-simulation {
+    min-height: clamp(500px, 90vh, 820px);
+  }
 }
 
 .tower-header {

--- a/index.html
+++ b/index.html
@@ -422,6 +422,64 @@
               </ul>
             </article>
           </section>
+          <section class="powder-stage" aria-label="Powderfall basin">
+            <article class="card powder-simulation">
+              <h3>Powderfall Basin</h3>
+              <div class="powder-basin" id="powder-basin">
+                <div class="powder-wall powder-wall-left" id="powder-wall-left" aria-hidden="true">
+                  <span
+                    class="powder-glyph"
+                    data-powder-glyph
+                    data-height-threshold="0.2"
+                    data-wall="left"
+                  >∑</span>
+                  <span
+                    class="powder-glyph"
+                    data-powder-glyph
+                    data-height-threshold="0.45"
+                    data-wall="left"
+                  >Δ</span>
+                  <span
+                    class="powder-glyph"
+                    data-powder-glyph
+                    data-height-threshold="0.7"
+                    data-wall="left"
+                  >Φ</span>
+                </div>
+                <canvas
+                  id="powder-canvas"
+                  width="240"
+                  height="320"
+                  role="img"
+                  aria-label="Powderfall basin simulation"
+                ></canvas>
+                <div class="powder-wall powder-wall-right" id="powder-wall-right" aria-hidden="true">
+                  <span
+                    class="powder-glyph"
+                    data-powder-glyph
+                    data-height-threshold="0.33"
+                    data-wall="right"
+                  >Ψ</span>
+                  <span
+                    class="powder-glyph"
+                    data-powder-glyph
+                    data-height-threshold="0.58"
+                    data-wall="right"
+                  >Ω</span>
+                  <span
+                    class="powder-glyph"
+                    data-powder-glyph
+                    data-height-threshold="0.85"
+                    data-wall="right"
+                  >ℵ</span>
+                </div>
+              </div>
+              <p class="powder-footnote" id="powder-simulation-note">
+                Captured crest: 0.0% full · dune height h = 1.00 · largest grain —.
+              </p>
+            </article>
+          </section>
+
           <div class="panel-grid powder-grid">
             <article class="card">
               <h3>Sandfall</h3>
@@ -439,19 +497,6 @@
               >
                 Stabilize Flow
               </button>
-            </article>
-            <article class="card powder-simulation">
-              <h3>Powderfall Basin</h3>
-              <canvas
-                id="powder-canvas"
-                width="240"
-                height="320"
-                role="img"
-                aria-label="Powderfall basin simulation"
-              ></canvas>
-              <p class="powder-footnote" id="powder-simulation-note">
-                Captured crest: 0.0% full · dune height h = 1.00 · largest grain —.
-              </p>
             </article>
             <article class="card">
               <h3>Dune Height</h3>


### PR DESCRIPTION
## Summary
- expand the powderfall basin into its own stage-sized card with etched wall glyphs that react to dune height
- update the simulation rendering so 2×2 grains glow yellow and wall activation feeds powder sigil tracking
- refresh powder styling to give the basin full-screen presence on mobile and illuminated containment walls

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f9866b031c832a95db048ba74056c0