### PR TITLE
Fix powder basin left wall visibility

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1454,6 +1454,7 @@ body.color-scheme-chromatic::before {
   background-position: center, center top;
   background-blend-mode: overlay, normal;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  z-index: 1;
   transition: box-shadow var(--transition), filter var(--transition), transform 0.45s ease-out;
   will-change: transform;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- ensure the powder basin wall elements render above the simulation canvas
- add a stacking context override so the left wall is no longer hidden behind the canvas

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fa884830b0832a99f8f84978476554