### PR TITLE
Enhance idle overlay transitions and prompt

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -209,8 +209,19 @@ body.color-scheme-chromatic::before {
   font-size: clamp(1.2rem, 3vw, 2.2rem);
 }
 
-.offline-overlay__button {
-  min-width: 220px;
+.offline-overlay__prompt {
+  margin: 0;
+  font-size: clamp(1rem, 2.8vw, 1.5rem);
+  font-style: italic;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.82);
+  text-shadow: 0 0 18px rgba(255, 255, 255, 0.4), 0 0 32px rgba(255, 255, 255, 0.24);
+  opacity: 0;
+  transition: opacity 600ms ease;
+}
+
+.offline-overlay__prompt--visible {
+  opacity: 1;
 }
 
 .panel {

--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
       role="dialog"
       aria-modal="true"
       aria-hidden="true"
+      tabindex="-1"
       hidden
     >
       <div class="offline-overlay__content">
@@ -50,9 +51,9 @@
           <span class="offline-symbol">=</span>
           <span class="offline-number" id="offline-total">0</span>
         </div>
-        <button class="action-button offline-overlay__button" type="button" id="offline-continue" hidden>
-          Resume Defense
-        </button>
+        <p class="offline-overlay__prompt" id="offline-prompt" aria-live="polite">
+          <em>Press anywhere to continue.</em>
+        </p>
       </div>
     </div>
     <div class="app-shell">


### PR DESCRIPTION
## Summary
- replace the idle overlay button with an italic prompt that appears after inactivity
- fade the offline overlay out on dismissal and restore focus after the animation
- add keyboard and pointer handling so tapping or pressing a key dismisses the overlay smoothly

## Testing
- Not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68fafa387578832abbd0a90617347923