### PR TITLE
Remove MathJax glow macro to clear tower tab error

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -8132,8 +8132,8 @@ import {
       const offset = powderState.sandOffset;
       powderElements.sandfallFormula.textContent =
         offset > 0
-          ? `\\( \\glow{\\Psi(g)} = 2.7\\, \\sin(t) + ${formatDecimal(offset, 1)} \\)`
-          : '\\( \\glow{\\Psi(g)} = 2.7\\, \\sin(t) \\)';
+          ? `\\( \\Psi(g) = 2.7\\, \\sin(t) + ${formatDecimal(offset, 1)} \\)`
+          : '\\( \\Psi(g) = 2.7\\, \\sin(t) \\)';
       renderMathElement(powderElements.sandfallFormula);
     }
 

--- a/index.html
+++ b/index.html
@@ -22,9 +22,6 @@
             ['\\[', '\\]'],
           ],
           packages: { '[+]': ['color', 'html'] },
-          macros: {
-            glow: ['\\class{formula-glow}{\\color{#f9e27d}{#1}}', 1],
-          },
         },
         options: {
           renderActions: {
@@ -315,7 +312,7 @@
                 <h3>ζ zeta tower</h3>
               </header>
               <div class="formula-block">
-                <p class="formula-line">\( \glow{\zeta} = \sum_{n = 1}^{N} n^{-s} \)</p>
+                <p class="formula-line">\( \zeta = \sum_{n = 1}^{N} n^{-s} \)</p>
                 <ul class="formula-definition">
                   <li>N → partial sum length scales with total glyph towers</li>
                   <li>s → 1 + ω<sub>progress</sub>/10 tunes harmonic focus</li>
@@ -999,7 +996,7 @@
               <h3>Sandfall</h3>
               <p>
                 Grains per tick:
-                <code id="powder-sandfall-formula">\( \glow{\Psi(g)} = 2.7\, \sin(t) \)</code>
+                <code id="powder-sandfall-formula">\( \Psi(g) = 2.7\, \sin(t) \)</code>
               </p>
               <p class="powder-footnote" id="powder-sandfall-note">
                 Crest is unstable—Motes drift off the board.


### PR DESCRIPTION
## Summary
- remove the custom MathJax glow macro that triggered illegal macro errors
- update static and dynamic formulas to display without the glow wrapper

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fa8caeb6c0832ab76c5564ba8cd70e