### PR TITLE
Add developer mode toggle and complete Greek tower roster

### DIFF
--- a/assets/images/tower-chi.svg
+++ b/assets/images/tower-chi.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <radialGradient id="chiGlow" cx="48%" cy="38%" r="60%">
+      <stop offset="0%" stop-color="#ffe3ff" stop-opacity="0.95" />
+      <stop offset="70%" stop-color="#ff94d6" stop-opacity="0.85" />
+      <stop offset="100%" stop-color="#270d25" stop-opacity="0.9" />
+    </radialGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="#150612" />
+  <circle cx="32" cy="30" r="24" fill="url(#chiGlow)" />
+  <path d="M18 48h28" stroke="#ffb8e9" stroke-width="2" stroke-linecap="round" opacity="0.55" />
+  <text
+    x="32"
+    y="41"
+    font-family="'Cormorant Garamond', 'Times New Roman', serif"
+    font-size="32"
+    text-anchor="middle"
+    fill="#2e102c"
+  >χ</text>
+</svg>

--- a/assets/images/tower-omicron.svg
+++ b/assets/images/tower-omicron.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <radialGradient id="omicronGlow" cx="48%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#d5fff4" stop-opacity="0.95" />
+      <stop offset="70%" stop-color="#5de3c5" stop-opacity="0.85" />
+      <stop offset="100%" stop-color="#0a1e1c" stop-opacity="0.9" />
+    </radialGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="#061412" />
+  <circle cx="32" cy="30" r="24" fill="url(#omicronGlow)" />
+  <path d="M16 48h32" stroke="#a9ffe9" stroke-width="2" stroke-linecap="round" opacity="0.55" />
+  <text
+    x="32"
+    y="41"
+    font-family="'Cormorant Garamond', 'Times New Roman', serif"
+    font-size="32"
+    text-anchor="middle"
+    fill="#11231f"
+  >ο</text>
+</svg>

--- a/assets/images/tower-phi.svg
+++ b/assets/images/tower-phi.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <radialGradient id="phiGlow" cx="50%" cy="36%" r="60%">
+      <stop offset="0%" stop-color="#fff7d8" stop-opacity="0.95" />
+      <stop offset="70%" stop-color="#ffd16d" stop-opacity="0.85" />
+      <stop offset="100%" stop-color="#241705" stop-opacity="0.9" />
+    </radialGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="#150d03" />
+  <circle cx="32" cy="30" r="24" fill="url(#phiGlow)" />
+  <path d="M16 48h32" stroke="#ffe4a1" stroke-width="2" stroke-linecap="round" opacity="0.55" />
+  <text
+    x="32"
+    y="41"
+    font-family="'Cormorant Garamond', 'Times New Roman', serif"
+    font-size="32"
+    text-anchor="middle"
+    fill="#2c1a04"
+  >φ</text>
+</svg>

--- a/assets/images/tower-pi.svg
+++ b/assets/images/tower-pi.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <radialGradient id="piGlow" cx="52%" cy="36%" r="62%">
+      <stop offset="0%" stop-color="#fff1d5" stop-opacity="0.95" />
+      <stop offset="70%" stop-color="#f5b54c" stop-opacity="0.85" />
+      <stop offset="100%" stop-color="#231607" stop-opacity="0.9" />
+    </radialGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="#1b1206" />
+  <circle cx="32" cy="30" r="24" fill="url(#piGlow)" />
+  <path d="M14 50h36" stroke="#ffe2a1" stroke-width="2" stroke-linecap="round" opacity="0.5" />
+  <text
+    x="32"
+    y="41"
+    font-family="'Cormorant Garamond', 'Times New Roman', serif"
+    font-size="32"
+    text-anchor="middle"
+    fill="#2a1a05"
+  >π</text>
+</svg>

--- a/assets/images/tower-psi.svg
+++ b/assets/images/tower-psi.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <radialGradient id="psiGlow" cx="50%" cy="36%" r="62%">
+      <stop offset="0%" stop-color="#e8f0ff" stop-opacity="0.95" />
+      <stop offset="70%" stop-color="#8ea6ff" stop-opacity="0.85" />
+      <stop offset="100%" stop-color="#161b33" stop-opacity="0.9" />
+    </radialGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="#090c19" />
+  <circle cx="32" cy="30" r="24" fill="url(#psiGlow)" />
+  <path d="M16 48h32" stroke="#c2d1ff" stroke-width="2" stroke-linecap="round" opacity="0.55" />
+  <text
+    x="32"
+    y="41"
+    font-family="'Cormorant Garamond', 'Times New Roman', serif"
+    font-size="32"
+    text-anchor="middle"
+    fill="#1b2140"
+  >ψ</text>
+</svg>

--- a/assets/images/tower-rho.svg
+++ b/assets/images/tower-rho.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <radialGradient id="rhoGlow" cx="48%" cy="38%" r="60%">
+      <stop offset="0%" stop-color="#ffdfe3" stop-opacity="0.95" />
+      <stop offset="70%" stop-color="#f26c7f" stop-opacity="0.85" />
+      <stop offset="100%" stop-color="#250b11" stop-opacity="0.9" />
+    </radialGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="#16060a" />
+  <circle cx="32" cy="30" r="24" fill="url(#rhoGlow)" />
+  <path d="M18 48h28" stroke="#ffc0c8" stroke-width="2" stroke-linecap="round" opacity="0.55" />
+  <text
+    x="32"
+    y="41"
+    font-family="'Cormorant Garamond', 'Times New Roman', serif"
+    font-size="32"
+    text-anchor="middle"
+    fill="#2c0f17"
+  >ρ</text>
+</svg>

