### PR TITLE
Align tower icons with Aleph visual style

### DIFF
--- a/assets/images/tower-alpha.svg
+++ b/assets/images/tower-alpha.svg
@@ -1,19 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <defs>
-    <radialGradient id="alphaGlow" cx="50%" cy="38%" r="60%">
-      <stop offset="0%" stop-color="#fff3c4" stop-opacity="0.95" />
-      <stop offset="70%" stop-color="#f0c75c" stop-opacity="0.85" />
-      <stop offset="100%" stop-color="#1a1724" stop-opacity="0.9" />
-    </radialGradient>
+    <linearGradient id="alphaAura" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#fff3c4" stop-opacity="0.94" />
+      <stop offset="100%" stop-color="#f0c75c" stop-opacity="0.72" />
+    </linearGradient>
   </defs>
-  <rect width="64" height="64" rx="14" fill="#0b0d14" />
-  <circle cx="32" cy="30" r="24" fill="url(#alphaGlow)" />
-  <path d="M14 46h36" stroke="#ffe89a" stroke-width="2" stroke-linecap="round" opacity="0.6" />
+  <rect width="64" height="64" rx="14" fill="#0a0c13" />
+  <circle cx="32" cy="32" r="22" fill="#141a2d" stroke="#f0f5ff" stroke-width="2" opacity="0.92" />
+  <circle cx="32" cy="32" r="16" fill="url(#alphaAura)" opacity="0.92" />
   <text
     x="32"
-    y="41"
+    y="39"
     font-family="'Cormorant Garamond', 'Times New Roman', serif"
-    font-size="32"
+    font-size="26"
     text-anchor="middle"
     fill="#231d14"
   >α</text>

--- a/assets/images/tower-beta.svg
+++ b/assets/images/tower-beta.svg
@@ -1,24 +1,19 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <defs>
-    <linearGradient id="betaField" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#102a33" />
-      <stop offset="100%" stop-color="#0b161d" />
+    <linearGradient id="betaAura" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#c8f7ff" stop-opacity="0.94" />
+      <stop offset="100%" stop-color="#3a9bd1" stop-opacity="0.72" />
     </linearGradient>
   </defs>
-  <rect width="64" height="64" rx="14" fill="#06080d" />
-  <rect x="8" y="8" width="48" height="48" rx="12" fill="url(#betaField)" />
-  <path
-    d="M20 18h12a10 10 0 1 1 0 20h-12z"
-    fill="none"
-    stroke="#8bf7ff"
-    stroke-width="3"
-    stroke-linejoin="round"
-  />
-  <path
-    d="M32 28h6a8 8 0 1 1 0 16h-6"
-    fill="none"
-    stroke="#8bf7ff"
-    stroke-width="3"
-    stroke-linejoin="round"
-  />
+  <rect width="64" height="64" rx="14" fill="#0a0c13" />
+  <circle cx="32" cy="32" r="22" fill="#141a2d" stroke="#f0f5ff" stroke-width="2" opacity="0.92" />
+  <circle cx="32" cy="32" r="16" fill="url(#betaAura)" opacity="0.92" />
+  <text
+    x="32"
+    y="39"
+    font-family="'Cormorant Garamond', 'Times New Roman', serif"
+    font-size="26"
+    text-anchor="middle"
+    fill="#082430"
+  >β</text>
 </svg>

--- a/assets/images/tower-chi.svg
+++ b/assets/images/tower-chi.svg
@@ -1,19 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <defs>
-    <radialGradient id="chiGlow" cx="48%" cy="38%" r="60%">
-      <stop offset="0%" stop-color="#ffe3ff" stop-opacity="0.95" />
-      <stop offset="70%" stop-color="#ff94d6" stop-opacity="0.85" />
-      <stop offset="100%" stop-color="#270d25" stop-opacity="0.9" />
-    </radialGradient>
+    <linearGradient id="chiAura" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#ffe3ff" stop-opacity="0.94" />
+      <stop offset="100%" stop-color="#ff94d6" stop-opacity="0.72" />
+    </linearGradient>
   </defs>
-  <rect width="64" height="64" rx="14" fill="#150612" />
-  <circle cx="32" cy="30" r="24" fill="url(#chiGlow)" />
-  <path d="M18 48h28" stroke="#ffb8e9" stroke-width="2" stroke-linecap="round" opacity="0.55" />
+  <rect width="64" height="64" rx="14" fill="#0a0c13" />
+  <circle cx="32" cy="32" r="22" fill="#141a2d" stroke="#f0f5ff" stroke-width="2" opacity="0.92" />
+  <circle cx="32" cy="32" r="16" fill="url(#chiAura)" opacity="0.92" />
   <text
     x="32"
-    y="41"
+    y="39"
     font-family="'Cormorant Garamond', 'Times New Roman', serif"
-    font-size="32"
+    font-size="26"
     text-anchor="middle"
     fill="#2e102c"
   >χ</text>

