### PR TITLE
Render interactive level previews

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -2018,6 +2018,13 @@ body.color-scheme-chromatic::before {
   filter: drop-shadow(0 12px 28px rgba(0, 0, 0, 0.45));
 }
 
+.overlay-preview__canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+  filter: drop-shadow(0 12px 28px rgba(0, 0, 0, 0.45));
+}
+
 .overlay-preview__empty {
   margin: 0;
   text-align: center;


### PR DESCRIPTION
## Summary
- add a preview-only mode to `SimplePlayfield` so the combat renderer can be reused inside dialogs
- swap the level overlay preview to instantiate a temporary playfield canvas for interactive levels while keeping the SVG fallback
- style the overlay canvas to match the existing preview framing

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68fa971e8b08832a94df4b52c3bb692d