### PR TITLE
Enhance powder simulation and tower visuals

### DIFF
--- a/assets/images/tower-alpha.svg
+++ b/assets/images/tower-alpha.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <radialGradient id="alphaGlow" cx="50%" cy="38%" r="60%">
+      <stop offset="0%" stop-color="#fff3c4" stop-opacity="0.95" />
+      <stop offset="70%" stop-color="#f0c75c" stop-opacity="0.85" />
+      <stop offset="100%" stop-color="#1a1724" stop-opacity="0.9" />
+    </radialGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="#0b0d14" />
+  <circle cx="32" cy="30" r="24" fill="url(#alphaGlow)" />
+  <path d="M14 46h36" stroke="#ffe89a" stroke-width="2" stroke-linecap="round" opacity="0.6" />
+  <text
+    x="32"
+    y="41"
+    font-family="'Cormorant Garamond', 'Times New Roman', serif"
+    font-size="32"
+    text-anchor="middle"
+    fill="#231d14"
+  >α</text>
+</svg>

--- a/assets/images/tower-beta.svg
+++ b/assets/images/tower-beta.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="betaField" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#102a33" />
+      <stop offset="100%" stop-color="#0b161d" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="#06080d" />
+  <rect x="8" y="8" width="48" height="48" rx="12" fill="url(#betaField)" />
+  <path
+    d="M20 18h12a10 10 0 1 1 0 20h-12z"
+    fill="none"
+    stroke="#8bf7ff"
+    stroke-width="3"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M32 28h6a8 8 0 1 1 0 16h-6"
+    fill="none"
+    stroke="#8bf7ff"
+    stroke-width="3"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/assets/images/tower-delta.svg
+++ b/assets/images/tower-delta.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="14" fill="#07090f" />
+  <path
+    d="M32 10l22 44H10z"
+    fill="#201824"
+    stroke="#ffb957"
+    stroke-width="2"
+    opacity="0.85"
+  />
+  <path d="M21 42h22" stroke="#ffb957" stroke-width="3" stroke-linecap="round" opacity="0.7" />
+  <path d="M32 26l8 16H24z" fill="#ffdc8f" opacity="0.8" />
+</svg>

--- a/assets/images/tower-gamma.svg
+++ b/assets/images/tower-gamma.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <radialGradient id="gammaCore" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#f5e6ff" stop-opacity="0.95" />
+      <stop offset="80%" stop-color="#6d4aa4" stop-opacity="0.85" />
+      <stop offset="100%" stop-color="#140d1f" stop-opacity="0.9" />
+    </radialGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="#08060d" />
+  <polygon points="32,8 54,32 32,56 10,32" fill="url(#gammaCore)" />
+  <path d="M24 20c10 0 16 10 16 18" stroke="#f6ecff" stroke-width="3" fill="none" />
+  <path d="M24 38h16" stroke="#f6ecff" stroke-width="3" stroke-linecap="round" />
+</svg>

--- a/assets/images/tower-omega.svg
+++ b/assets/images/tower-omega.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="omegaAura" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.8" />
+      <stop offset="100%" stop-color="#9ea6ff" stop-opacity="0.65" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="#0a0c13" />
+  <circle cx="32" cy="32" r="22" fill="#14192b" stroke="#e9edff" stroke-width="2" opacity="0.9" />
+  <path
+    d="M18 25a14 14 0 0 1 28 0c0 6-4 11-9 13l4 7h-18l4-7c-5-2-9-7-9-13z"
+    fill="url(#omegaAura)"
+    stroke="#f8f9ff"
+    stroke-width="2"
+  />
+</svg>

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -361,14 +361,14 @@ body::before {
   border-radius: 14px;
   border: 1px solid rgba(139, 247, 255, 0.25);
   background: rgba(6, 7, 12, 0.92);
-  padding: 12px 10px;
+  padding: 14px 10px 12px;
   display: grid;
   justify-items: center;
-  gap: 8px;
+  gap: 10px;
   cursor: grab;
   transition: transform var(--transition), border-color var(--transition), box-shadow var(--transition),
     opacity var(--transition);
-  min-height: 84px;
+  min-height: 116px;
 }
 
 .tower-loadout-item:active {
@@ -396,6 +396,17 @@ body::before {
   font-family: "Cormorant Garamond", serif;
   font-size: 1.6rem;
   letter-spacing: 0.08em;
+}
+
+.tower-loadout-art {
+  width: 56px;
+  height: 56px;
+  border-radius: 14px;
+  padding: 6px;
+  background: radial-gradient(circle at 50% 30%, rgba(255, 228, 120, 0.28), rgba(12, 14, 20, 0.85));
+  box-shadow: 0 10px 18px rgba(255, 228, 120, 0.18);
+  object-fit: contain;
+  mix-blend-mode: screen;
 }
 
 .tower-loadout-label {
@@ -1137,6 +1148,19 @@ body::before {
   color: rgba(255, 228, 120, 0.75);
   background: rgba(14, 16, 24, 0.65);
   box-shadow: 0 0 6px rgba(255, 228, 120, 0.28);
+}
+
+.powder-crest-marker {
+  background: linear-gradient(90deg, rgba(139, 247, 255, 0.7), rgba(255, 255, 255, 0.45));
+  box-shadow: 0 0 10px rgba(139, 247, 255, 0.28);
+  opacity: 0.9;
+}
+
+.powder-crest-marker::after {
+  right: auto;
+  left: -2.8rem;
+  color: rgba(139, 247, 255, 0.8);
+  box-shadow: 0 0 6px rgba(139, 247, 255, 0.35);
 }
 
 .powder-wall.wall-awake {

--- a/index.html
+++ b/index.html
@@ -445,7 +445,13 @@
                     data-height-threshold="0.7"
                     data-wall="left"
                   >Φ</span>
-                  <div class="powder-wall-marker" id="powder-wall-marker" data-height="0.00" aria-hidden="true"></div>
+                  <div class="powder-wall-marker" id="powder-wall-marker" data-height="Peak 0.00" aria-hidden="true"></div>
+                  <div
+                    class="powder-wall-marker powder-crest-marker"
+                    id="powder-crest-marker"
+                    data-height="Crest 0.00"
+                    aria-hidden="true"
+                  ></div>
                 </div>
                 <canvas
                   id="powder-canvas"


### PR DESCRIPTION
## Summary
- allow the powder basin to grow taller with scrolling thresholds and show crest/peak markers while rendering solid-color grains
- update tower pricing to grow exponentially per placement and show new SVG art in the loadout grid
- add dedicated glyph-themed illustrations for the available towers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f98ebffee0832aa2f49fb12b9a8e41