--- a/assets/images/tower-delta.svg
+++ b/assets/images/tower-delta.svg
@@ -1,12 +1,19 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="14" fill="#07090f" />
-  <path
-    d="M32 10l22 44H10z"
-    fill="#201824"
-    stroke="#ffb957"
-    stroke-width="2"
-    opacity="0.85"
-  />
-  <path d="M21 42h22" stroke="#ffb957" stroke-width="3" stroke-linecap="round" opacity="0.7" />
-  <path d="M32 26l8 16H24z" fill="#ffdc8f" opacity="0.8" />
+  <defs>
+    <linearGradient id="deltaAura" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#ffdc8f" stop-opacity="0.94" />
+      <stop offset="100%" stop-color="#ff9b3f" stop-opacity="0.72" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="#0a0c13" />
+  <circle cx="32" cy="32" r="22" fill="#141a2d" stroke="#f0f5ff" stroke-width="2" opacity="0.92" />
+  <circle cx="32" cy="32" r="16" fill="url(#deltaAura)" opacity="0.92" />
+  <text
+    x="32"
+    y="39"
+    font-family="'Cormorant Garamond', 'Times New Roman', serif"
+    font-size="26"
+    text-anchor="middle"
+    fill="#2c1604"
+  >δ</text>
 </svg>

--- a/assets/images/tower-epsilon.svg
+++ b/assets/images/tower-epsilon.svg
@@ -1,19 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <defs>
-    <radialGradient id="epsilonGlow" cx="48%" cy="36%" r="62%">
-      <stop offset="0%" stop-color="#e2f3ff" stop-opacity="0.95" />
-      <stop offset="70%" stop-color="#7ec4ff" stop-opacity="0.85" />
-      <stop offset="100%" stop-color="#101624" stop-opacity="0.9" />
-    </radialGradient>
+    <linearGradient id="epsilonAura" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#e2f3ff" stop-opacity="0.94" />
+      <stop offset="100%" stop-color="#7ec4ff" stop-opacity="0.72" />
+    </linearGradient>
   </defs>
-  <rect width="64" height="64" rx="14" fill="#0a0d16" />
-  <circle cx="32" cy="30" r="24" fill="url(#epsilonGlow)" />
-  <path d="M18 20c6 4 12 4 16 0s10-4 14 0" stroke="#d6ecff" stroke-width="2" stroke-linecap="round" opacity="0.6" />
+  <rect width="64" height="64" rx="14" fill="#0a0c13" />
+  <circle cx="32" cy="32" r="22" fill="#141a2d" stroke="#f0f5ff" stroke-width="2" opacity="0.92" />
+  <circle cx="32" cy="32" r="16" fill="url(#epsilonAura)" opacity="0.92" />
   <text
     x="32"
-    y="41"
+    y="39"
     font-family="'Cormorant Garamond', 'Times New Roman', serif"
-    font-size="32"
+    font-size="26"
     text-anchor="middle"
     fill="#102038"
   >ε</text>

--- a/assets/images/tower-eta.svg
+++ b/assets/images/tower-eta.svg
@@ -1,26 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <defs>
-    <radialGradient id="etaGlow" cx="46%" cy="42%" r="60%">
-      <stop offset="0%" stop-color="#fff4e8" stop-opacity="0.95" />
-      <stop offset="70%" stop-color="#ffb27d" stop-opacity="0.85" />
-      <stop offset="100%" stop-color="#21160c" stop-opacity="0.92" />
-    </radialGradient>
+    <linearGradient id="etaAura" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#fff4e8" stop-opacity="0.94" />
+      <stop offset="100%" stop-color="#ffb27d" stop-opacity="0.72" />
+    </linearGradient>
   </defs>
-  <rect width="64" height="64" rx="14" fill="#120d08" />
-  <circle cx="32" cy="30" r="24" fill="url(#etaGlow)" />
-  <path
-    d="M22 18v24c0 6 6 10 10 10s10-4 10-10V18"
-    fill="none"
-    stroke="#ffe3cc"
-    stroke-width="2"
-    stroke-linecap="round"
-    opacity="0.65"
-  />
+  <rect width="64" height="64" rx="14" fill="#0a0c13" />
+  <circle cx="32" cy="32" r="22" fill="#141a2d" stroke="#f0f5ff" stroke-width="2" opacity="0.92" />
+  <circle cx="32" cy="32" r="16" fill="url(#etaAura)" opacity="0.92" />
   <text
     x="32"
-    y="41"
+    y="39"
     font-family="'Cormorant Garamond', 'Times New Roman', serif"
-    font-size="32"
+    font-size="26"
     text-anchor="middle"
     fill="#2a1406"
   >η</text>

