### PR TITLE
Fix achievement powder rate and update status displays

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -75,6 +75,22 @@ body::before {
   font-size: clamp(1.1rem, 2vw, 1.4rem);
 }
 
+.status-value--stacked {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+}
+
+.status-multiplier {
+  font-family: "Space Mono", monospace;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  color: var(--accent-3);
+  text-transform: uppercase;
+  text-shadow: 0 0 12px rgba(255, 228, 120, 0.45), 0 0 24px rgba(255, 228, 120, 0.35);
+}
+
 .main-stage {
   position: relative;
   display: grid;

--- a/index.html
+++ b/index.html
@@ -17,7 +17,10 @@
       <header class="status-bar">
         <div class="status-group">
           <span class="status-label">Τh Thero</span>
-          <span class="status-value" id="status-score">0</span>
+          <span class="status-value status-value--stacked">
+            <span id="status-score">0 Th</span>
+            <span class="status-multiplier" id="status-score-multiplier">×0</span>
+          </span>
         </div>
         <div class="status-group">
           <span class="status-label">Ψ Glyphs</span>


### PR DESCRIPTION
## Summary
- ensure achievement unlocks grant +1 powder per minute by separating their rewards from the base powder flow
- restyle the Thero status display to show a glowing multiplier derived from unused and collected glyphs
- simplify the glyph status readout and add supporting styles for the updated header layout

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68f9a83272fc832a9b55e8c990154042