### PR TITLE
Add Aleph Null chain system and platform support blueprint

### DIFF
--- a/docs/JAVASCRIPT_MODULE_SYSTEM.md
+++ b/docs/JAVASCRIPT_MODULE_SYSTEM.md
@@ -92,3 +92,9 @@ Always document the formula or algorithm inline with JSDoc-style comments.
 By following this module system, the JavaScript codebase stays manageable, every file
 remains approachable, and AI assistants can reason about individual subsystems without
 wading through monolithic scripts.
+
+## Live Example
+
+- `scripts/features/towers/alephChain.js` implements the Aleph Null chaining math
+  used by `assets/main.js`. The module stays free of DOM code so the same logic
+  can ship in the future desktop client without changes.

--- a/docs/PLATFORM_SUPPORT.md
+++ b/docs/PLATFORM_SUPPORT.md
@@ -1,0 +1,54 @@
+# Platform Support Blueprint
+
+Glyph Defense Idle is built as a mobile-first experience, but every new system
+must remain portable to an eventual desktop build. Use the following guidance
+whenever you touch gameplay, UI, or infrastructure code.
+
+## Shared Architectural Goals
+
+- **One code path per feature.** Route platform-specific quirks through
+  configuration rather than branching logic. Modules inside `scripts/` should
+  expose platform-agnostic APIs that a desktop renderer can call without
+  modification.
+- **Input abstraction.** Keep tap, drag, and hover handling in UI/controller
+  modules. Desktop builds can map those hooks to mouse and keyboard events
+  without rewriting feature math.
+- **Responsive layout.** Design components so they scale gracefully between
+  portrait mobile screens and wider desktop canvases. Favor flexbox and CSS grid
+  with rem-based sizing so the same markup adapts automatically.
+- **Performance budgeting.** Use the same update loops for all platforms. Avoid
+  mobile-only micro-optimizations that make a desktop build diverge.
+
+## Module Expectations
+
+- Place gameplay math and data transformations in `scripts/core/` or
+  `scripts/features/` modules. DOM-specific bindings should live in
+  `scripts/ui/`.
+- Keep module exports pure where possible. Side effects—audio, DOM mutations,
+  or canvas draws—should be triggered by shell code such as `assets/main.js`.
+- Document every new module with a top-level comment describing how it supports
+  mobile and desktop builds.
+
+## Aleph Null Chain Upgrades
+
+Aleph Null towers now use the dedicated chain registry in
+`scripts/features/towers/alephChain.js`. Upgrades expose three variables that
+any UI (mobile or desktop) can adjust through
+`window.glyphDefenseUpgrades.alephChain`:
+
+| Variable | Symbol | Effect                          | Default |
+| -------- | ------ | ------------------------------- | ------- |
+| `x`      | Range  | Multiplies chain hop distance   | 1.0     |
+| `y`      | Speed  | Multiplies firing cadence       | 1.0     |
+| `z`      | Links  | Maximum enemies struck per shot | 3       |
+
+Desktop implementations should use the same interface—no duplicated logic is
+necessary. Update docs and UI copy when adding new variables or changing base
+values.
+
+## Documentation Checklist
+
+- Note cross-platform considerations in feature PRs.
+- Update this blueprint whenever adding a new upgrade surface or platform hook.
+- Record any temporary platform-specific workarounds so they can be unified
+  before the desktop build ships.

--- a/index.html
+++ b/index.html
@@ -1372,6 +1372,6 @@
         <p class="overlay-instruction">Tap to enter</p>
       </div>
     </div>
-    <script src="./assets/main.js" defer></script>
+    <script type="module" src="./assets/main.js"></script>
   </body>
 </html>

