### PR TITLE
Add offline powder harvest UI and move Omega to final tier

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -94,6 +94,19 @@ body::before {
   text-shadow: 0 0 12px rgba(255, 228, 120, 0.45), 0 0 24px rgba(255, 228, 120, 0.35);
 }
 
+.status-subvalue {
+  font-family: "Space Mono", monospace;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.status-subvalue--gold {
+  color: var(--accent-3);
+  text-shadow: 0 0 10px rgba(255, 228, 120, 0.5), 0 0 22px rgba(255, 228, 120, 0.32);
+}
+
 .main-stage {
   position: relative;
   display: grid;
@@ -103,6 +116,71 @@ body::before {
   border: 1px solid var(--panel-border);
   background: linear-gradient(160deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.015));
   box-shadow: var(--shadow);
+}
+
+.offline-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: grid;
+  place-items: center;
+  padding: clamp(24px, 8vw, 64px);
+  background: radial-gradient(circle at 50% 50%, rgba(255, 215, 128, 0.1), transparent 62%),
+    rgba(3, 3, 5, 0.94);
+  backdrop-filter: blur(4px);
+  transition: opacity var(--transition);
+  opacity: 0;
+  pointer-events: none;
+}
+
+.offline-overlay.active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.offline-overlay[hidden] {
+  display: none;
+}
+
+.offline-overlay__content {
+  display: grid;
+  gap: 18px;
+  justify-items: center;
+  text-align: center;
+}
+
+.offline-overlay__title {
+  margin: 0;
+  font-size: clamp(1.4rem, 3vw, 2.2rem);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent-3);
+  text-shadow: 0 0 18px rgba(255, 228, 120, 0.35);
+}
+
+.offline-overlay__equation {
+  display: inline-grid;
+  grid-auto-flow: column;
+  align-items: baseline;
+  gap: clamp(10px, 2.5vw, 18px);
+  font-family: "Space Mono", monospace;
+  font-size: clamp(1.6rem, 4.5vw, 3.4rem);
+}
+
+.offline-number {
+  color: var(--accent-3);
+  text-shadow: 0 0 14px rgba(255, 228, 120, 0.55), 0 0 28px rgba(255, 228, 120, 0.35);
+  min-width: 4ch;
+  text-align: right;
+}
+
+.offline-symbol {
+  color: rgba(255, 255, 255, 0.68);
+  font-size: clamp(1.2rem, 3vw, 2.2rem);
+}
+
+.offline-overlay__button {
+  min-width: 220px;
 }
 
 .panel {
@@ -1125,6 +1203,25 @@ body::before {
     linear-gradient(180deg, rgba(15, 16, 24, 0.96) 0%, rgba(22, 25, 37, 0.96) 100%);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12), inset 0 -20px 40px rgba(8, 8, 12, 0.6);
   --powder-crest: 0;
+}
+
+.powder-basin--pulse {
+  animation: powder-basin-pulse 0.9s ease;
+}
+
+@keyframes powder-basin-pulse {
+  0% {
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12), inset 0 -20px 40px rgba(8, 8, 12, 0.6);
+  }
+  40% {
+    box-shadow:
+      inset 0 0 0 1px rgba(255, 228, 120, 0.45),
+      inset 0 -32px 60px rgba(255, 228, 120, 0.32),
+      0 0 48px rgba(255, 228, 120, 0.18);
+  }
+  100% {
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12), inset 0 -20px 40px rgba(8, 8, 12, 0.6);
+  }
 }
 
 .powder-basin::before,

--- a/index.html
+++ b/index.html
@@ -13,6 +13,28 @@
     <link rel="stylesheet" href="./assets/styles.css" />
   </head>
   <body>
+    <div
+      class="offline-overlay"
+      id="offline-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-hidden="true"
+      hidden
+    >
+      <div class="offline-overlay__content">
+        <p class="offline-overlay__title">Idle Powder Harvest</p>
+        <div class="offline-overlay__equation" aria-live="polite">
+          <span class="offline-number" id="offline-minutes">0</span>
+          <span class="offline-symbol">×</span>
+          <span class="offline-number" id="offline-rate">0</span>
+          <span class="offline-symbol">=</span>
+          <span class="offline-number" id="offline-total">0</span>
+        </div>
+        <button class="action-button offline-overlay__button" type="button" id="offline-continue" hidden>
+          Resume Defense
+        </button>
+      </div>
+    </div>
     <div class="app-shell">
       <header class="status-bar">
         <div class="status-group">
@@ -24,11 +46,17 @@
         </div>
         <div class="status-group">
           <span class="status-label">Ψ Glyphs</span>
-          <span class="status-value" id="status-energy">0</span>
+          <span class="status-value status-value--stacked">
+            <span id="status-glyphs-total">0 Glyphs</span>
+            <span class="status-subvalue status-subvalue--gold" id="status-glyphs-unused">(0 unused)</span>
+          </span>
         </div>
         <div class="status-group">
-          <span class="status-label">★ Achievements</span>
-          <span class="status-value" id="status-flux">0</span>
+          <span class="status-label">Powderfall Rate</span>
+          <span class="status-value status-value--stacked">
+            <span id="status-powder-rate">+0 Powder/min</span>
+            <span class="status-subvalue status-subvalue--gold" id="status-achievement-count">(0 achievements)</span>
+          </span>
         </div>
       </header>
 
@@ -508,6 +536,10 @@
                 <div>
                   <dt>Crystal Resonance</dt>
                   <dd id="powder-crystal-bonus">+0.00%</dd>
+                </div>
+                <div>
+                  <dt>Powder Stockpile</dt>
+                  <dd id="powder-stockpile">0 Powder</dd>
                 </div>
               </dl>
             </article>


### PR DESCRIPTION
## Summary
- reorder late-game tower tiers so Iota follows Theta and Omega becomes the ultimate upgrade with stronger stats
- persist powder accumulation across sessions, granting idle rewards through a glowing overlay and logging deposits in the powder log
- refresh HUD elements to highlight powder per minute with achievement counts, display glyph totals versus unused glyphs, and surface the powder stockpile in the powder lab

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f9b2a29e84832abd3c5040b3c2cdcf