--- a/assets/images/tower-sigma.svg
+++ b/assets/images/tower-sigma.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <radialGradient id="sigmaGlow" cx="50%" cy="38%" r="62%">
+      <stop offset="0%" stop-color="#f4e5ff" stop-opacity="0.95" />
+      <stop offset="70%" stop-color="#b57cff" stop-opacity="0.85" />
+      <stop offset="100%" stop-color="#1b0f28" stop-opacity="0.9" />
+    </radialGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="#0f0618" />
+  <circle cx="32" cy="30" r="24" fill="url(#sigmaGlow)" />
+  <path d="M16 49h32" stroke="#e0c3ff" stroke-width="2" stroke-linecap="round" opacity="0.55" />
+  <text
+    x="32"
+    y="40"
+    font-family="'Cormorant Garamond', 'Times New Roman', serif"
+    font-size="32"
+    text-anchor="middle"
+    fill="#231233"
+  >σ</text>
+</svg>

--- a/assets/images/tower-tau.svg
+++ b/assets/images/tower-tau.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <radialGradient id="tauGlow" cx="50%" cy="36%" r="60%">
+      <stop offset="0%" stop-color="#d9f4ff" stop-opacity="0.95" />
+      <stop offset="70%" stop-color="#6fc1ff" stop-opacity="0.85" />
+      <stop offset="100%" stop-color="#071b29" stop-opacity="0.9" />
+    </radialGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="#05111b" />
+  <circle cx="32" cy="30" r="24" fill="url(#tauGlow)" />
+  <path d="M14 48h36" stroke="#a2dcff" stroke-width="2" stroke-linecap="round" opacity="0.55" />
+  <text
+    x="32"
+    y="41"
+    font-family="'Cormorant Garamond', 'Times New Roman', serif"
+    font-size="32"
+    text-anchor="middle"
+    fill="#0c2536"
+  >τ</text>
+</svg>

--- a/assets/images/tower-upsilon.svg
+++ b/assets/images/tower-upsilon.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <radialGradient id="upsilonGlow" cx="48%" cy="38%" r="60%">
+      <stop offset="0%" stop-color="#dfffe6" stop-opacity="0.95" />
+      <stop offset="70%" stop-color="#7fdc96" stop-opacity="0.85" />
+      <stop offset="100%" stop-color="#081a0c" stop-opacity="0.9" />
+    </radialGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="#041107" />
+  <circle cx="32" cy="30" r="24" fill="url(#upsilonGlow)" />
+  <path d="M17 48h30" stroke="#b9f7c8" stroke-width="2" stroke-linecap="round" opacity="0.55" />
+  <text
+    x="32"
+    y="41"
+    font-family="'Cormorant Garamond', 'Times New Roman', serif"
+    font-size="32"
+    text-anchor="middle"
+    fill="#12331a"
+  >υ</text>
+</svg>

--- a/assets/main.js
+++ b/assets/main.js
@@ -3,6 +3,7 @@
 
   const levelBlueprints = [
     {
+      set: 'Conjecture',
       id: 'Conjecture - 1',
       title: 'Lemniscate Hypothesis',
       path: '∞ loop traced from r² = cos(2θ); mirrored spawn lanes cross twice.',
@@ -11,6 +12,7 @@
         "Goldbach’s Conjecture: Every even integer greater than 2 is the sum of two primes.",
     },
     {
+      set: 'Conjecture',
       id: 'Conjecture - 2',
       title: 'Collatz Cascade',
       path: 'Stepwise descent generated from the 3n + 1 map with teleport risers.',
@@ -19,6 +21,7 @@
         'Collatz Conjecture: Iterate n → n/2 or 3n + 1 and every positive integer reaches 1.',
     },
     {
+      set: 'Conjecture',
       id: 'Conjecture - 3',
       title: 'Riemann Helix',
       path: 'Logarithmic spiral with harmonic bulges keyed to ζ(s) zero estimates.',
@@ -27,6 +30,7 @@
         'Riemann Hypothesis: Every nontrivial zero of ζ(s) lies on the line Re(s) = 1/2.',
     },
     {
+      set: 'Conjecture',
       id: 'Conjecture - 4',
       title: 'Twin Prime Fork',
       path: 'Dual lattice rails linked by prime gaps; enemies swap lanes unpredictably.',
@@ -35,6 +39,7 @@
         'Twin Prime Conjecture: Infinitely many primes p exist such that p + 2 is prime.',
     },
     {
+      set: 'Conjecture',
       id: 'Conjecture - 5',
       title: 'Birch Flow',
       path: 'Cardioid river influenced by elliptic curve rank gradients.',
@@ -43,6 +48,16 @@
         'Birch and Swinnerton-Dyer Conjecture: Rational points of elliptic curves link to L-series behavior.',
     },
     {
+      set: 'Conjecture',
+      id: 'Conjecture - Secret',
+      title: 'Apocrypha Loop',
+      path: 'Hidden lemniscate mirrored through complex planes; portals bloom off-axis.',
+      focus: 'Only reveals during total glyph alignment—expect mixed archetypes in waves.',
+      example:
+        'Secret Lemma: When harmonic sums stabilize, an unseen proof thread emerges from the void.',
+    },
+    {
+      set: 'Corollary',
       id: 'Corollary - 6',
       title: 'Derivative Bloom',
       path: 'Petal loops bloom where f′(x) = 0 across mirrored cardioids and saddle petals.',
@@ -51,6 +66,7 @@
         "Rolle's Corollary: If f(a) = f(b) for differentiable f, some c in (a, b) satisfies f′(c) = 0.",
     },
     {
+      set: 'Corollary',
       id: 'Corollary - 7',
       title: 'Integral Cascade',
       path: 'Stepped integrator ramps descend in quantized slopes shaped by accumulated area.',
@@ -59,6 +75,7 @@
         'Fundamental Corollary: Integrating a derivative recovers the original function up to constants.',
     },
     {
+      set: 'Corollary',
       id: 'Corollary - 8',
       title: 'Fibonacci Turnabout',
       path: 'Interleaved golden spirals shift radius on Fibonacci indices and teleport pads.',
@@ -67,6 +84,7 @@
         'Binet Corollary: Fₙ = (φⁿ − ψⁿ)/√5 gives the closed form of Fibonacci growth.',
     },
     {
+      set: 'Corollary',
       id: 'Corollary - 9',
       title: 'Euler Bridge',
       path: 'Bridge arcs obey planar graph constraints; parity lanes swap over Euler gaps.',
@@ -75,12 +93,22 @@
         'Euler Characteristic Corollary: For planar graphs, F = E − V + 2 limits feasible crossings.',
     },
     {
+      set: 'Corollary',
       id: 'Corollary - 10',
       title: 'Modular Bloom',
       path: 'Modular roses rotate through residue-locked petals with congruence gate warps.',
       focus: 'Reversal sentinels invert on residue gates—δ rallies convert them mid-arc.',
       example:
         'Chinese Remainder Corollary: Congruence systems share synchronized solutions modulo their product.',
+    },
+    {
+      set: 'Corollary',
+      id: 'Corollary - Secret',
+      title: 'Shadow Integral',
+      path: 'Phase-shifted archipelago of calculus islands hidden beneath modular petals.',
+      focus: 'Resource siphons and reversal elites stack together—prepare universal counters.',
+      example:
+        'Secret Corollary: The boundary integral of concealed paths equals interior flux you never saw.',
     },
   ];
 