--- a/scripts/features/towers/alephChain.js
+++ b/scripts/features/towers/alephChain.js
@@ -1,0 +1,138 @@
+/**
+ * Aleph Null chain management utilities.
+ *
+ * This module centralizes the math for chaining Aleph Null towers so the
+ * gameplay loop can scale to mobile-first inputs while remaining portable to
+ * a desktop build. It exposes a tiny registry that tracks the order Aleph Null
+ * lattices are placed, calculates their squared totals, and provides upgrade
+ * hooks for range (x), attack speed (y), and chain length (z).
+ */
+
+export const ALEPH_CHAIN_DEFAULT_UPGRADES = Object.freeze({
+  /** Range multiplier applied to each Aleph Null chain hop. */
+  x: 1.0,
+  /** Attack-speed multiplier applied to the base fire rate. */
+  y: 1.0,
+  /** Number of enemies struck per firing sequence (minimum 1). */
+  z: 3,
+});
+
+function clampMultiplier(value, fallback) {
+  if (!Number.isFinite(value) || value <= 0) {
+    return fallback;
+  }
+  return value;
+}
+
+function normalizeUpgradeSet(upgrades = {}) {
+  return {
+    x: clampMultiplier(upgrades.x, ALEPH_CHAIN_DEFAULT_UPGRADES.x),
+    y: clampMultiplier(upgrades.y, ALEPH_CHAIN_DEFAULT_UPGRADES.y),
+    z: Math.max(1, Math.floor(Number.isFinite(upgrades.z) ? upgrades.z : ALEPH_CHAIN_DEFAULT_UPGRADES.z)),
+  };
+}
+
+function safeSquare(value) {
+  if (!Number.isFinite(value)) {
+    return Number.MAX_VALUE;
+  }
+  const result = value * value;
+  if (!Number.isFinite(result)) {
+    return Number.MAX_VALUE;
+  }
+  return Math.min(result, Number.MAX_VALUE);
+}
+
+class AlephChainRegistry {
+  constructor(options = {}) {
+    const { upgrades } = options;
+    this.upgrades = normalizeUpgradeSet(upgrades);
+    this.towerOrder = [];
+    this.states = new Map();
+  }
+
+  reset() {
+    this.towerOrder = [];
+    this.states.clear();
+  }
+
+  registerTower(towerId, baseDamage) {
+    if (!towerId) {
+      return null;
+    }
+    const index = this.towerOrder.findIndex((entry) => entry.id === towerId);
+    const normalizedDamage = Number.isFinite(baseDamage) ? baseDamage : 0;
+    if (index >= 0) {
+      this.towerOrder[index].baseDamage = normalizedDamage;
+    } else {
+      this.towerOrder.push({ id: towerId, baseDamage: normalizedDamage });
+    }
+    this.recomputeTotals();
+    return this.states.get(towerId) || null;
+  }
+
+  unregisterTower(towerId) {
+    if (!towerId) {
+      return;
+    }
+    const index = this.towerOrder.findIndex((entry) => entry.id === towerId);
+    if (index >= 0) {
+      this.towerOrder.splice(index, 1);
+      this.recomputeTotals();
+    }
+  }
+
+  setUpgrades(upgrades = {}) {
+    this.upgrades = normalizeUpgradeSet({ ...this.upgrades, ...upgrades });
+    this.recomputeTotals();
+  }
+
+  getState(towerId) {
+    return towerId ? this.states.get(towerId) || null : null;
+  }
+
+  getAllStates() {
+    return new Map(this.states);
+  }
+
+  getRangeMultiplier() {
+    return this.upgrades.x;
+  }
+
+  getSpeedMultiplier() {
+    return this.upgrades.y;
+  }
+
+  getLinkCount() {
+    return this.upgrades.z;
+  }
+
+  recomputeTotals() {
+    const nextStates = new Map();
+    let previousTotal = null;
+
+    this.towerOrder.forEach((entry, index) => {
+      const baseDamage = Number.isFinite(entry.baseDamage) ? entry.baseDamage : 0;
+      const totalDamage = index === 0 ? baseDamage : safeSquare(previousTotal ?? baseDamage);
+      const state = {
+        towerId: entry.id,
+        index,
+        baseDamage,
+        totalDamage,
+        rangeMultiplier: this.upgrades.x,
+        speedMultiplier: this.upgrades.y,
+        linkCount: this.upgrades.z,
+      };
+      nextStates.set(entry.id, state);
+      previousTotal = totalDamage;
+    });
+
+    this.states = nextStates;
+  }
+}
+
+export function createAlephChainRegistry(options = {}) {
+  return new AlephChainRegistry(options);
+}
+
+export { AlephChainRegistry };


### PR DESCRIPTION
## Summary
- modularize the Aleph Null tower chain math into `scripts/features/towers/alephChain.js` and integrate it with the playfield runtime
- add upgrade hooks for range (x), attack speed (y), and chain links (z) via `window.glyphDefenseUpgrades.alephChain`
- document cross-platform expectations in `docs/PLATFORM_SUPPORT.md` and update the module guide; load the app through an ES module entry point

## Testing
- node --check assets/main.js
- node --check scripts/features/towers/alephChain.js

------
https://chatgpt.com/codex/tasks/task_e_68fa54d808ac832ab74f8897de3991e5