### PR TITLE
Fix merge action cost to use next-tier tower price

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -3236,7 +3236,7 @@ import {
 
       const baseCost = this.getCurrentTowerCost(towerType);
       const mergeCost = nextDefinition ? this.getCurrentTowerCost(nextDefinition.id) : 0;
-      const actionCost = merging ? Math.max(baseCost, mergeCost) : baseCost;
+      const actionCost = merging ? mergeCost : baseCost;
       const hasFunds = this.energy >= actionCost;
 
       let valid = validation.valid && hasFunds;
@@ -3571,12 +3571,16 @@ import {
 
       const baseCost = this.getCurrentTowerCost(selectedType);
       const mergeCost = nextDefinition ? this.getCurrentTowerCost(nextDefinition.id) : 0;
-      const actionCost = merging ? Math.max(baseCost, mergeCost) : baseCost;
+      const actionCost = merging ? mergeCost : baseCost;
 
       if (this.energy < actionCost) {
         const needed = Math.ceil(actionCost - this.energy);
         if (this.messageEl && !silent) {
-          this.messageEl.textContent = `Need ${needed} Th more to lattice ${definition.symbol}.`;
+          if (merging && nextDefinition) {
+            this.messageEl.textContent = `Need ${needed} Th more to merge into ${nextDefinition.symbol}.`;
+          } else {
+            this.messageEl.textContent = `Need ${needed} Th more to lattice ${definition.symbol}.`;
+          }
         }
         return false;
       }


### PR DESCRIPTION
## Summary
- ensure merging towers charges the cost of the resulting tier instead of the source tier
- clarify the insufficient funds message when attempting a merge

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fa7fff793c832a83f9316fe884366e