### PR TITLE
Fix level unlock initialization to restore button interactivity

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -345,8 +345,8 @@
 
   const levelLookup = new Map(levelBlueprints.map((level) => [level.id, level]));
   const levelState = new Map();
-  const interactiveLevelOrder = Array.from(levelConfigs.keys());
-  const unlockedLevels = new Set([firstLevelConfig.id]);
+  let interactiveLevelOrder = [];
+  const unlockedLevels = new Set();
 
   let tabs = [];
   let panels = [];
@@ -1784,6 +1784,11 @@
       levelTenConfig,
     ].map((config) => [config.id, config]),
   );
+
+  interactiveLevelOrder = Array.from(levelConfigs.keys());
+  if (interactiveLevelOrder.length) {
+    unlockedLevels.add(interactiveLevelOrder[0]);
+  }
 
   const idleLevelConfigs = new Map();
 


### PR DESCRIPTION
## Summary
- delay populating the interactive level order until the level configuration map exists
- seed the unlocked level set only after configuration data is ready to avoid ReferenceErrors during startup

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68f9a062d3f4832a843255e63a31a81a