### PR TITLE
Update mote tab reference copy and remove towers heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,7 +190,6 @@
           aria-labelledby="tab-towers"
           hidden
         >
-          <header class="panel-header">Towers &amp; Formulae</header>
           <div class="panel-grid">
             <article class="card" data-tower-id="alpha">
               <header class="tower-header">
@@ -904,11 +903,6 @@
           hidden
         >
           <header class="panel-header">Mote Lab</header>
-          <p class="powder-intro">
-            Channel mote cascades to braid bonuses back into the tower core.
-            Each ritual manipulates flow rates, dune topology, or crystalline charge to
-            accelerate Σ score, Δ energy, and λ flux.
-          </p>
           <section class="panel-grid powder-summary">
             <article class="card powder-overview">
               <h3>Flux Overview</h3>
@@ -989,6 +983,44 @@
                 Captured crest: 0.0% full · dune height h = 1.00 · largest grain —.
               </p>
             </article>
+          </section>
+          <section class="card powder-reference" aria-label="Flux overview reference">
+            <h3>Flux Overview</h3>
+            <p>
+              Total Multiplier<br />
+              ×1.22<br />
+              Sandfall Bonus<br />
+              +18.3%<br />
+              Dune Channeling<br />
+              +4.00%<br />
+              Crystal Resonance<br />
+              +0.00%<br />
+              Mote Stockpile<br />
+              0.00 Motes
+            </p>
+            <h3>Sigil Ladder</h3>
+            <p>
+              Mote height illuminates etched glyphs. Each rung unlocks new research rites once the
+              total multiplier meets or exceeds its mark.
+            </p>
+            <ul class="powder-sigil-list">
+              <li>
+                <span class="sigil-name">Boundary Sigil</span>
+                <span class="sigil-note">Stabilize the sandfall to breach ×1.05 flow.</span>
+              </li>
+              <li>
+                <span class="sigil-name">Dune Crest Sigil</span>
+                <span class="sigil-note">Raise h to carve channels and reach ×1.15.</span>
+              </li>
+              <li>
+                <span class="sigil-name">Crystal Harmonic Sigil</span>
+                <span class="sigil-note">Store a full lattice of charges to strike ×1.35.</span>
+              </li>
+              <li>
+                <span class="sigil-name">Archive Sigil</span>
+                <span class="sigil-note">Sustain every ritual to engrave ×1.50 and beyond.</span>
+              </li>
+            </ul>
           </section>
 
           <div class="panel-grid powder-grid">


### PR DESCRIPTION
## Summary
- remove the mote lab introduction paragraph to match the latest copy
- add the requested flux overview and sigil ladder reference block beneath the motefall basin
- remove the "Towers & Formulae" header from the towers tab

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fa9205d930832a90c4ea53c30f565d