--- a/assets/images/tower-gamma.svg
+++ b/assets/images/tower-gamma.svg
@@ -1,13 +1,19 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <defs>
-    <radialGradient id="gammaCore" cx="50%" cy="50%" r="60%">
-      <stop offset="0%" stop-color="#f5e6ff" stop-opacity="0.95" />
-      <stop offset="80%" stop-color="#6d4aa4" stop-opacity="0.85" />
-      <stop offset="100%" stop-color="#140d1f" stop-opacity="0.9" />
-    </radialGradient>
+    <linearGradient id="gammaAura" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#f5e6ff" stop-opacity="0.94" />
+      <stop offset="100%" stop-color="#6d4aa4" stop-opacity="0.72" />
+    </linearGradient>
   </defs>
-  <rect width="64" height="64" rx="14" fill="#08060d" />
-  <polygon points="32,8 54,32 32,56 10,32" fill="url(#gammaCore)" />
-  <path d="M24 20c10 0 16 10 16 18" stroke="#f6ecff" stroke-width="3" fill="none" />
-  <path d="M24 38h16" stroke="#f6ecff" stroke-width="3" stroke-linecap="round" />
+  <rect width="64" height="64" rx="14" fill="#0a0c13" />
+  <circle cx="32" cy="32" r="22" fill="#141a2d" stroke="#f0f5ff" stroke-width="2" opacity="0.92" />
+  <circle cx="32" cy="32" r="16" fill="url(#gammaAura)" opacity="0.92" />
+  <text
+    x="32"
+    y="39"
+    font-family="'Cormorant Garamond', 'Times New Roman', serif"
+    font-size="26"
+    text-anchor="middle"
+    fill="#1a1232"
+  >γ</text>
 </svg>

--- a/assets/images/tower-iota.svg
+++ b/assets/images/tower-iota.svg
@@ -1,19 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <defs>
-    <radialGradient id="iotaGlow" cx="52%" cy="42%" r="62%">
+    <linearGradient id="iotaAura" x1="0%" y1="0%" x2="0%" y2="100%">
       <stop offset="0%" stop-color="#fefaff" stop-opacity="0.94" />
-      <stop offset="68%" stop-color="#9bd7ff" stop-opacity="0.82" />
-      <stop offset="100%" stop-color="#10131f" stop-opacity="0.92" />
-    </radialGradient>
+      <stop offset="100%" stop-color="#9bd7ff" stop-opacity="0.72" />
+    </linearGradient>
   </defs>
-  <rect width="64" height="64" rx="14" fill="#080a12" />
-  <circle cx="32" cy="30" r="24" fill="url(#iotaGlow)" />
-  <path d="M18 50c8-6 20-6 28 0" stroke="#d8f1ff" stroke-width="2" stroke-linecap="round" opacity="0.5" />
+  <rect width="64" height="64" rx="14" fill="#0a0c13" />
+  <circle cx="32" cy="32" r="22" fill="#141a2d" stroke="#f0f5ff" stroke-width="2" opacity="0.92" />
+  <circle cx="32" cy="32" r="16" fill="url(#iotaAura)" opacity="0.92" />
   <text
     x="32"
-    y="41"
+    y="39"
     font-family="'Cormorant Garamond', 'Times New Roman', serif"
-    font-size="30"
+    font-size="26"
     text-anchor="middle"
     fill="#1c2236"
   >ι</text>

--- a/assets/images/tower-kappa.svg
+++ b/assets/images/tower-kappa.svg
@@ -1,20 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <defs>
-    <radialGradient id="kappaGlow" cx="48%" cy="38%" r="64%">
-      <stop offset="0%" stop-color="#fffced" stop-opacity="0.92" />
-      <stop offset="66%" stop-color="#ffdba3" stop-opacity="0.84" />
-      <stop offset="100%" stop-color="#17131f" stop-opacity="0.93" />
-    </radialGradient>
+    <linearGradient id="kappaAura" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#fffced" stop-opacity="0.94" />
+      <stop offset="100%" stop-color="#ffdba3" stop-opacity="0.72" />
+    </linearGradient>
   </defs>
-  <rect width="64" height="64" rx="14" fill="#0a0b14" />
-  <circle cx="32" cy="30" r="24" fill="url(#kappaGlow)" />
-  <path d="M18 18l28 24" stroke="#ffe0b0" stroke-width="2" stroke-linecap="round" opacity="0.45" />
-  <path d="M18 42l28-24" stroke="#ffe0b0" stroke-width="2" stroke-linecap="round" opacity="0.45" />
+  <rect width="64" height="64" rx="14" fill="#0a0c13" />
+  <circle cx="32" cy="32" r="22" fill="#141a2d" stroke="#f0f5ff" stroke-width="2" opacity="0.92" />
+  <circle cx="32" cy="32" r="16" fill="url(#kappaAura)" opacity="0.92" />
   <text
     x="32"
-    y="41"
+    y="39"
     font-family="'Cormorant Garamond', 'Times New Roman', serif"
-    font-size="32"
+    font-size="26"
     text-anchor="middle"
     fill="#231b14"
   >κ</text>

