### PR TITLE
Refine powder simulation scale and scrolling

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1096,7 +1096,8 @@ body::before {
   padding: 32px 10px;
   background: linear-gradient(180deg, rgba(10, 12, 18, 0.8) 0%, rgba(12, 14, 20, 0.9) 100%);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
-  transition: box-shadow var(--transition), filter var(--transition);
+  transition: box-shadow var(--transition), filter var(--transition), transform 0.45s ease-out;
+  will-change: transform;
 }
 
 .powder-wall-left {
@@ -1107,6 +1108,35 @@ body::before {
 .powder-wall-right {
   right: 0;
   border-left: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.powder-wall-marker {
+  position: absolute;
+  left: 14%;
+  right: 14%;
+  height: 2px;
+  background: linear-gradient(90deg, rgba(255, 228, 120, 0.8), rgba(255, 255, 255, 0.45));
+  border-radius: 999px;
+  pointer-events: none;
+  box-shadow: 0 0 12px rgba(255, 228, 120, 0.32);
+  opacity: 0.85;
+  transform: translateY(0);
+  transition: transform 0.45s ease-out;
+}
+
+.powder-wall-marker::after {
+  content: attr(data-height);
+  position: absolute;
+  top: -1.2rem;
+  right: -2.2rem;
+  padding: 2px 6px;
+  border-radius: 999px;
+  font-family: 'Space Mono', monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  color: rgba(255, 228, 120, 0.75);
+  background: rgba(14, 16, 24, 0.65);
+  box-shadow: 0 0 6px rgba(255, 228, 120, 0.28);
 }
 
 .powder-wall.wall-awake {

--- a/index.html
+++ b/index.html
@@ -445,6 +445,7 @@
                     data-height-threshold="0.7"
                     data-wall="left"
                   >Φ</span>
+                  <div class="powder-wall-marker" id="powder-wall-marker" data-height="0.00" aria-hidden="true"></div>
                 </div>
                 <canvas
                   id="powder-canvas"


### PR DESCRIPTION
## Summary
- shrink simulated powder grains and enforce cliff-wall collisions while keeping flow stabilized by default
- add vertical scrolling that accumulates dune height, shifts glyph walls, and reports crest progress
- surface the dune crest with a translating wall marker and refreshed styling hooks

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68f98927ba6c832ab5004ac391619c5c