### PR TITLE
Gate merging matrix behind beta unlock and improve scrolling

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1764,7 +1764,11 @@ body::before {
 
 .upgrade-overlay .overlay-panel {
   max-width: 520px;
+  max-height: min(85vh, 680px);
   text-align: left;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
 .upgrade-overlay .overlay-label,
@@ -1783,6 +1787,9 @@ body::before {
   gap: 12px;
   margin: 0 0 22px;
   padding: 0;
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding-right: 4px;
 }
 
 .upgrade-matrix-row {

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
           ],
           packages: { '[+]': ['color', 'html'] },
           macros: {
-            glow: '\\class{formula-glow}{\\color{#f9e27d}{#1}}',
+            glow: ['\\class{formula-glow}{\\color{#f9e27d}{#1}}', 1],
           },
         },
         options: {
@@ -889,7 +889,7 @@
               </button>
             </article>
 
-            <article class="card">
+            <article class="card" id="merging-logic-card" hidden aria-hidden="true">
               <header class="tower-header">
                 <span class="tower-tier">Convergence</span>
                 <h3>Merging Logic</h3>


### PR DESCRIPTION
## Summary
- ensure the tower and towers panels respond to mouse-wheel scrolling even when hovering interactive cards
- reveal the merging logic card and upgrade matrix button only after beta is unlocked, and filter the matrix to discovered towers
- allow the upgrade matrix overlay to scroll, and fix the MathJax macro definition error

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68fa3f6ba8c8832a8f2e01f26589260c