### PR TITLE
Hide locked tower cards by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,7 +191,7 @@
           hidden
         >
           <div class="panel-grid">
-            <article class="card" data-tower-id="alpha">
+            <article class="card" data-tower-id="alpha" aria-hidden="false">
               <header class="tower-header">
                 <span class="tower-tier">Tier I</span>
                 <h3>α alpha tower</h3>
@@ -213,7 +213,7 @@
                 Equip α
               </button>
             </article>
-            <article class="card" data-tower-id="beta">
+            <article class="card" data-tower-id="beta" hidden aria-hidden="true">
               <header class="tower-header">
                 <span class="tower-tier">Tier II</span>
                 <h3>β beta tower</h3>
@@ -239,7 +239,7 @@
                 Equip β
               </button>
             </article>
-            <article class="card" data-tower-id="gamma">
+            <article class="card" data-tower-id="gamma" hidden aria-hidden="true">
               <header class="tower-header">
                 <span class="tower-tier">Tier III</span>
                 <h3>γ gamma tower</h3>
@@ -261,7 +261,7 @@
                 Equip γ
               </button>
             </article>
-            <article class="card" data-tower-id="delta">
+            <article class="card" data-tower-id="delta" hidden aria-hidden="true">
               <header class="tower-header">
                 <span class="tower-tier">Tier IV</span>
                 <h3>δ delta tower</h3>
@@ -283,7 +283,7 @@
                 Equip δ
               </button>
             </article>
-            <article class="card" data-tower-id="epsilon">
+            <article class="card" data-tower-id="epsilon" hidden aria-hidden="true">
               <header class="tower-header">
                 <span class="tower-tier">Tier V</span>
                 <h3>ε epsilon tower</h3>
@@ -305,7 +305,7 @@
                 Equip ε
               </button>
             </article>
-            <article class="card" data-tower-id="zeta">
+            <article class="card" data-tower-id="zeta" hidden aria-hidden="true">
               <header class="tower-header">
                 <span class="tower-tier">Tier VI</span>
                 <h3>ζ zeta tower</h3>
@@ -327,7 +327,7 @@
                 Equip ζ
               </button>
             </article>
-            <article class="card" data-tower-id="eta">
+            <article class="card" data-tower-id="eta" hidden aria-hidden="true">
               <header class="tower-header">
                 <span class="tower-tier">Tier VII</span>
                 <h3>η eta tower</h3>
@@ -349,7 +349,7 @@
                 Equip η
               </button>
             </article>
-            <article class="card" data-tower-id="theta">
+            <article class="card" data-tower-id="theta" hidden aria-hidden="true">
               <header class="tower-header">
                 <span class="tower-tier">Tier VIII</span>
                 <h3>θ theta tower</h3>
@@ -371,7 +371,7 @@
                 Equip θ
               </button>
             </article>
-            <article class="card" data-tower-id="iota">
+            <article class="card" data-tower-id="iota" hidden aria-hidden="true">
               <header class="tower-header">
                 <span class="tower-tier">Tier IX</span>
                 <h3>ι iota tower</h3>
@@ -393,7 +393,7 @@
                 Equip ι
               </button>
             </article>
-            <article class="card" data-tower-id="kappa">
+            <article class="card" data-tower-id="kappa" hidden aria-hidden="true">
               <header class="tower-header">
                 <span class="tower-tier">Tier X</span>
                 <h3>κ kappa tower</h3>
@@ -415,7 +415,7 @@
                 Equip κ
               </button>
             </article>
-            <article class="card" data-tower-id="lambda">
+            <article class="card" data-tower-id="lambda" hidden aria-hidden="true">
               <header class="tower-header">
                 <span class="tower-tier">Tier XI</span>
                 <h3>λ lambda tower</h3>
@@ -437,7 +437,7 @@
                 Equip λ
               </button>
             </article>
-            <article class="card" data-tower-id="mu">
+            <article class="card" data-tower-id="mu" hidden aria-hidden="true">
               <header class="tower-header">
                 <span class="tower-tier">Tier XII</span>
                 <h3>μ mu tower</h3>
@@ -459,7 +459,7 @@
                 Equip μ
               </button>
             </article>
-            <article class="card" data-tower-id="nu">
+            <article class="card" data-tower-id="nu" hidden aria-hidden="true">
               <header class="tower-header">
                 <span class="tower-tier">Tier XIII</span>
                 <h3>ν nu tower</h3>
@@ -481,7 +481,7 @@
                 Equip ν
               </button>
             </article>
-            <article class="card" data-tower-id="xi">
+            <article class="card" data-tower-id="xi" hidden aria-hidden="true">
               <header class="tower-header">
                 <span class="tower-tier">Tier XIV</span>
                 <h3>ξ xi tower</h3>
@@ -503,7 +503,7 @@
                 Equip ξ
               </button>
             </article>
-            <article class="card" data-tower-id="omicron">
+            <article class="card" data-tower-id="omicron" hidden aria-hidden="true">
               <header class="tower-header">
                 <span class="tower-tier">Tier XV</span>
                 <h3>ο omicron tower</h3>
@@ -525,7 +525,7 @@
                 Equip ο
               </button>
             </article>