--- a/assets/images/tower-lambda.svg
+++ b/assets/images/tower-lambda.svg
@@ -1,20 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <defs>
-    <radialGradient id="lambdaGlow" cx="50%" cy="40%" r="66%">
-      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.9" />
-      <stop offset="64%" stop-color="#c8ffcf" stop-opacity="0.8" />
-      <stop offset="100%" stop-color="#14151f" stop-opacity="0.94" />
-    </radialGradient>
+    <linearGradient id="lambdaAura" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.94" />
+      <stop offset="100%" stop-color="#c8ffcf" stop-opacity="0.72" />
+    </linearGradient>
   </defs>
-  <rect width="64" height="64" rx="14" fill="#070910" />
-  <circle cx="32" cy="30" r="24" fill="url(#lambdaGlow)" />
-  <path d="M16 48h32" stroke="#dfffe6" stroke-width="2" stroke-linecap="round" opacity="0.55" />
-  <path d="M24 18l8 26 8-26" stroke="#dfffe6" stroke-width="2" stroke-linecap="round" fill="none" opacity="0.7" />
+  <rect width="64" height="64" rx="14" fill="#0a0c13" />
+  <circle cx="32" cy="32" r="22" fill="#141a2d" stroke="#f0f5ff" stroke-width="2" opacity="0.92" />
+  <circle cx="32" cy="32" r="16" fill="url(#lambdaAura)" opacity="0.92" />
   <text
     x="32"
-    y="41"
+    y="39"
     font-family="'Cormorant Garamond', 'Times New Roman', serif"
-    font-size="32"
+    font-size="26"
     text-anchor="middle"
     fill="#182322"
   >λ</text>

--- a/assets/images/tower-mu.svg
+++ b/assets/images/tower-mu.svg
@@ -1,20 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <defs>
-    <radialGradient id="muGlow" cx="50%" cy="38%" r="68%">
-      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.92" />
-      <stop offset="62%" stop-color="#bff0ff" stop-opacity="0.82" />
-      <stop offset="100%" stop-color="#10111a" stop-opacity="0.95" />
-    </radialGradient>
+    <linearGradient id="muAura" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.94" />
+      <stop offset="100%" stop-color="#bff0ff" stop-opacity="0.72" />
+    </linearGradient>
   </defs>
-  <rect width="64" height="64" rx="14" fill="#060810" />
-  <circle cx="32" cy="30" r="24" fill="url(#muGlow)" />
-  <path d="M18 46h28" stroke="#dff7ff" stroke-width="2" stroke-linecap="round" opacity="0.5" />
-  <path d="M22 20v18c0 6 4 8 10 8s10-2 10-8V20" stroke="#dff7ff" stroke-width="2.2" stroke-linecap="round" fill="none" opacity="0.72" />
+  <rect width="64" height="64" rx="14" fill="#0a0c13" />
+  <circle cx="32" cy="32" r="22" fill="#141a2d" stroke="#f0f5ff" stroke-width="2" opacity="0.92" />
+  <circle cx="32" cy="32" r="16" fill="url(#muAura)" opacity="0.92" />
   <text
     x="32"
-    y="40.5"
+    y="39"
     font-family="'Cormorant Garamond', 'Times New Roman', serif"
-    font-size="32"
+    font-size="26"
     text-anchor="middle"
     fill="#182026"
   >μ</text>

--- a/assets/images/tower-nu.svg
+++ b/assets/images/tower-nu.svg
@@ -1,20 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <defs>
-    <radialGradient id="nuGlow" cx="48%" cy="36%" r="70%">
-      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.9" />
-      <stop offset="60%" stop-color="#ffe7c0" stop-opacity="0.82" />
-      <stop offset="100%" stop-color="#14130f" stop-opacity="0.95" />
-    </radialGradient>
+    <linearGradient id="nuAura" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.94" />
+      <stop offset="100%" stop-color="#ffe7c0" stop-opacity="0.72" />
+    </linearGradient>
   </defs>
-  <rect width="64" height="64" rx="14" fill="#09080a" />
-  <circle cx="32" cy="30" r="24" fill="url(#nuGlow)" />
-  <path d="M18 46h28" stroke="#fff4d8" stroke-width="2" stroke-linecap="round" opacity="0.52" />
-  <path d="M22 20l5 22c1 4 3 6 5 6s4-2 5-6l5-22" stroke="#fff4d8" stroke-width="2.2" stroke-linecap="round" fill="none" opacity="0.7" />
+  <rect width="64" height="64" rx="14" fill="#0a0c13" />
+  <circle cx="32" cy="32" r="22" fill="#141a2d" stroke="#f0f5ff" stroke-width="2" opacity="0.92" />
+  <circle cx="32" cy="32" r="16" fill="url(#nuAura)" opacity="0.92" />
   <text
     x="32"
-    y="41"
+    y="39"
     font-family="'Cormorant Garamond', 'Times New Roman', serif"
-    font-size="32"
+    font-size="26"
     text-anchor="middle"
     fill="#241d12"
   >ν</text>

