### PR TITLE
Add developer mote tower developer drop

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1743,6 +1743,14 @@ body.color-scheme-chromatic::before {
   border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
+.tower-utility-note {
+  margin: 16px 0 12px;
+  font-size: 0.9rem;
+  line-height: 1.45;
+  text-align: center;
+  color: var(--muted);
+}
+
 
 .formula-line {
   margin: 0;

--- a/index.html
+++ b/index.html
@@ -864,6 +864,23 @@
               </button>
             </article>
 
+            <article class="card developer-card" id="developer-mote-tower" hidden aria-hidden="true">
+              <header class="tower-header">
+                <span class="tower-tier">Developer Utility</span>
+                <h3>Σ mote tower</h3>
+              </header>
+              <div class="formula-block">
+                <p class="formula-line">\( \Delta m = 1000 \)</p>
+                <p class="formula-line result">Instant mote drop for rapid flux calibration.</p>
+              </div>
+              <p class="tower-utility-note" id="developer-mote-tower-status" aria-live="polite">
+                Developer mote tower ready—click to release +1,000 motes.
+              </p>
+              <button class="tower-equip-button" type="button" id="developer-mote-tower-button">
+                Release +1,000 motes
+              </button>
+            </article>
+
             <article class="card" id="merging-logic-card" hidden aria-hidden="true">
               <header class="tower-header">
                 <span class="tower-tier">Convergence</span>


### PR DESCRIPTION
## Summary
- add a developer-only mote tower card that becomes available when developer mode is enabled
- wire the mote tower activation to drop 1,000 motes, refresh powder displays, and log the event
- add styling for the developer mote tower status note

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68fafd56281c832aad6d49a03df95d73