### PR TITLE
Refine defense simulation layout and codex presentation

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -300,25 +300,6 @@ body.color-scheme-chromatic::before {
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
 }
 
-.playfield-header {
-  text-align: center;
-  display: grid;
-  gap: 6px;
-}
-
-.playfield-header h3 {
-  margin: 0;
-  font-size: clamp(1.2rem, 2.3vw, 1.6rem);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.playfield-header p {
-  margin: 0;
-  font-size: 0.96rem;
-  color: var(--muted);
-}
-
 .playfield-shell {
   display: grid;
   justify-items: center;
@@ -543,34 +524,41 @@ body.color-scheme-chromatic::before {
   color: rgba(255, 228, 120, 0.75);
 }
 
-.playfield-hud {
-  display: grid;
-  gap: 12px;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  padding: clamp(12px, 3vw, 18px);
-  border-radius: 18px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(5, 6, 12, 0.78);
+.playfield-stats {
+  position: absolute;
+  inset-inline: 0;
+  bottom: 12px;
+  margin: 0;
+  display: flex;
+  justify-content: center;
+  gap: clamp(14px, 4vw, 28px);
+  padding: 8px 16px;
   font-family: "Space Mono", monospace;
-}
-
-.playfield-hud div {
-  display: grid;
-  gap: 6px;
-  text-align: center;
-}
-
-.playfield-hud dt {
-  margin: 0;
-  font-size: 0.78rem;
-  letter-spacing: 0.14em;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--muted);
+  color: rgba(247, 247, 245, 0.72);
+  background: linear-gradient(90deg, rgba(10, 10, 16, 0.6), rgba(10, 10, 16, 0.2));
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  backdrop-filter: blur(6px);
 }
 
-.playfield-hud dd {
+.playfield-stats__item {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.playfield-stats dt {
   margin: 0;
-  font-size: clamp(1rem, 2vw, 1.2rem);
+  color: rgba(247, 247, 245, 0.56);
+}
+
+.playfield-stats dd {
+  margin: 0;
+  color: var(--accent-3);
+  font-size: 0.85rem;
 }
 
 .subsection-title {
@@ -1116,20 +1104,13 @@ body.color-scheme-chromatic::before {
   color: rgba(247, 247, 245, 0.55);
 }
 
-.stage-footer {
-  margin-top: auto;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 16px;
-}
-
 .stage-controls {
   display: flex;
   flex-direction: column;
   gap: 12px;
   align-items: center;
   width: 100%;
+  margin: 16px 0 0;
 }
 
 .control-row {
@@ -1188,15 +1169,24 @@ body.color-scheme-chromatic::before {
   transform: none;
 }
 
-.progress {
-  width: 100%;
-  padding: 12px;
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
+.stage-controls + .level-section {
+  margin-top: 12px;
+}
+
+.codex-header {
+  display: grid;
+  justify-items: center;
+  gap: 4px;
   text-align: center;
+  margin-bottom: 12px;
+}
+
+.codex-label {
   font-family: "Space Mono", monospace;
-  font-size: 0.85rem;
-  color: var(--muted);
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(247, 247, 245, 0.6);
 }
 
 .panel-header {

--- a/index.html
+++ b/index.html
@@ -92,13 +92,6 @@
           aria-labelledby="tab-tower"
         >
           <section class="playfield-wrapper" aria-live="polite">
-            <header class="playfield-header">
-              <h3>Active Defense Simulation</h3>
-              <p id="playfield-message">
-                Select a level to command the defense. Drag glyph chips from your loadout onto the
-                plane to lattice towers.
-              </p>
-            </header>
             <div class="playfield-shell">
               <div
                 class="playfield"
@@ -107,6 +100,20 @@
                 aria-label="Interactive glyph defense lane"
               >
                 <canvas id="playfield-canvas" width="560" height="360"></canvas>
+                <dl class="playfield-stats" aria-live="polite">
+                  <div class="playfield-stats__item">
+                    <dt>Wave</dt>
+                    <dd id="playfield-wave">—</dd>
+                  </div>
+                  <div class="playfield-stats__item">
+                    <dt>Core Integrity</dt>
+                    <dd id="playfield-health">—</dd>
+                  </div>
+                  <div class="playfield-stats__item">
+                    <dt>Glyph Energy</dt>
+                    <dd id="playfield-energy">—</dd>
+                  </div>
+                </dl>
               </div>
             </div>
             <div class="tower-loadout" id="tower-loadout" aria-label="Tower loadout" role="region">
@@ -116,21 +123,24 @@
               </p>
               <div class="tower-loadout-grid" id="tower-loadout-grid" role="list"></div>
             </div>
-            <dl class="playfield-hud">
-              <div>
-                <dt>Wave</dt>
-                <dd id="playfield-wave">—</dd>
-              </div>
-              <div>
-                <dt>Core Integrity</dt>
-                <dd id="playfield-health">—</dd>
-              </div>
-              <div>
-                <dt>Glyph Energy</dt>
-                <dd id="playfield-energy">—</dd>
-              </div>
-            </dl>
           </section>
+          <div class="stage-controls" role="group" aria-label="Defense controls">
+            <button class="play-button" type="button" id="playfield-start" disabled>
+              Commence Wave
+            </button>
+            <div class="control-row" role="group" aria-label="Stage utilities">
+              <button class="control-button" type="button" id="playfield-speed">
+                Speed ×1
+              </button>
+              <button class="control-button" type="button" id="playfield-auto">
+                Auto-lattice α
+              </button>
+            </div>
+            <label class="auto-wave-toggle" for="playfield-auto-wave">
+              <input type="checkbox" id="playfield-auto-wave" checked />
+              Auto-send next wave
+            </label>
+          </div>
           <section class="level-section">
             <header class="subsection-title">Conjecture Set</header>
             <p class="level-intro">
@@ -141,7 +151,10 @@
             </p>
             <div class="level-grid" id="level-grid" aria-live="polite"></div>
             <aside class="level-legend">
-              <h3>Proof Roadmap</h3>
+              <header class="codex-header">
+                <span class="codex-label">Codex</span>
+                <h3>Proof Roadmap</h3>
+              </header>
               <ul class="set-timeline">
                 <li class="set-card active-set">
                   <h4>Conjecture Levels 1-5</h4>
@@ -170,41 +183,6 @@
               </ul>
             </aside>
           </section>
-          <section class="level-status" aria-live="polite">
-            <div class="level-status-banner">
-              <span class="status-label">Active Level</span>
-              <p class="level-status-value" id="active-level">None selected</p>
-            </div>
-            <p class="level-status-note">
-              Levels persist while you browse other tabs. Return to the Stage to
-              continue defending, or leave the level to reset its wave pattern.
-            </p>
-            <button class="action-button ghost" type="button" id="leave-level" aria-live="off">
-              Leave Current Level
-            </button>
-          </section>
-          <div class="stage-footer">
-            <div class="stage-controls">
-              <button class="play-button" type="button" id="playfield-start" disabled>
-                Commence Wave
-              </button>
-              <div class="control-row" role="group" aria-label="Stage utilities">
-                <button class="control-button" type="button" id="playfield-speed">
-                  Speed ×1
-                </button>
-                <button class="control-button" type="button" id="playfield-auto">
-                  Auto-lattice α
-                </button>
-              </div>
-              <label class="auto-wave-toggle" for="playfield-auto-wave">
-                <input type="checkbox" id="playfield-auto-wave" checked />
-                Auto-send next wave
-              </label>
-            </div>
-            <div class="progress">
-              <span id="playfield-progress">No active level.</span>
-            </div>
-          </div>
         </section>
 
         <section


### PR DESCRIPTION
## Summary
- overlay the wave, core integrity, and energy readouts along the bottom of the defense simulation
- reposition the wave control buttons beneath the playfield and remove the progress/status panels
- refresh codex styling so the proof roadmap lives under a dedicated codex header

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68fa82c085b0832aaca02138f699cf35