--- a/assets/images/tower-omega.svg
+++ b/assets/images/tower-omega.svg
@@ -1,16 +1,19 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <defs>
     <linearGradient id="omegaAura" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.8" />
-      <stop offset="100%" stop-color="#9ea6ff" stop-opacity="0.65" />
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.94" />
+      <stop offset="100%" stop-color="#9ea6ff" stop-opacity="0.72" />
     </linearGradient>
   </defs>
   <rect width="64" height="64" rx="14" fill="#0a0c13" />
-  <circle cx="32" cy="32" r="22" fill="#14192b" stroke="#e9edff" stroke-width="2" opacity="0.9" />
-  <path
-    d="M18 25a14 14 0 0 1 28 0c0 6-4 11-9 13l4 7h-18l4-7c-5-2-9-7-9-13z"
-    fill="url(#omegaAura)"
-    stroke="#f8f9ff"
-    stroke-width="2"
-  />
+  <circle cx="32" cy="32" r="22" fill="#141a2d" stroke="#f0f5ff" stroke-width="2" opacity="0.92" />
+  <circle cx="32" cy="32" r="16" fill="url(#omegaAura)" opacity="0.92" />
+  <text
+    x="32"
+    y="39"
+    font-family="'Cormorant Garamond', 'Times New Roman', serif"
+    font-size="26"
+    text-anchor="middle"
+    fill="#1a1733"
+  >Ω</text>
 </svg>

--- a/assets/images/tower-omicron.svg
+++ b/assets/images/tower-omicron.svg
@@ -1,19 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <defs>
-    <radialGradient id="omicronGlow" cx="48%" cy="40%" r="60%">
-      <stop offset="0%" stop-color="#d5fff4" stop-opacity="0.95" />
-      <stop offset="70%" stop-color="#5de3c5" stop-opacity="0.85" />
-      <stop offset="100%" stop-color="#0a1e1c" stop-opacity="0.9" />
-    </radialGradient>
+    <linearGradient id="omicronAura" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#d5fff4" stop-opacity="0.94" />
+      <stop offset="100%" stop-color="#5de3c5" stop-opacity="0.72" />
+    </linearGradient>
   </defs>
-  <rect width="64" height="64" rx="14" fill="#061412" />
-  <circle cx="32" cy="30" r="24" fill="url(#omicronGlow)" />
-  <path d="M16 48h32" stroke="#a9ffe9" stroke-width="2" stroke-linecap="round" opacity="0.55" />
+  <rect width="64" height="64" rx="14" fill="#0a0c13" />
+  <circle cx="32" cy="32" r="22" fill="#141a2d" stroke="#f0f5ff" stroke-width="2" opacity="0.92" />
+  <circle cx="32" cy="32" r="16" fill="url(#omicronAura)" opacity="0.92" />
   <text
     x="32"
-    y="41"
+    y="39"
     font-family="'Cormorant Garamond', 'Times New Roman', serif"
-    font-size="32"
+    font-size="26"
     text-anchor="middle"
     fill="#11231f"
   >ο</text>

--- a/assets/images/tower-phi.svg
+++ b/assets/images/tower-phi.svg
@@ -1,19 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <defs>
-    <radialGradient id="phiGlow" cx="50%" cy="36%" r="60%">
-      <stop offset="0%" stop-color="#fff7d8" stop-opacity="0.95" />
-      <stop offset="70%" stop-color="#ffd16d" stop-opacity="0.85" />
-      <stop offset="100%" stop-color="#241705" stop-opacity="0.9" />
-    </radialGradient>
+    <linearGradient id="phiAura" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#fff7d8" stop-opacity="0.94" />
+      <stop offset="100%" stop-color="#ffd16d" stop-opacity="0.72" />
+    </linearGradient>
   </defs>
-  <rect width="64" height="64" rx="14" fill="#150d03" />
-  <circle cx="32" cy="30" r="24" fill="url(#phiGlow)" />
-  <path d="M16 48h32" stroke="#ffe4a1" stroke-width="2" stroke-linecap="round" opacity="0.55" />
+  <rect width="64" height="64" rx="14" fill="#0a0c13" />
+  <circle cx="32" cy="32" r="22" fill="#141a2d" stroke="#f0f5ff" stroke-width="2" opacity="0.92" />
+  <circle cx="32" cy="32" r="16" fill="url(#phiAura)" opacity="0.92" />
   <text
     x="32"
-    y="41"
+    y="39"
     font-family="'Cormorant Garamond', 'Times New Roman', serif"
-    font-size="32"
+    font-size="26"
     text-anchor="middle"
     fill="#2c1a04"
   >φ</text>

