### PR TITLE
Fix MathJax glow macro and tile powder wall art

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1456,7 +1456,13 @@ body.color-scheme-chromatic::before {
   justify-content: flex-end;
   align-items: center;
   padding: 32px 10px;
-  background: linear-gradient(180deg, rgba(10, 12, 18, 0.8) 0%, rgba(12, 14, 20, 0.9) 100%);
+  background-image:
+    linear-gradient(180deg, rgba(10, 12, 18, 0.82) 0%, rgba(12, 14, 20, 0.94) 100%),
+    url('./sprites/inspiration_tower_wall.png');
+  background-repeat: no-repeat, repeat-y;
+  background-size: 100% 100%, 128px 192px;
+  background-position: center, center top;
+  background-blend-mode: overlay, normal;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
   transition: box-shadow var(--transition), filter var(--transition), transform 0.45s ease-out;
   will-change: transform;

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
           ],
           packages: { '[+]': ['color', 'html'] },
           macros: {
-            glow: ['\\class{formula-glow}{\\color{##f9e27d}{#1}}', 1],
+            glow: ['\\class{formula-glow}{\\color{#f9e27d}{#1}}', 1],
           },
         },
         options: {


### PR DESCRIPTION
## Summary
- fix the MathJax glow macro so the inline color literal no longer triggers runtime errors in the tower menu
- apply the inspiration tower wall sprite to the powder walls and tile it at an appropriate scale

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68fa7ed041c4832abc4c3408b07afed4