@@ -288,17 +316,125 @@
       rate: 0.64,
       range: 0.48,
       icon: 'assets/images/tower-xi.svg',
+      nextTierId: 'omicron',
+    },
+    {
+      id: 'omicron',
+      symbol: 'ο',
+      name: 'Omicron Tower',
+      tier: 15,
+      baseCost: 240000000000,
+      damage: 1500,
+      rate: 0.58,
+      range: 0.54,
+      icon: 'assets/images/tower-omicron.svg',
+      nextTierId: 'pi',
+    },
+    {
+      id: 'pi',
+      symbol: 'π',
+      name: 'Pi Tower',
+      tier: 16,
+      baseCost: 780000000000,
+      damage: 1900,
+      rate: 0.56,
+      range: 0.56,
+      icon: 'assets/images/tower-pi.svg',
+      nextTierId: 'rho',
+    },
+    {
+      id: 'rho',
+      symbol: 'ρ',
+      name: 'Rho Tower',
+      tier: 17,
+      baseCost: 2500000000000,
+      damage: 2300,
+      rate: 0.54,
+      range: 0.58,
+      icon: 'assets/images/tower-rho.svg',
+      nextTierId: 'sigma',
+    },
+    {
+      id: 'sigma',
+      symbol: 'σ',
+      name: 'Sigma Tower',
+      tier: 18,
+      baseCost: 8000000000000,
+      damage: 2800,
+      rate: 0.52,
+      range: 0.6,
+      icon: 'assets/images/tower-sigma.svg',
+      nextTierId: 'tau',
+    },
+    {
+      id: 'tau',
+      symbol: 'τ',
+      name: 'Tau Tower',
+      tier: 19,
+      baseCost: 26000000000000,
+      damage: 3400,
+      rate: 0.5,
+      range: 0.62,
+      icon: 'assets/images/tower-tau.svg',
+      nextTierId: 'upsilon',
+    },
+    {
+      id: 'upsilon',
+      symbol: 'υ',
+      name: 'Upsilon Tower',
+      tier: 20,
+      baseCost: 85000000000000,
+      damage: 4100,
+      rate: 0.48,
+      range: 0.64,
+      icon: 'assets/images/tower-upsilon.svg',
+      nextTierId: 'phi',
+    },
+    {
+      id: 'phi',
+      symbol: 'φ',
+      name: 'Phi Tower',
+      tier: 21,
+      baseCost: 280000000000000,
+      damage: 4900,
+      rate: 0.46,
+      range: 0.66,
+      icon: 'assets/images/tower-phi.svg',
+      nextTierId: 'chi',
+    },
+    {
+      id: 'chi',
+      symbol: 'χ',
+      name: 'Chi Tower',
+      tier: 22,
+      baseCost: 920000000000000,
+      damage: 5800,
+      rate: 0.44,
+      range: 0.68,
+      icon: 'assets/images/tower-chi.svg',
+      nextTierId: 'psi',
+    },
+    {
+      id: 'psi',
+      symbol: 'ψ',
+      name: 'Psi Tower',
+      tier: 23,
+      baseCost: 3000000000000000,
+      damage: 6800,
+      rate: 0.42,
+      range: 0.7,
+      icon: 'assets/images/tower-psi.svg',
       nextTierId: 'omega',
     },
     {
       id: 'omega',
       symbol: 'Ω',
       name: 'Omega Tower',
-      tier: 15,
-      baseCost: 75000000000,
-      damage: 1200,
-      rate: 0.6,
-      range: 0.52,
+      tier: 24,
+      baseCost: 9600000000000000,
+      damage: 8000,
+      rate: 0.4,
+      range: 0.74,
       icon: 'assets/images/tower-omega.svg',
       nextTierId: null,
     },
@@ -460,6 +596,13 @@
     empty: null,
     note: null,
   };