--- a/assets/images/tower-pi.svg
+++ b/assets/images/tower-pi.svg
@@ -1,19 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <defs>
-    <radialGradient id="piGlow" cx="52%" cy="36%" r="62%">
-      <stop offset="0%" stop-color="#fff1d5" stop-opacity="0.95" />
-      <stop offset="70%" stop-color="#f5b54c" stop-opacity="0.85" />
-      <stop offset="100%" stop-color="#231607" stop-opacity="0.9" />
-    </radialGradient>
+    <linearGradient id="piAura" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#fff1d5" stop-opacity="0.94" />
+      <stop offset="100%" stop-color="#f5b54c" stop-opacity="0.72" />
+    </linearGradient>
   </defs>
-  <rect width="64" height="64" rx="14" fill="#1b1206" />
-  <circle cx="32" cy="30" r="24" fill="url(#piGlow)" />
-  <path d="M14 50h36" stroke="#ffe2a1" stroke-width="2" stroke-linecap="round" opacity="0.5" />
+  <rect width="64" height="64" rx="14" fill="#0a0c13" />
+  <circle cx="32" cy="32" r="22" fill="#141a2d" stroke="#f0f5ff" stroke-width="2" opacity="0.92" />
+  <circle cx="32" cy="32" r="16" fill="url(#piAura)" opacity="0.92" />
   <text
     x="32"
-    y="41"
+    y="39"
     font-family="'Cormorant Garamond', 'Times New Roman', serif"
-    font-size="32"
+    font-size="26"
     text-anchor="middle"
     fill="#2a1a05"
   >π</text>

--- a/assets/images/tower-psi.svg
+++ b/assets/images/tower-psi.svg
@@ -1,19 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <defs>
-    <radialGradient id="psiGlow" cx="50%" cy="36%" r="62%">
-      <stop offset="0%" stop-color="#e8f0ff" stop-opacity="0.95" />
-      <stop offset="70%" stop-color="#8ea6ff" stop-opacity="0.85" />
-      <stop offset="100%" stop-color="#161b33" stop-opacity="0.9" />
-    </radialGradient>
+    <linearGradient id="psiAura" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#e8f0ff" stop-opacity="0.94" />
+      <stop offset="100%" stop-color="#8ea6ff" stop-opacity="0.72" />
+    </linearGradient>
   </defs>
-  <rect width="64" height="64" rx="14" fill="#090c19" />
-  <circle cx="32" cy="30" r="24" fill="url(#psiGlow)" />
-  <path d="M16 48h32" stroke="#c2d1ff" stroke-width="2" stroke-linecap="round" opacity="0.55" />
+  <rect width="64" height="64" rx="14" fill="#0a0c13" />
+  <circle cx="32" cy="32" r="22" fill="#141a2d" stroke="#f0f5ff" stroke-width="2" opacity="0.92" />
+  <circle cx="32" cy="32" r="16" fill="url(#psiAura)" opacity="0.92" />
   <text
     x="32"
-    y="41"
+    y="39"
     font-family="'Cormorant Garamond', 'Times New Roman', serif"
-    font-size="32"
+    font-size="26"
     text-anchor="middle"
     fill="#1b2140"
   >ψ</text>

--- a/assets/images/tower-rho.svg
+++ b/assets/images/tower-rho.svg
@@ -1,19 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <defs>
-    <radialGradient id="rhoGlow" cx="48%" cy="38%" r="60%">
-      <stop offset="0%" stop-color="#ffdfe3" stop-opacity="0.95" />
-      <stop offset="70%" stop-color="#f26c7f" stop-opacity="0.85" />
-      <stop offset="100%" stop-color="#250b11" stop-opacity="0.9" />
-    </radialGradient>
+    <linearGradient id="rhoAura" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#ffdfe3" stop-opacity="0.94" />
+      <stop offset="100%" stop-color="#f26c7f" stop-opacity="0.72" />
+    </linearGradient>
   </defs>
-  <rect width="64" height="64" rx="14" fill="#16060a" />
-  <circle cx="32" cy="30" r="24" fill="url(#rhoGlow)" />
-  <path d="M18 48h28" stroke="#ffc0c8" stroke-width="2" stroke-linecap="round" opacity="0.55" />
+  <rect width="64" height="64" rx="14" fill="#0a0c13" />
+  <circle cx="32" cy="32" r="22" fill="#141a2d" stroke="#f0f5ff" stroke-width="2" opacity="0.92" />
+  <circle cx="32" cy="32" r="16" fill="url(#rhoAura)" opacity="0.92" />
   <text
     x="32"
-    y="41"
+    y="39"
     font-family="'Cormorant Garamond', 'Times New Roman', serif"
-    font-size="32"
+    font-size="26"
     text-anchor="middle"
     fill="#2c0f17"
   >ρ</text>

--- a/assets/images/tower-sigma.svg
+++ b/assets/images/tower-sigma.svg
@@ -1,19 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <defs>
-    <radialGradient id="sigmaGlow" cx="50%" cy="38%" r="62%">
-      <stop offset="0%" stop-color="#f4e5ff" stop-opacity="0.95" />
-      <stop offset="70%" stop-color="#b57cff" stop-opacity="0.85" />
-      <stop offset="100%" stop-color="#1b0f28" stop-opacity="0.9" />
-    </radialGradient>
+    <linearGradient id="sigmaAura" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#f4e5ff" stop-opacity="0.94" />
+      <stop offset="100%" stop-color="#b57cff" stop-opacity="0.72" />
+    </linearGradient>
   </defs>