-            <article class="card" data-tower-id="pi">
+            <article class="card" data-tower-id="pi" hidden aria-hidden="true">
               <header class="tower-header">
                 <span class="tower-tier">Tier XVI</span>
                 <h3>π pi tower</h3>
@@ -547,7 +547,7 @@
                 Equip π
               </button>
             </article>
-            <article class="card" data-tower-id="rho">
+            <article class="card" data-tower-id="rho" hidden aria-hidden="true">
               <header class="tower-header">
                 <span class="tower-tier">Tier XVII</span>
                 <h3>ρ rho tower</h3>
@@ -569,7 +569,7 @@
                 Equip ρ
               </button>
             </article>
-            <article class="card" data-tower-id="sigma">
+            <article class="card" data-tower-id="sigma" hidden aria-hidden="true">
               <header class="tower-header">
                 <span class="tower-tier">Tier XVIII</span>
                 <h3>σ sigma tower</h3>
@@ -591,7 +591,7 @@
                 Equip σ
               </button>
             </article>
-            <article class="card" data-tower-id="tau">
+            <article class="card" data-tower-id="tau" hidden aria-hidden="true">
               <header class="tower-header">
                 <span class="tower-tier">Tier XIX</span>
                 <h3>τ tau tower</h3>
@@ -613,7 +613,7 @@
                 Equip τ
               </button>
             </article>
-            <article class="card" data-tower-id="upsilon">
+            <article class="card" data-tower-id="upsilon" hidden aria-hidden="true">
               <header class="tower-header">
                 <span class="tower-tier">Tier XX</span>
                 <h3>υ upsilon tower</h3>
@@ -635,7 +635,7 @@
                 Equip υ
               </button>
             </article>
-            <article class="card" data-tower-id="phi">
+            <article class="card" data-tower-id="phi" hidden aria-hidden="true">
               <header class="tower-header">
                 <span class="tower-tier">Tier XXI</span>
                 <h3>φ phi tower</h3>
@@ -657,7 +657,7 @@
                 Equip φ
               </button>
             </article>
-            <article class="card" data-tower-id="chi">
+            <article class="card" data-tower-id="chi" hidden aria-hidden="true">
               <header class="tower-header">
                 <span class="tower-tier">Tier XXII</span>
                 <h3>χ chi tower</h3>
@@ -679,7 +679,7 @@
                 Equip χ
               </button>
             </article>
-            <article class="card" data-tower-id="psi">
+            <article class="card" data-tower-id="psi" hidden aria-hidden="true">
               <header class="tower-header">
                 <span class="tower-tier">Tier XXIII</span>
                 <h3>ψ psi tower</h3>
@@ -701,7 +701,7 @@
                 Equip ψ
               </button>
             </article>
-            <article class="card" data-tower-id="omega">
+            <article class="card" data-tower-id="omega" hidden aria-hidden="true">
               <header class="tower-header">
                 <span class="tower-tier">Tier XXIV</span>
                 <h3>Ω omega tower</h3>
@@ -725,7 +725,7 @@
               </button>
             </article>
 
-            <article class="card" data-tower-id="aleph-null">
+            <article class="card" data-tower-id="aleph-null" hidden aria-hidden="true">
               <header class="tower-header">
                 <span class="tower-tier">Tier XXV</span>
                 <h3>ℵ₀ aleph-null tower</h3>
@@ -748,7 +748,7 @@
               </button>
             </article>
 
-            <article class="card" data-tower-id="aleph-one">
+            <article class="card" data-tower-id="aleph-one" hidden aria-hidden="true">
               <header class="tower-header">
                 <span class="tower-tier">Tier XXVI</span>
                 <h3>ℵ₁ aleph-one tower</h3>
@@ -771,7 +771,7 @@
               </button>
             </article>
 
-            <article class="card" data-tower-id="aleph-two">
+            <article class="card" data-tower-id="aleph-two" hidden aria-hidden="true">
               <header class="tower-header">
                 <span class="tower-tier">Tier XXVII</span>
                 <h3>ℵ₂ aleph-two tower</h3>
@@ -794,7 +794,7 @@
               </button>
             </article>
 
-            <article class="card" data-tower-id="aleph-three">
+            <article class="card" data-tower-id="aleph-three" hidden aria-hidden="true">
               <header class="tower-header">
                 <span class="tower-tier">Tier XXVIII</span>
                 <h3>ℵ₃ aleph-three tower</h3>
@@ -817,7 +817,7 @@
               </button>
             </article>
 
-            <article class="card" data-tower-id="aleph-four">
+            <article class="card" data-tower-id="aleph-four" hidden aria-hidden="true">
               <header class="tower-header">
                 <span class="tower-tier">Tier XXIX</span>
                 <h3>ℵ₄ aleph-four tower</h3>
@@ -840,7 +840,7 @@
               </button>
             </article>
 
-            <article class="card" data-tower-id="aleph-five">
+            <article class="card" data-tower-id="aleph-five" hidden aria-hidden="true">
               <header class="tower-header">
                 <span class="tower-tier">Tier XXX</span>
                 <h3>ℵ₅ aleph-five tower</h3>


### PR DESCRIPTION
## Summary
- mark every tower card other than alpha as hidden/aria-hidden in the Towers panel markup
- ensure freshly loaded pages only show the alpha tower until other lattices are unlocked by play

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68faeeb53d2c832a88bc2988ec5222e0