### PR TITLE
Add Aleph tower tier, secret levels, and endless glyph wall

### DIFF
--- a/assets/images/tower-aleph-five.svg
+++ b/assets/images/tower-aleph-five.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="alephFiveAura" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#ffe4f9" stop-opacity="0.92" />
+      <stop offset="100%" stop-color="#ff8fb7" stop-opacity="0.65" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="#0a0c13" />
+  <circle cx="32" cy="32" r="22" fill="#20132e" stroke="#ffe8f7" stroke-width="2" opacity="0.92" />
+  <circle cx="32" cy="32" r="16" fill="url(#alephFiveAura)" opacity="0.94" />
+  <text
+    x="32"
+    y="39"
+    font-family="'Cormorant Garamond', 'Times New Roman', serif"
+    font-size="22"
+    text-anchor="middle"
+    fill="#2a0731"
+  >ℵ₅</text>
+</svg>

--- a/assets/images/tower-aleph-four.svg
+++ b/assets/images/tower-aleph-four.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <radialGradient id="alephFourAura" cx="50%" cy="40%" r="65%">
+      <stop offset="0%" stop-color="#f4e2ff" stop-opacity="0.88" />
+      <stop offset="100%" stop-color="#8bd8ff" stop-opacity="0.62" />
+    </radialGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="#0a0c13" />
+  <circle cx="32" cy="32" r="22" fill="#181b2f" stroke="#f3f0ff" stroke-width="2" opacity="0.92" />
+  <circle cx="32" cy="32" r="16" fill="url(#alephFourAura)" opacity="0.92" />
+  <text
+    x="32"
+    y="39"
+    font-family="'Cormorant Garamond', 'Times New Roman', serif"
+    font-size="22"
+    text-anchor="middle"
+    fill="#102236"
+  >ℵ₄</text>
+</svg>

--- a/assets/images/tower-aleph-null.svg
+++ b/assets/images/tower-aleph-null.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="alephNullAura" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#dff7ff" stop-opacity="0.85" />
+      <stop offset="100%" stop-color="#7fb6ff" stop-opacity="0.65" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="#0a0c13" />
+  <circle cx="32" cy="32" r="22" fill="#141a2d" stroke="#eff6ff" stroke-width="2" opacity="0.92" />
+  <circle cx="32" cy="32" r="16" fill="url(#alephNullAura)" opacity="0.9" />
+  <text
+    x="32"
+    y="39"
+    font-family="'Cormorant Garamond', 'Times New Roman', serif"
+    font-size="22"
+    text-anchor="middle"
+    fill="#0a1833"
+  >ℵ₀</text>
+</svg>

--- a/assets/images/tower-aleph-one.svg
+++ b/assets/images/tower-aleph-one.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <radialGradient id="alephOneAura" cx="50%" cy="45%" r="60%">
+      <stop offset="0%" stop-color="#ffe6ff" stop-opacity="0.9" />
+      <stop offset="100%" stop-color="#b28dff" stop-opacity="0.6" />
+    </radialGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="#0a0c13" />
+  <circle cx="32" cy="32" r="22" fill="#16172b" stroke="#f0e8ff" stroke-width="2" opacity="0.92" />
+  <circle cx="32" cy="32" r="16" fill="url(#alephOneAura)" opacity="0.92" />
+  <text
+    x="32"
+    y="39"
+    font-family="'Cormorant Garamond', 'Times New Roman', serif"
+    font-size="22"
+    text-anchor="middle"
+    fill="#1a0d33"
+  >ℵ₁</text>
+</svg>

--- a/assets/images/tower-aleph-three.svg
+++ b/assets/images/tower-aleph-three.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="alephThreeAura" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#fff5d8" stop-opacity="0.88" />
+      <stop offset="100%" stop-color="#ffb35a" stop-opacity="0.65" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="#0a0c13" />
+  <circle cx="32" cy="32" r="22" fill="#1c1728" stroke="#fff3df" stroke-width="2" opacity="0.92" />
+  <circle cx="32" cy="32" r="16" fill="url(#alephThreeAura)" opacity="0.92" />
+  <text
+    x="32"
+    y="39"
+    font-family="'Cormorant Garamond', 'Times New Roman', serif"
+    font-size="22"
+    text-anchor="middle"
+    fill="#2a1307"
+  >ℵ₃</text>
+</svg>