-  <rect width="64" height="64" rx="14" fill="#0f0618" />
-  <circle cx="32" cy="30" r="24" fill="url(#sigmaGlow)" />
-  <path d="M16 49h32" stroke="#e0c3ff" stroke-width="2" stroke-linecap="round" opacity="0.55" />
+  <rect width="64" height="64" rx="14" fill="#0a0c13" />
+  <circle cx="32" cy="32" r="22" fill="#141a2d" stroke="#f0f5ff" stroke-width="2" opacity="0.92" />
+  <circle cx="32" cy="32" r="16" fill="url(#sigmaAura)" opacity="0.92" />
   <text
     x="32"
-    y="40"
+    y="39"
     font-family="'Cormorant Garamond', 'Times New Roman', serif"
-    font-size="32"
+    font-size="26"
     text-anchor="middle"
     fill="#231233"
   >σ</text>

--- a/assets/images/tower-tau.svg
+++ b/assets/images/tower-tau.svg
@@ -1,19 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <defs>
-    <radialGradient id="tauGlow" cx="50%" cy="36%" r="60%">
-      <stop offset="0%" stop-color="#d9f4ff" stop-opacity="0.95" />
-      <stop offset="70%" stop-color="#6fc1ff" stop-opacity="0.85" />
-      <stop offset="100%" stop-color="#071b29" stop-opacity="0.9" />
-    </radialGradient>
+    <linearGradient id="tauAura" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#d9f4ff" stop-opacity="0.94" />
+      <stop offset="100%" stop-color="#6fc1ff" stop-opacity="0.72" />
+    </linearGradient>
   </defs>
-  <rect width="64" height="64" rx="14" fill="#05111b" />
-  <circle cx="32" cy="30" r="24" fill="url(#tauGlow)" />
-  <path d="M14 48h36" stroke="#a2dcff" stroke-width="2" stroke-linecap="round" opacity="0.55" />
+  <rect width="64" height="64" rx="14" fill="#0a0c13" />
+  <circle cx="32" cy="32" r="22" fill="#141a2d" stroke="#f0f5ff" stroke-width="2" opacity="0.92" />
+  <circle cx="32" cy="32" r="16" fill="url(#tauAura)" opacity="0.92" />
   <text
     x="32"
-    y="41"
+    y="39"
     font-family="'Cormorant Garamond', 'Times New Roman', serif"
-    font-size="32"
+    font-size="26"
     text-anchor="middle"
     fill="#0c2536"
   >τ</text>

--- a/assets/images/tower-theta.svg
+++ b/assets/images/tower-theta.svg
@@ -1,27 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <defs>
-    <radialGradient id="thetaGlow" cx="52%" cy="38%" r="64%">
-      <stop offset="0%" stop-color="#f0fff5" stop-opacity="0.95" />
-      <stop offset="70%" stop-color="#7df5c6" stop-opacity="0.85" />
-      <stop offset="100%" stop-color="#0f1f18" stop-opacity="0.92" />
-    </radialGradient>
+    <linearGradient id="thetaAura" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#f0fff5" stop-opacity="0.94" />
+      <stop offset="100%" stop-color="#7df5c6" stop-opacity="0.72" />
+    </linearGradient>
   </defs>
-  <rect width="64" height="64" rx="14" fill="#081510" />
-  <circle cx="32" cy="30" r="24" fill="url(#thetaGlow)" />
-  <path
-    d="M16 30c4-10 12-16 16-16s12 6 16 16-12 16-16 16-20-6-16-16z"
-    fill="none"
-    stroke="#c6ffeb"
-    stroke-width="2"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-    opacity="0.65"
-  />
+  <rect width="64" height="64" rx="14" fill="#0a0c13" />
+  <circle cx="32" cy="32" r="22" fill="#141a2d" stroke="#f0f5ff" stroke-width="2" opacity="0.92" />
+  <circle cx="32" cy="32" r="16" fill="url(#thetaAura)" opacity="0.92" />
   <text
     x="32"
-    y="41"
+    y="39"
     font-family="'Cormorant Garamond', 'Times New Roman', serif"
-    font-size="32"
+    font-size="26"
     text-anchor="middle"
     fill="#0a281c"
   >θ</text>

--- a/assets/images/tower-upsilon.svg
+++ b/assets/images/tower-upsilon.svg
@@ -1,19 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <defs>
-    <radialGradient id="upsilonGlow" cx="48%" cy="38%" r="60%">
-      <stop offset="0%" stop-color="#dfffe6" stop-opacity="0.95" />
-      <stop offset="70%" stop-color="#7fdc96" stop-opacity="0.85" />
-      <stop offset="100%" stop-color="#081a0c" stop-opacity="0.9" />
-    </radialGradient>
+    <linearGradient id="upsilonAura" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#dfffe6" stop-opacity="0.94" />
+      <stop offset="100%" stop-color="#7fdc96" stop-opacity="0.72" />
+    </linearGradient>
   </defs>