+
+  const developerModeElements = {
+    toggle: null,
+    note: null,
+  };
+
+  let developerModeActive = false;
 
   let playfield = null;
   const playfieldElements = {
@@ -5110,48 +5253,89 @@
 
   function buildLevelCards() {
     if (!levelGrid) return;
+    levelGrid.innerHTML = '';
+
     const fragment = document.createDocumentFragment();
+    const groups = new Map();
 
     levelBlueprints.forEach((level) => {
-      const card = document.createElement('article');
-      card.className = 'level-card';
-      card.dataset.level = level.id;
-      card.setAttribute('role', 'button');
-      card.setAttribute('tabindex', '0');
-      card.setAttribute('aria-pressed', 'false');
-      card.setAttribute('aria-label', `${level.id}: ${level.title}`);
-      card.innerHTML = `
-        <header>
-          <span class="level-id">${level.id}</span>
-          <h3>${level.title}</h3>
-        </header>
-        <p class="level-path"><strong>Path:</strong> ${level.path}</p>
-        <p class="level-hazard"><strong>Focus:</strong> ${level.focus}</p>
-        <p class="level-status-pill">New</p>
-        <dl class="level-metrics">
-          <div>
-            <dt>Mode</dt>
-            <dd class="level-mode">—</dd>
-          </div>
-          <div>
-            <dt>Run Length</dt>
-            <dd class="level-duration">—</dd>
-          </div>
-          <div>
-            <dt>Rewards</dt>
-            <dd class="level-rewards">—</dd>
-          </div>
-        </dl>
-        <p class="level-last-result">No attempts recorded.</p>
-      `;
-      card.addEventListener('click', () => handleLevelSelection(level));
-      card.addEventListener('keydown', (event) => {
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault();
-          handleLevelSelection(level);
-        }
+      const groupKey = level.set || level.id.split(' - ')[0] || 'Levels';
+      if (!groups.has(groupKey)) {
+        groups.set(groupKey, []);
+      }
+      groups.get(groupKey).push(level);
+    });
+
+    let groupIndex = 0;
+    groups.forEach((levels, setName) => {
+      const wrapper = document.createElement('details');
+      wrapper.className = 'level-group';
+      if (groupIndex === 0) {
+        wrapper.open = true;
+      }
+
+      const summary = document.createElement('summary');
+      summary.className = 'level-group-summary';
+
+      const title = document.createElement('span');
+      title.className = 'level-group-title';
+      title.textContent = `${setName} Set`;
+
+      const count = document.createElement('span');
+      count.className = 'level-group-count';
+      count.textContent = `${levels.length} levels`;
+
+      summary.append(title, count);
+      wrapper.append(summary);
+
+      const groupGrid = document.createElement('div');
+      groupGrid.className = 'level-group-grid';
+
+      levels.forEach((level) => {
+        const card = document.createElement('article');
+        card.className = 'level-card';
+        card.dataset.level = level.id;
+        card.setAttribute('role', 'button');
+        card.setAttribute('tabindex', '0');
+        card.setAttribute('aria-pressed', 'false');
+        card.setAttribute('aria-label', `${level.id}: ${level.title}`);
+        card.innerHTML = `
+          <header>
+            <span class="level-id">${level.id}</span>
+            <h3>${level.title}</h3>
+          </header>
+          <p class="level-path"><strong>Path:</strong> ${level.path}</p>
+          <p class="level-hazard"><strong>Focus:</strong> ${level.focus}</p>
+          <p class="level-status-pill">New</p>
+          <dl class="level-metrics">
+            <div>
+              <dt>Mode</dt>
+              <dd class="level-mode">—</dd>
+            </div>
+            <div>
+              <dt>Run Length</dt>
+              <dd class="level-duration">—</dd>
+            </div>
+            <div>
+              <dt>Rewards</dt>
+              <dd class="level-rewards">—</dd>
+            </div>
+          </dl>
+          <p class="level-last-result">No attempts recorded.</p>
+        `;
+        card.addEventListener('click', () => handleLevelSelection(level));
+        card.addEventListener('keydown', (event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            handleLevelSelection(level);
+          }
+        });
+        groupGrid.append(card);
       });
-      fragment.append(card);
+
+      wrapper.append(groupGrid);
+      fragment.append(wrapper);
+      groupIndex += 1;
     });
 
     levelGrid.append(fragment);
@@ -5546,7 +5730,7 @@
         : null;
       nextTier.textContent = nextDefinition
         ? `→ ${nextDefinition.symbol} ${nextDefinition.name}`
-        : '→ Zenith unlocked';
+        : '→ Final lattice awakened';
 
       row.append(tier, name, cost, nextTier);
       fragment.append(row);
@@ -6387,7 +6571,7 @@
     enemyCodexElements.list.innerHTML = '';
 
     if (enemyCodexElements.note) {
-      enemyCodexElements.note.hidden = encountered.length > 0 ? true : false;
+      enemyCodexElements.note.hidden = encountered.length > 0 ? false : true;
     }
 
     if (!encountered.length) {
@@ -6431,6 +6615,116 @@
     }
     codexState.encounteredEnemies.add(enemyId);
     renderEnemyCodex();
+  }
+
+  function enableDeveloperMode() {
+    developerModeActive = true;
+    if (developerModeElements.toggle && !developerModeElements.toggle.checked) {
+      developerModeElements.toggle.checked = true;
+    }
+
+    towerDefinitions.forEach((definition) => {
+      unlockTower(definition.id, { silent: true });
+    });
+
+    towerLoadoutState.selected = towerDefinitions
+      .slice(0, TOWER_LOADOUT_LIMIT)
+      .map((definition) => definition.id);
+
+    pruneLockedTowersFromLoadout();
+
+    unlockedLevels.clear();
+    interactiveLevelOrder.forEach((levelId) => {
+      unlockedLevels.add(levelId);
+      const existing = levelState.get(levelId) || {};
+      levelState.set(levelId, {
+        ...existing,
+        entered: true,
+        running: false,
+        completed: true,
+      });
+    });
+
+    levelBlueprints.forEach((level) => {
+      if (!levelState.has(level.id)) {
+        levelState.set(level.id, { entered: true, running: false, completed: true });
+      }
+    });
+
+    codexState.encounteredEnemies = new Set(enemyCodexEntries.map((entry) => entry.id));
+
+    renderEnemyCodex();
+    updateLevelCards();
+    updateActiveLevelBanner();
+    updateTowerCardVisibility();
+    updateTowerSelectionButtons();
+    syncLoadoutToPlayfield();
+    updateStatusDisplays();
+
+    if (developerModeElements.note) {
+      developerModeElements.note.hidden = false;
+    }
+
+    if (playfield?.messageEl) {
+      playfield.messageEl.textContent =
+        'Developer lattice engaged—every tower, level, and codex entry is unlocked.';
+    }
+  }
+
+  function disableDeveloperMode() {
+    developerModeActive = false;
+    if (developerModeElements.toggle && developerModeElements.toggle.checked) {
+      developerModeElements.toggle.checked = false;
+    }
+
+    towerUnlockState.unlocked = new Set(['alpha']);
+    towerLoadoutState.selected = ['alpha'];
+    pruneLockedTowersFromLoadout();
+
+    codexState.encounteredEnemies = new Set();
+
+    levelState.clear();
+    unlockedLevels.clear();
+    if (interactiveLevelOrder.length) {
+      unlockedLevels.add(interactiveLevelOrder[0]);
+    }
+
+    activeLevelId = null;
+    pendingLevel = null;
+    resourceState.running = false;
+
+    if (playfield) {
+      playfield.leaveLevel();
+    }
+
+    renderEnemyCodex();
+    updateLevelCards();
+    updateActiveLevelBanner();
+    updateTowerCardVisibility();
+    updateTowerSelectionButtons();
+    syncLoadoutToPlayfield();
+    updateStatusDisplays();
+
+    if (developerModeElements.note) {
+      developerModeElements.note.hidden = true;
+    }
+  }
+
+  function bindDeveloperModeToggle() {
+    developerModeElements.toggle = document.getElementById('codex-developer-mode');
+    developerModeElements.note = document.getElementById('codex-developer-note');
+
+    if (!developerModeElements.toggle) {
+      return;
+    }
+
+    developerModeElements.toggle.addEventListener('change', (event) => {
+      if (event.target.checked) {
+        enableDeveloperMode();
+      } else {
+        disableDeveloperMode();
+      }
+    });
   }
 
   function notifyAutoAnchorUsed(currentPlaced, totalAnchors) {
@@ -7352,6 +7646,7 @@
     enemyCodexElements.list = document.getElementById('enemy-codex-list');
     enemyCodexElements.empty = document.getElementById('enemy-codex-empty');
     enemyCodexElements.note = document.getElementById('enemy-codex-note');
+    bindDeveloperModeToggle();
     if (audioManager) {
       const activationElements = [
         playfieldElements.startButton,

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -577,8 +577,66 @@ body::before {
 }
 
 .level-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.level-group {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 18px;
+  background: rgba(5, 6, 12, 0.75);
+  padding: 12px 18px 6px;
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+.level-group[open] {
+  border-color: rgba(139, 247, 255, 0.35);
+  box-shadow: 0 12px 28px rgba(139, 247, 255, 0.18);
+}
+
+.level-group-summary {
+  list-style: none;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  font-family: "Space Mono", monospace;
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+  color: var(--muted);
+}
+
+.level-group-summary::-webkit-details-marker {
+  display: none;
+}
+
+.level-group-summary::after {
+  content: '\25BC';
+  font-size: 0.75rem;
+  transition: transform var(--transition);
+}
+
+.level-group[open] > .level-group-summary::after {
+  transform: rotate(180deg);
+}
+
+.level-group-title {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.level-group-count {
+  font-size: 0.75rem;
+  opacity: 0.7;
+}
+
+.level-group-grid {
   display: grid;
   gap: 16px;
+  margin-top: 14px;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
@@ -790,6 +848,35 @@ body::before {
 .enemy-codex {
   display: grid;
   gap: 18px;
+}
+
+.codex-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 4px 0 2px;
+}
+
+.developer-mode-toggle {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.85rem;
+  color: var(--muted);
+  cursor: pointer;
+  user-select: none;
+}
+
+.developer-mode-toggle input {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--accent);
+}
+
+.developer-mode-note {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--accent-2);
 }
 
 .enemy-grid {

--- a/index.html
+++ b/index.html
@@ -383,13 +383,343 @@
                 Equip θ
               </button>
             </article>
-            <article class="card" data-tower-id="omega">
+            <article class="card" data-tower-id="iota">
               <header class="tower-header">
                 <span class="tower-tier">Tier IX</span>
+                <h3>ι iota tower</h3>
+              </header>
+              <div class="formula-block">
+                <p class="formula-line"><span class="formula-symbol">ι</span> = ∮ α · dl</p>
+                <ul class="formula-definition">
+                  <li>∮ dl → closed contour tracing the lane geometry</li>
+                  <li>α → baseline pulse strength from alpha lattices</li>
+                </ul>
+                <p class="formula-line result">Wraps the path in circulating glyph lasers that grow with the loop.</p>
+              </div>
+              <ul class="upgrade-list">
+                <li>Stack additional contours to layer multiple perimeter beams</li>
+                <li>Collapse the integral to detonate when enemies cross the loop</li>
+              </ul>
+              <footer class="card-footer">Sweeps circular beams around waypoints, carving foes that hug the curve.</footer>
+              <button class="tower-equip-button" type="button" data-tower-toggle="iota">
+                Equip ι
+              </button>
+            </article>
+            <article class="card" data-tower-id="kappa">
+              <header class="tower-header">
+                <span class="tower-tier">Tier X</span>
+                <h3>κ kappa tower</h3>
+              </header>
+              <div class="formula-block">
+                <p class="formula-line"><span class="formula-symbol">κ</span> = dθ ∕ ds</p>
+                <ul class="formula-definition">
+                  <li>dθ → angular velocity harvested from θ slows</li>
+                  <li>ds → arc-length scaling with enemy travel distance</li>
+                </ul>
+                <p class="formula-line result">High curvature concentrates fire where paths bend hardest.</p>
+              </div>
+              <ul class="upgrade-list">
+                <li>Sharpen curvature to stun enemies turning corners</li>
+                <li>Diffuse κ to grant allies bonus range along curved lanes</li>
+              </ul>
+              <footer class="card-footer">Focuses on choke points, amplifying damage when the path twists sharply.</footer>
+              <button class="tower-equip-button" type="button" data-tower-toggle="kappa">
+                Equip κ
+              </button>
+            </article>
+            <article class="card" data-tower-id="lambda">
+              <header class="tower-header">
+                <span class="tower-tier">Tier XI</span>
+                <h3>λ lambda tower</h3>
+              </header>
+              <div class="formula-block">
+                <p class="formula-line"><span class="formula-symbol">λ</span> = eig(A)</p>
+                <ul class="formula-definition">
+                  <li>A → adjacency matrix of allied towers</li>
+                  <li>eig(A) → dominant eigenvalue dictates aura strength</li>
+                </ul>
+                <p class="formula-line result">Computes eigen auras that scale every connected glyph.</p>
+              </div>
+              <ul class="upgrade-list">
+                <li>Stabilize eigenvectors to extend aura radius</li>
+                <li>Channel surplus eigenvalues into Δ energy for nearby towers</li>
+              </ul>
+              <footer class="card-footer">Links towers into a networked aura that multiplies shared damage formulas.</footer>
+              <button class="tower-equip-button" type="button" data-tower-toggle="lambda">
+                Equip λ
+              </button>
+            </article>
+            <article class="card" data-tower-id="mu">
+              <header class="tower-header">
+                <span class="tower-tier">Tier XII</span>
+                <h3>μ mu tower</h3>
+              </header>
+              <div class="formula-block">
+                <p class="formula-line"><span class="formula-symbol">μ</span> = E[X] + σ</p>
+                <ul class="formula-definition">
+                  <li>E[X] → expected damage averaged over allied fire</li>
+                  <li>σ → standard deviation captured from ε derivatives</li>
+                </ul>
+                <p class="formula-line result">Predictive volleys adjust in real time to enemy variance.</p>
+              </div>
+              <ul class="upgrade-list">
+                <li>Reduce variance to guarantee steady DPS across waves</li>
+                <li>Exploit outliers to unleash bonus crits on unpredictable foes</li>
+              </ul>
+              <footer class="card-footer">Forecasts damage bands and fires correcting shots before enemies deviate.</footer>
+              <button class="tower-equip-button" type="button" data-tower-toggle="mu">
+                Equip μ
+              </button>
+            </article>
+            <article class="card" data-tower-id="nu">
+              <header class="tower-header">
+                <span class="tower-tier">Tier XIII</span>
+                <h3>ν nu tower</h3>
+              </header>
+              <div class="formula-block">
+                <p class="formula-line"><span class="formula-symbol">ν</span> = f(ω) = ω<sup>3</sup> · θ</p>
+                <ul class="formula-definition">
+                  <li>ω → enemy frequency detected by resonance sensors</li>
+                  <li>θ → temperature field from theta lattices</li>
+                </ul>
+                <p class="formula-line result">Frequency-locked beams punish rhythmic enemy waves.</p>
+              </div>
+              <ul class="upgrade-list">
+                <li>Tune ν to counter alternating slow/fast enemy pulses</li>
+                <li>Convert frequency matches into temporary stuns</li>
+              </ul>
+              <footer class="card-footer">Beats with incoming tempo, amplifying fire when enemies stay on rhythm.</footer>
+              <button class="tower-equip-button" type="button" data-tower-toggle="nu">
+                Equip ν
+              </button>
+            </article>
+            <article class="card" data-tower-id="xi">
+              <header class="tower-header">
+                <span class="tower-tier">Tier XIV</span>
+                <h3>ξ xi tower</h3>
+              </header>
+              <div class="formula-block">
+                <p class="formula-line"><span class="formula-symbol">ξ</span> = ζ(s) · Γ(s∕2)</p>
+                <ul class="formula-definition">
+                  <li>ζ(s) → harmonic sum from zeta resonance</li>
+                  <li>Γ(s∕2) → gamma folding that thickens splash</li>
+                </ul>
+                <p class="formula-line result">Forms balanced blasts immune to parity swings.</p>
+              </div>
+              <ul class="upgrade-list">
+                <li>Shift s along the critical line to pierce armored foes</li>
+                <li>Harness Γ(s∕2) to heal nearby towers after each burst</li>
+              </ul>
+              <footer class="card-footer">Combines zeta harmonics with gamma folds for perfectly symmetric detonations.</footer>
+              <button class="tower-equip-button" type="button" data-tower-toggle="xi">
+                Equip ξ
+              </button>
+            </article>
+            <article class="card" data-tower-id="omicron">
+              <header class="tower-header">
+                <span class="tower-tier">Tier XV</span>
+                <h3>ο omicron tower</h3>
+              </header>
+              <div class="formula-block">
+                <p class="formula-line"><span class="formula-symbol">ο</span> = (1∕N) · Σ e<sup>iωt</sup></p>
+                <ul class="formula-definition">
+                  <li>N → number of active harmonic emitters</li>
+                  <li>e<sup>iωt</sup> → rotating phasors borrowed from ν frequency locks</li>
+                </ul>
+                <p class="formula-line result">Averaged phasors stabilize range and damage as the grid expands.</p>
+              </div>
+              <ul class="upgrade-list">
+                <li>Increase N by linking with λ networks for broader coverage</li>
+                <li>Collapse phasors into a single beam for massive burst output</li>
+              </ul>
+              <footer class="card-footer">Maintains a steady barrage anchored by synchronized phasors.</footer>
+              <button class="tower-equip-button" type="button" data-tower-toggle="omicron">
+                Equip ο
+              </button>
+            </article>
+            <article class="card" data-tower-id="pi">
+              <header class="tower-header">
+                <span class="tower-tier">Tier XVI</span>
+                <h3>π pi tower</h3>
+              </header>
+              <div class="formula-block">
+                <p class="formula-line"><span class="formula-symbol">π</span> = C ∕ (2πr)</p>
+                <ul class="formula-definition">
+                  <li>C → circumference traced by iota's perimeter beams</li>
+                  <li>r → radial distance to the tower's focus</li>
+                </ul>
+                <p class="formula-line result">Projects circular shockwaves proportionate to perfect ratios.</p>
+              </div>
+              <ul class="upgrade-list">
+                <li>Pulse faster by shrinking r with theta slow fields</li>
+                <li>Amplify circumference to cover the entire map in expanding rings</li>
+              </ul>
+              <footer class="card-footer">Unleashes rhythmic rings that reinforce every geometric defense.</footer>
+              <button class="tower-equip-button" type="button" data-tower-toggle="pi">
+                Equip π
+              </button>
+            </article>
+            <article class="card" data-tower-id="rho">
+              <header class="tower-header">
+                <span class="tower-tier">Tier XVII</span>
+                <h3>ρ rho tower</h3>
+              </header>
+              <div class="formula-block">
+                <p class="formula-line"><span class="formula-symbol">ρ</span> = m ∕ V</p>
+                <ul class="formula-definition">
+                  <li>m → enemy mass accrued from divisor counters</li>
+                  <li>V → volume of the defense zone shaped by π rings</li>
+                </ul>
+                <p class="formula-line result">Density locks slow heavy foes while light enemies slip through.</p>
+              </div>
+              <ul class="upgrade-list">
+                <li>Compress V to immobilize armored juggernauts</li>
+                <li>Expand the zone to siphon resources from defeated heavy units</li>
+              </ul>
+              <footer class="card-footer">Manipulates battlefield density, crushing bulky invaders in weighted fields.</footer>
+              <button class="tower-equip-button" type="button" data-tower-toggle="rho">
+                Equip ρ
+              </button>
+            </article>
+            <article class="card" data-tower-id="sigma">
+              <header class="tower-header">
+                <span class="tower-tier">Tier XVIII</span>
+                <h3>σ sigma tower</h3>
+              </header>
+              <div class="formula-block">
+                <p class="formula-line"><span class="formula-symbol">σ</span> = Σ Δι</p>
+                <ul class="formula-definition">
+                  <li>Σ → running total of captured iota loops</li>
+                  <li>Δι → incremental boost gained whenever loops overlap</li>
+                </ul>
+                <p class="formula-line result">Adds every stored loop into one crushing resonance strike.</p>
+              </div>
+              <ul class="upgrade-list">
+                <li>Store more loops before release for exponential splash</li>
+                <li>Convert surplus Σ into shields for nearby towers</li>
+              </ul>
+              <footer class="card-footer">Cascades loop energy into repeated detonations across the grid.</footer>
+              <button class="tower-equip-button" type="button" data-tower-toggle="sigma">
+                Equip σ
+              </button>
+            </article>
+            <article class="card" data-tower-id="tau">
+              <header class="tower-header">
+                <span class="tower-tier">Tier XIX</span>
+                <h3>τ tau tower</h3>
+              </header>
+              <div class="formula-block">
+                <p class="formula-line"><span class="formula-symbol">τ</span> = 2π · r</p>
+                <ul class="formula-definition">
+                  <li>2π → double-angle harmonics from pi rings</li>
+                  <li>r → reactive radius tuned by rho density shifts</li>
+                </ul>
+                <p class="formula-line result">Turns circular motion into relentless rotational fire.</p>
+              </div>
+              <ul class="upgrade-list">
+                <li>Accelerate rotation to fire additional bolts per cycle</li>
+                <li>Stabilize τ to extend slow fields while spinning</li>
+              </ul>
+              <footer class="card-footer">Spins energy arcs faster than any enemy wave can react.</footer>
+              <button class="tower-equip-button" type="button" data-tower-toggle="tau">
+                Equip τ
+              </button>
+            </article>
+            <article class="card" data-tower-id="upsilon">
+              <header class="tower-header">
+                <span class="tower-tier">Tier XX</span>
+                <h3>υ upsilon tower</h3>
+              </header>
+              <div class="formula-block">
+                <p class="formula-line"><span class="formula-symbol">υ</span> = ∇ · Φ</p>
+                <ul class="formula-definition">
+                  <li>∇ → divergence operator shaped by θ thermal gradients</li>
+                  <li>Φ → vector potential projected from phi towers</li>
+                </ul>
+                <p class="formula-line result">Converts gradients into resource gain and enemy pushback.</p>
+              </div>
+              <ul class="upgrade-list">
+                <li>Focus divergence to vacuum enemies toward kill zones</li>
+                <li>Reverse flow to shove elites backward through the gauntlet</li>
+              </ul>
+              <footer class="card-footer">Pulls or repels foes while feeding flux to allied constructs.</footer>
+              <button class="tower-equip-button" type="button" data-tower-toggle="upsilon">
+                Equip υ
+              </button>
+            </article>
+            <article class="card" data-tower-id="phi">
+              <header class="tower-header">
+                <span class="tower-tier">Tier XXI</span>
+                <h3>φ phi tower</h3>
+              </header>
+              <div class="formula-block">
+                <p class="formula-line"><span class="formula-symbol">φ</span> = (1 + √5) ∕ 2</p>
+                <ul class="formula-definition">
+                  <li>(1 + √5) ∕ 2 → golden ratio guiding projectile spacing</li>
+                  <li>√5 → determines bonus split shots at harmonic intervals</li>
+                </ul>
+                <p class="formula-line result">Golden spirals weave through the path, boosting nearby allies.</p>
+              </div>
+              <ul class="upgrade-list">
+                <li>Extend the spiral to grant stacking buffs to every linked tower</li>
+                <li>Invert the ratio to trigger burst damage when enemies cross nodes</li>
+              </ul>
+              <footer class="card-footer">Weaves golden spirals that empower the grid with perfect symmetry.</footer>
+              <button class="tower-equip-button" type="button" data-tower-toggle="phi">
+                Equip φ
+              </button>
+            </article>
+            <article class="card" data-tower-id="chi">
+              <header class="tower-header">
+                <span class="tower-tier">Tier XXII</span>
+                <h3>χ chi tower</h3>
+              </header>
+              <div class="formula-block">
+                <p class="formula-line"><span class="formula-symbol">χ</span> = Σ (α<sub>i</sub> · β<sub>i</sub>)</p>
+                <ul class="formula-definition">
+                  <li>α<sub>i</sub> → burst inputs from alpha-line towers</li>
+                  <li>β<sub>i</sub> → beam contributions from beta conduits</li>
+                </ul>
+                <p class="formula-line result">Cross-correlates allied fire to find the strongest combined output.</p>
+              </div>
+              <ul class="upgrade-list">
+                <li>Link more inputs to widen χ's correlation matrix</li>
+                <li>Trigger interference waves that double damage on matched timings</li>
+              </ul>
+              <footer class="card-footer">Synchronizes every tower pair into perfectly aligned kill windows.</footer>
+              <button class="tower-equip-button" type="button" data-tower-toggle="chi">
+                Equip χ
+              </button>
+            </article>
+            <article class="card" data-tower-id="psi">
+              <header class="tower-header">
+                <span class="tower-tier">Tier XXIII</span>
+                <h3>ψ psi tower</h3>
+              </header>
+              <div class="formula-block">
+                <p class="formula-line"><span class="formula-symbol">ψ</span> = |Ψ(x, t)|<sup>2</sup></p>
+                <ul class="formula-definition">
+                  <li>Ψ(x, t) → quantum waveform seeded by phi spirals</li>
+                  <li>|Ψ|<sup>2</sup> → probability density that collapses into crit chance</li>
+                </ul>
+                <p class="formula-line result">Waveforms collapse into brutal crits when enemies enter the field.</p>
+              </div>
+              <ul class="upgrade-list">
+                <li>Stretch the waveform to blanket the map with probability spikes</li>
+                <li>Collimate Ψ into a single lane for concentrated burst damage</li>
+              </ul>
+              <footer class="card-footer">Manifest probability waves that erupt into critical hits on contact.</footer>
+              <button class="tower-equip-button" type="button" data-tower-toggle="psi">
+                Equip ψ
+              </button>
+            </article>
+            <article class="card" data-tower-id="omega">
+              <header class="tower-header">
+                <span class="tower-tier">Tier XXIV</span>
                 <h3>Ω omega tower</h3>
               </header>
               <div class="formula-block">
-                <p class="formula-line"><span class="formula-symbol">Ω</span> = θ · β<sup>α∕10</sup> + δ · ζ</p>
+                <p class="formula-line"><span class="formula-symbol">Ω</span> = θ · β<sup>α∕10</sup> + δ · ζ + ψ</p>
                 <ul class="formula-definition">
                   <li>θ → modular waves inherited from theta distort path timing</li>
                   <li>β<sup>α∕10</sup> → range oscillates with total β output</li>
@@ -406,6 +736,7 @@
                 Equip Ω
               </button>
             </article>
+
             <article class="card">
               <header class="tower-header">
                 <span class="tower-tier">Convergence</span>
@@ -415,9 +746,9 @@
                 Two <strong>α</strong> towers lattice together into a <strong>β</strong> tower,
                 fusing burst DPS with piercing beams. Merge β constructs to access
                 <strong>γ</strong> conductors, braid γ into <strong>δ</strong> summoners, then
-                differentiate into <strong>ε</strong> through the harmonic ladder of
-                <strong>ζ</strong>, <strong>η</strong>, and <strong>θ</strong>.
-                Ascend every branch to awaken the <strong>Ω</strong> keystone.
+                differentiate into <strong>ε</strong> before scaling the full glyph ladder—
+                <strong>ζ</strong> through <strong>ψ</strong>—to awaken the final
+                <strong>Ω</strong> keystone.
               </p>
               <p class="merge-note">
                 Upgrades rewrite variables dynamically—boost towers grant additive buffs
@@ -778,7 +1109,19 @@
           </div>
           <section class="enemy-codex" aria-live="polite">
             <header class="subsection-title">Enemy Codex</header>
+            <div class="codex-controls">
+              <label class="developer-mode-toggle" for="codex-developer-mode">
+                <input type="checkbox" id="codex-developer-mode" />
+                Developer Mode — unlock all towers, levels, and entries
+              </label>
+              <p class="developer-mode-note" id="codex-developer-note" hidden>
+                Developer mode active: all content is unlocked for rapid iteration.
+              </p>
+            </div>
             <p class="enemy-codex-note" id="enemy-codex-empty">Encounter enemies to unlock their entries.</p>
+            <p class="enemy-codex-note" id="enemy-codex-note" hidden>
+              Known enemy glyphs are cataloged below for quick reference.
+            </p>
             <div class="enemy-grid" id="enemy-codex-list" role="list"></div>
           </section>
         </section>


### PR DESCRIPTION
## Summary
- Expand level blueprint data with per-set metadata, stub secret stages, and collapsible level groups
- Grow the tower roster to all 24 Greek letters, updating definitions, UI cards, and adding matching icons
- Add a developer mode toggle in the codex that unlocks every tower, level, and enemy entry when enabled

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f9c2b93310832a90cad5aa63098a0d