--- a/assets/images/tower-aleph-two.svg
+++ b/assets/images/tower-aleph-two.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="alephTwoAura" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#d8fff3" stop-opacity="0.85" />
+      <stop offset="100%" stop-color="#71e4c8" stop-opacity="0.6" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="#0a0c13" />
+  <circle cx="32" cy="32" r="22" fill="#141c2a" stroke="#e9fff6" stroke-width="2" opacity="0.92" />
+  <circle cx="32" cy="32" r="16" fill="url(#alephTwoAura)" opacity="0.9" />
+  <text
+    x="32"
+    y="39"
+    font-family="'Cormorant Garamond', 'Times New Roman', serif"
+    font-size="22"
+    text-anchor="middle"
+    fill="#072220"
+  >ℵ₂</text>
+</svg>

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -325,6 +325,10 @@ body::before {
 
 .playfield canvas {
   width: 100%;
+  display: block;
+  text-align: center;
+  display: block;
+  text-align: center;
   height: 100%;
   display: block;
   cursor: inherit;
@@ -1344,13 +1348,14 @@ body::before {
   width: clamp(36px, 14%, 68px);
   display: flex;
   flex-direction: column;
-  justify-content: space-around;
+  justify-content: flex-end;
   align-items: center;
   padding: 32px 10px;
   background: linear-gradient(180deg, rgba(10, 12, 18, 0.8) 0%, rgba(12, 14, 20, 0.9) 100%);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
   transition: box-shadow var(--transition), filter var(--transition), transform 0.45s ease-out;
   will-change: transform;
+  overflow: hidden;
 }
 
 .powder-wall-left {
@@ -1368,12 +1373,12 @@ body::before {
   top: 0;
   left: 14%;
   right: 14%;
-  height: 3px;
-  background: linear-gradient(90deg, rgba(80, 160, 255, 0.85), rgba(255, 152, 96, 0.85));
+  height: 4px;
+  background: linear-gradient(90deg, rgba(80, 160, 255, 0.9), rgba(255, 152, 96, 0.9));
   border-radius: 999px;
   pointer-events: none;
-  box-shadow: 0 0 14px rgba(80, 160, 255, 0.32);
-  opacity: 0.9;
+  box-shadow: 0 0 18px rgba(120, 185, 255, 0.45), 0 0 24px rgba(255, 152, 96, 0.35);
+  opacity: 0.95;
   transform: translateY(0);
   transition: transform 0.45s ease-out;
   z-index: 2;
@@ -1382,16 +1387,16 @@ body::before {
 .powder-wall-marker::after {
   content: attr(data-height);
   position: absolute;
-  top: -1.2rem;
-  right: -2.2rem;
-  padding: 2px 6px;
-  border-radius: 999px;
+  top: -1.45rem;
+  right: -2.4rem;
+  padding: 2px 8px;
+  border-radius: 12px;
   font-family: 'Space Mono', monospace;
   font-size: 0.7rem;
   letter-spacing: 0.08em;
-  color: rgba(255, 152, 96, 0.78);
-  background: rgba(14, 16, 24, 0.72);
-  box-shadow: 0 0 6px rgba(255, 152, 96, 0.32);
+  color: rgba(255, 196, 128, 0.92);
+  background: rgba(14, 16, 24, 0.82);
+  box-shadow: 0 0 8px rgba(255, 196, 128, 0.38);
 }
 
 .powder-crest-marker {
@@ -1412,19 +1417,63 @@ body::before {
   filter: saturate(1.2);
 }
 
-.powder-glyph {
-  font-family: "Cormorant Garamond", "Space Mono", serif;
-  font-size: clamp(1.4rem, 3vw, 2.1rem);
-  letter-spacing: 0.18em;
-  color: rgba(255, 255, 255, 0.26);
-  text-shadow: 0 0 10px rgba(255, 255, 255, 0.05);
-  transition: color var(--transition), text-shadow var(--transition), transform var(--transition);
+.powder-glyph-column {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
 }
 
-.powder-glyph.glowing {
-  color: var(--accent-3);
-  text-shadow: 0 0 12px rgba(255, 228, 120, 0.75), 0 0 28px rgba(255, 195, 32, 0.45);
-  transform: translateY(-2px);
+.powder-glyph {
+  position: absolute;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 100%;
+  display: block;
+  text-align: center;
+  font-family: 'Cormorant Garamond', 'Space Mono', serif;
+  font-size: clamp(1.3rem, 2.6vw, 2rem);
+  letter-spacing: 0.14em;
+  color: rgba(255, 255, 255, 0.28);
+  text-shadow: 0 0 6px rgba(255, 255, 255, 0.08);
+  transition: color 0.3s ease, text-shadow 0.3s ease;
+  pointer-events: none;
+}
+
+.powder-glyph::before {
+  content: '';
+  position: absolute;
+  left: 12%;
+  right: 12%;
+  top: 50%;
+  height: 2px;
+  transform: translateY(-50%);
+  background: linear-gradient(90deg, rgba(190, 198, 255, 0.2), rgba(255, 214, 170, 0.2));
+  border-radius: 999px;
+  box-shadow: 0 0 0 rgba(255, 255, 255, 0);
+  opacity: 0.35;
+  transition: background 0.3s ease, box-shadow 0.3s ease, opacity 0.3s ease;
+}
+
+.powder-glyph--achieved {
+  color: rgba(255, 255, 255, 0.72);
+  text-shadow: 0 0 14px rgba(255, 255, 255, 0.28);
+}
+
+.powder-glyph--achieved::before {
+  opacity: 0.7;
+  background: linear-gradient(90deg, rgba(175, 215, 255, 0.7), rgba(255, 204, 150, 0.65));
+  box-shadow: 0 0 12px rgba(175, 215, 255, 0.35);
+}
+
+.powder-glyph--target {
+  color: rgba(255, 240, 200, 0.95);
+  text-shadow: 0 0 18px rgba(255, 208, 140, 0.45);
+}
+
+.powder-glyph--target::before {
+  opacity: 0.95;
+  background: linear-gradient(90deg, rgba(120, 180, 255, 0.95), rgba(255, 168, 120, 0.95));
+  box-shadow: 0 0 18px rgba(120, 180, 255, 0.45), 0 0 22px rgba(255, 168, 120, 0.4);
 }
 
 .powder-simulation .powder-footnote {

--- a/index.html
+++ b/index.html
@@ -737,6 +737,144 @@
               </button>
             </article>
 
+            <article class="card" data-tower-id="aleph-null">
+              <header class="tower-header">
+                <span class="tower-tier">Tier XXV</span>
+                <h3>ℵ₀ aleph-null tower</h3>
+              </header>
+              <div class="formula-block">
+                <p class="formula-line"><span class="formula-symbol">ℵ₀</span> = sup { n ∈ ℕ }</p>
+                <ul class="formula-definition">
+                  <li>sup { n } → infinite series stabilizes projectile count</li>
+                  <li>ℕ → natural-number cadence sets rhythmic burst cadence</li>
+                </ul>
+                <p class="formula-line result">Summons a countably infinite beam lattice that never exhausts.</p>
+              </div>
+              <ul class="upgrade-list">
+                <li>Fold the infinite series into convergent volleys for focused fire</li>
+                <li>Spiral ℕ cadence outward to feed allies with bonus projectiles</li>
+              </ul>
+              <footer class="card-footer">Anchors the Aleph ladder by drawing limitless threads of glyph light.</footer>
+              <button class="tower-equip-button" type="button" data-tower-toggle="aleph-null">
+                Equip ℵ₀
+              </button>
+            </article>
+
+            <article class="card" data-tower-id="aleph-one">
+              <header class="tower-header">
+                <span class="tower-tier">Tier XXVI</span>
+                <h3>ℵ₁ aleph-one tower</h3>
+              </header>
+              <div class="formula-block">
+                <p class="formula-line"><span class="formula-symbol">ℵ₁</span> = ω<sub>1</sub> · log ζ(s)</p>
+                <ul class="formula-definition">
+                  <li>ω<sub>1</sub> → first uncountable ordinal sweeps entire lanes at once</li>
+                  <li>log ζ(s) → primes feed the tower with scaling damage pulses</li>
+                </ul>
+                <p class="formula-line result">Turns transfinite ordinals into lane-wide surges of harmonic fire.</p>
+              </div>
+              <ul class="upgrade-list">
+                <li>Collapse ω<sub>1</sub> into cardinal shards that shred elite armor</li>
+                <li>Channel ζ(s) resonances to multiply damage whenever primes spawn</li>
+              </ul>
+              <footer class="card-footer">Sweeps entire paths with uncountable force sourced from prime harmonics.</footer>
+              <button class="tower-equip-button" type="button" data-tower-toggle="aleph-one">
+                Equip ℵ₁
+              </button>
+            </article>
+
+            <article class="card" data-tower-id="aleph-two">
+              <header class="tower-header">
+                <span class="tower-tier">Tier XXVII</span>
+                <h3>ℵ₂ aleph-two tower</h3>
+              </header>
+              <div class="formula-block">
+                <p class="formula-line"><span class="formula-symbol">ℵ₂</span> = 2<sup>ℵ₁</sup> · Γ(x)</p>
+                <ul class="formula-definition">
+                  <li>2<sup>ℵ₁</sup> → exponential lift doubles splash layers on every shot</li>
+                  <li>Γ(x) → gamma function stabilizes damage over factorial timing</li>
+                </ul>
+                <p class="formula-line result">Exponentiates the Aleph surge, layering factorial splash across the board.</p>
+              </div>
+              <ul class="upgrade-list">
+                <li>Raise 2<sup>ℵ₁</sup> power to seed recursive explosions down the lane</li>
+                <li>Flatten Γ(x) to smooth DPS for bosses immune to burst damage</li>
+              </ul>
+              <footer class="card-footer">Stacks transfinite exponents until every path resonates with factorial shockwaves.</footer>
+              <button class="tower-equip-button" type="button" data-tower-toggle="aleph-two">
+                Equip ℵ₂
+              </button>
+            </article>
+
+            <article class="card" data-tower-id="aleph-three">
+              <header class="tower-header">
+                <span class="tower-tier">Tier XXVIII</span>
+                <h3>ℵ₃ aleph-three tower</h3>
+              </header>
+              <div class="formula-block">
+                <p class="formula-line"><span class="formula-symbol">ℵ₃</span> = ∮ Σ ω<sub>κ</sub> · dl</p>
+                <ul class="formula-definition">
+                  <li>∮ Σ ω<sub>κ</sub> → contour integral captures every rotation of lower Aleph towers</li>
+                  <li>dl → path length sets continuous shielding around the dune</li>
+                </ul>
+                <p class="formula-line result">Winds contour integrals into orbiting wards that repel anything that remains.</p>
+              </div>
+              <ul class="upgrade-list">
+                <li>Increase contour density to multiply shielding segments per revolution</li>
+                <li>Shear dl into sawtooth waves that slice enemies caught inside the orbit</li>
+              </ul>
+              <footer class="card-footer">Laces the battlefield with integral wards that both defend and incinerate.</footer>
+              <button class="tower-equip-button" type="button" data-tower-toggle="aleph-three">
+                Equip ℵ₃
+              </button>
+            </article>
+
+            <article class="card" data-tower-id="aleph-four">
+              <header class="tower-header">
+                <span class="tower-tier">Tier XXIX</span>
+                <h3>ℵ₄ aleph-four tower</h3>
+              </header>
+              <div class="formula-block">
+                <p class="formula-line"><span class="formula-symbol">ℵ₄</span> = lim<sub>κ→ω₄</sub> κ · Φ(κ)</p>
+                <ul class="formula-definition">
+                  <li>lim<sub>κ→ω₄</sub> → approaching ω₄ unleashes infinite-range pulses</li>
+                  <li>Φ(κ) → potential function modulates slow, stun, and siphon effects</li>
+                </ul>
+                <p class="formula-line result">Approaches higher ordinals to freeze time and siphon energy between lanes.</p>
+              </div>
+              <ul class="upgrade-list">
+                <li>Amplify Φ to grant allies within range permanent slow immunity</li>
+                <li>Collapse the limit to detonate stored siphons for burst resource gains</li>
+              </ul>
+              <footer class="card-footer">Bends ordinal limits to stall entire waves and refuel the glyph lattice.</footer>
+              <button class="tower-equip-button" type="button" data-tower-toggle="aleph-four">
+                Equip ℵ₄
+              </button>
+            </article>
+
+            <article class="card" data-tower-id="aleph-five">
+              <header class="tower-header">
+                <span class="tower-tier">Tier XXX</span>
+                <h3>ℵ₅ aleph-five tower</h3>
+              </header>
+              <div class="formula-block">
+                <p class="formula-line"><span class="formula-symbol">ℵ₅</span> = Ω<sup>ℵ₄</sup> ⊗ ψ</p>
+                <ul class="formula-definition">
+                  <li>Ω<sup>ℵ₄</sup> → raises the omega keystone into transfinite resonance</li>
+                  <li>⊗ ψ → quantum tensor couples every tower into unified burst timing</li>
+                </ul>
+                <p class="formula-line result">Tensor fusion unleashes omnidirectional storms synced across the grid.</p>
+              </div>
+              <ul class="upgrade-list">
+                <li>Project Ω<sup>ℵ₄</sup> outward to draw enemies into the final maelstrom</li>
+                <li>Tune ψ coupling to copy every allied on-hit effect at reduced strength</li>
+              </ul>
+              <footer class="card-footer">The final Aleph tower—merges every glyph into a single world-shattering strike.</footer>
+              <button class="tower-equip-button" type="button" data-tower-toggle="aleph-five">
+                Equip ℵ₅
+              </button>
+            </article>
+
             <article class="card">
               <header class="tower-header">
                 <span class="tower-tier">Convergence</span>
@@ -839,24 +977,7 @@
               <h3>Powderfall Basin</h3>
               <div class="powder-basin" id="powder-basin">
                 <div class="powder-wall powder-wall-left" id="powder-wall-left" aria-hidden="true">
-                  <span
-                    class="powder-glyph"
-                    data-powder-glyph
-                    data-height-threshold="0.2"
-                    data-wall="left"
-                  >∑</span>
-                  <span
-                    class="powder-glyph"
-                    data-powder-glyph
-                    data-height-threshold="0.45"
-                    data-wall="left"
-                  >Δ</span>
-                  <span
-                    class="powder-glyph"
-                    data-powder-glyph
-                    data-height-threshold="0.7"
-                    data-wall="left"
-                  >Φ</span>
+                  <div class="powder-glyph-column" data-powder-glyph-column="left"></div>
                   <div class="powder-wall-marker" id="powder-wall-marker" data-height="Peak 0.00" aria-hidden="true"></div>
                   <div
                     class="powder-wall-marker powder-crest-marker"
@@ -873,24 +994,7 @@
                   aria-label="Powderfall basin simulation"
                 ></canvas>
                 <div class="powder-wall powder-wall-right" id="powder-wall-right" aria-hidden="true">
-                  <span
-                    class="powder-glyph"
-                    data-powder-glyph
-                    data-height-threshold="0.33"
-                    data-wall="right"
-                  >Ψ</span>
-                  <span
-                    class="powder-glyph"
-                    data-powder-glyph
-                    data-height-threshold="0.58"
-                    data-wall="right"
-                  >Ω</span>
-                  <span
-                    class="powder-glyph"
-                    data-powder-glyph
-                    data-height-threshold="0.85"
-                    data-wall="right"
-                  >ℵ</span>
+                  <div class="powder-glyph-column" data-powder-glyph-column="right"></div>
                 </div>
               </div>
               <p class="powder-footnote" id="powder-simulation-note">


### PR DESCRIPTION
## Summary
- extend the tower progression with Aleph-tier definitions, UI cards, and bespoke icons
- introduce interactive configs for the Conjecture and Corollary secret levels with new waves and rewards
- rebuild the powder glyph wall to generate Aleph markings dynamically and show peak progress on an illuminated ruler

## Testing
- not run (web app)


------
https://chatgpt.com/codex/tasks/task_e_68f9ce22edbc832a92abbd3bff883d23