### PR TITLE
Fix codex button navigation and refine panel wheel scrolling

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -6242,8 +6242,23 @@ import {
           return;
         }
 
+        const deltaMode = typeof event.deltaMode === 'number' ? event.deltaMode : 0;
+        let deltaY = event.deltaY;
+
+        if (deltaMode === 1) {
+          const computed = window.getComputedStyle(panel);
+          const lineHeight = parseFloat(computed.lineHeight) || 16;
+          deltaY *= lineHeight;
+        } else if (deltaMode === 2) {
+          deltaY *= panel.clientHeight || window.innerHeight || 600;
+        }
+
+        if (!deltaY) {
+          return;
+        }
+
         const previous = panel.scrollTop;
-        panel.scrollTop += event.deltaY;
+        panel.scrollTop += deltaY;
         if (panel.scrollTop !== previous) {
           event.preventDefault();
         }
@@ -7284,11 +7299,26 @@ import {
         if (!codexSection) {
           return;
         }
-        try {
-          codexSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        } catch (error) {
-          codexSection.scrollIntoView(true);
+
+        const codexPanel = codexSection.closest('.panel');
+        if (codexPanel) {
+          const panelRect = codexPanel.getBoundingClientRect();
+          const sectionRect = codexSection.getBoundingClientRect();
+          const targetOffset = sectionRect.top - panelRect.top + codexPanel.scrollTop;
+          const scrollOptions = { top: Math.max(0, targetOffset - 16), behavior: 'smooth' };
+          try {
+            codexPanel.scrollTo(scrollOptions);
+          } catch (error) {
+            codexPanel.scrollTop = scrollOptions.top;
+          }
+        } else {
+          try {
+            codexSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          } catch (error) {
+            codexSection.scrollIntoView(true);
+          }
         }
+
         if (typeof codexSection.focus === 'function') {
           try {
             codexSection.focus({ preventScroll: true });


### PR DESCRIPTION
## Summary
- ensure the "Open Codex" action always scrolls the options panel to the codex section before focusing it
- adjust the panel scroll helper to translate wheel delta modes into pixels so mouse wheel scrolling feels consistent

## Testing
- Not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68fa93080b70832a832a9001e2e06dfd