### PR TITLE
Add chromatic color scheme and omega tower wave pattern

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -30,6 +30,18 @@ body {
   justify-content: center;
 }
 
+body.color-scheme-aurora {
+  background: radial-gradient(circle at 50% 0, rgba(139, 247, 255, 0.12), transparent 55%), var(--bg);
+}
+
+body.color-scheme-chromatic {
+  --accent: #ff6b6b;
+  --accent-2: #8e54e9;
+  --accent-3: #ffd166;
+  background: radial-gradient(circle at 52% 6%, rgba(255, 139, 139, 0.18), transparent 58%),
+    radial-gradient(circle at 48% 120%, rgba(142, 84, 233, 0.18), transparent 56%), var(--bg);
+}
+
 body::before {
   content: "";
   position: fixed;
@@ -37,6 +49,11 @@ body::before {
   pointer-events: none;
   background: radial-gradient(circle at 50% 120%, rgba(255, 125, 235, 0.12), transparent 45%);
   opacity: 0.9;
+}
+
+body.color-scheme-chromatic::before {
+  background: radial-gradient(circle at 50% 120%, rgba(142, 84, 233, 0.2), transparent 48%);
+  opacity: 0.85;
 }
 
 .app-shell {

--- a/index.html
+++ b/index.html
@@ -1215,8 +1215,10 @@
             </article>
             <article class="card">
               <h3>Visual Theme</h3>
-              <p>Switch between monochrome and aurora accents.</p>
-              <button class="action-button ghost" type="button">Cycle Palette</button>
+              <p>Switch between aurora and chromatic palettes.</p>
+              <button class="action-button ghost" type="button" id="color-scheme-button">
+                Palette · Aurora
+              </button>
             </article>
             <article class="card">
               <h3>Codex</h3>


### PR DESCRIPTION
## Summary
- add a color scheme toggle to the options panel with a new chromatic palette
- render towers using scheme-aware visuals, giving the chromatic mode a red-to-purple gradient with glow effects
- update omega-tier towers to emit looping projectile waves that scale with their upgrades

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68fa47a0ce60832a83ffc372e89d940c