-  <rect width="64" height="64" rx="14" fill="#041107" />
-  <circle cx="32" cy="30" r="24" fill="url(#upsilonGlow)" />
-  <path d="M17 48h30" stroke="#b9f7c8" stroke-width="2" stroke-linecap="round" opacity="0.55" />
+  <rect width="64" height="64" rx="14" fill="#0a0c13" />
+  <circle cx="32" cy="32" r="22" fill="#141a2d" stroke="#f0f5ff" stroke-width="2" opacity="0.92" />
+  <circle cx="32" cy="32" r="16" fill="url(#upsilonAura)" opacity="0.92" />
   <text
     x="32"
-    y="41"
+    y="39"
     font-family="'Cormorant Garamond', 'Times New Roman', serif"
-    font-size="32"
+    font-size="26"
     text-anchor="middle"
     fill="#12331a"
   >υ</text>

--- a/assets/images/tower-xi.svg
+++ b/assets/images/tower-xi.svg
@@ -1,20 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <defs>
-    <radialGradient id="xiGlow" cx="52%" cy="34%" r="70%">
-      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.9" />
-      <stop offset="58%" stop-color="#d7c6ff" stop-opacity="0.82" />
-      <stop offset="100%" stop-color="#16121f" stop-opacity="0.95" />
-    </radialGradient>
+    <linearGradient id="xiAura" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.94" />
+      <stop offset="100%" stop-color="#d7c6ff" stop-opacity="0.72" />
+    </linearGradient>
   </defs>
-  <rect width="64" height="64" rx="14" fill="#07060d" />
-  <circle cx="32" cy="30" r="24" fill="url(#xiGlow)" />
-  <path d="M18 46h28" stroke="#efe5ff" stroke-width="2" stroke-linecap="round" opacity="0.52" />
-  <path d="M22 22h20m-18 8h16m-14 8h12" stroke="#efe5ff" stroke-width="2" stroke-linecap="round" opacity="0.68" />
+  <rect width="64" height="64" rx="14" fill="#0a0c13" />
+  <circle cx="32" cy="32" r="22" fill="#141a2d" stroke="#f0f5ff" stroke-width="2" opacity="0.92" />
+  <circle cx="32" cy="32" r="16" fill="url(#xiAura)" opacity="0.92" />
   <text
     x="32"
-    y="41"
+    y="39"
     font-family="'Cormorant Garamond', 'Times New Roman', serif"
-    font-size="32"
+    font-size="26"
     text-anchor="middle"
     fill="#1f1628"
   >ξ</text>

--- a/assets/images/tower-zeta.svg
+++ b/assets/images/tower-zeta.svg
@@ -1,26 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <defs>
-    <radialGradient id="zetaGlow" cx="50%" cy="40%" r="64%">
-      <stop offset="0%" stop-color="#fdefff" stop-opacity="0.95" />
-      <stop offset="70%" stop-color="#d68bff" stop-opacity="0.85" />
-      <stop offset="100%" stop-color="#190f26" stop-opacity="0.92" />
-    </radialGradient>
+    <linearGradient id="zetaAura" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#fdefff" stop-opacity="0.94" />
+      <stop offset="100%" stop-color="#d68bff" stop-opacity="0.72" />
+    </linearGradient>
   </defs>
-  <rect width="64" height="64" rx="14" fill="#0b0716" />
-  <circle cx="32" cy="30" r="24" fill="url(#zetaGlow)" />
-  <path
-    d="M16 24h32l-8 8 8 8H16l8-8z"
-    fill="none"
-    stroke="#f7d2ff"
-    stroke-width="1.6"
-    stroke-linejoin="round"
-    opacity="0.65"
-  />
+  <rect width="64" height="64" rx="14" fill="#0a0c13" />
+  <circle cx="32" cy="32" r="22" fill="#141a2d" stroke="#f0f5ff" stroke-width="2" opacity="0.92" />
+  <circle cx="32" cy="32" r="16" fill="url(#zetaAura)" opacity="0.92" />
   <text
     x="32"
-    y="41"
+    y="39"
     font-family="'Cormorant Garamond', 'Times New Roman', serif"
-    font-size="32"
+    font-size="26"
     text-anchor="middle"
     fill="#200b36"
   >ζ</text>


### PR DESCRIPTION
## Summary
- restyled all non-Aleph tower SVGs to use the concentric-circle motif established by the Aleph towers
- applied gentle gradients and centered glyphs to reinforce the unified mystical-mathematical aesthetic

## Testing
- not run (asset update only)

------
https://chatgpt.com/codex/tasks/task_e_68fa8439a85c832a88b41bebf840eb2f