### PR TITLE
Ensure Open Codex button works across browsers

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -7304,9 +7304,17 @@
         if (!codexSection) {
           return;
         }
-        codexSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        try {
+          codexSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        } catch (error) {
+          codexSection.scrollIntoView(true);
+        }
         if (typeof codexSection.focus === 'function') {
-          codexSection.focus({ preventScroll: true });
+          try {
+            codexSection.focus({ preventScroll: true });
+          } catch (error) {
+            codexSection.focus();
+          }
         }
       });
 


### PR DESCRIPTION
## Summary
- wrap the Open Codex button's scroll and focus helpers in fallbacks so the control works on browsers that lack support for option objects

## Testing
- _Not run (not applicable)_

------
https://chatgpt.com/codex/tasks/task_e_68fa3bb724d0832abecfb064d33823c1