### PR TITLE
Add button ripple effect and sequential level set gating

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -43,6 +43,11 @@ body {
   justify-content: center;
 }
 
+button {
+  position: relative;
+  overflow: hidden;
+}
+
 body.color-scheme-aurora {
   background: radial-gradient(circle at 50% 0, rgba(139, 247, 255, 0.12), transparent 55%), var(--bg);
 }
@@ -829,19 +834,19 @@ body.color-scheme-chromatic::before {
   color: rgba(247, 247, 245, 0.75);
 }
 
-.level-card-ripple {
+.button-ripple {
   position: absolute;
   pointer-events: none;
   border: 2px solid var(--accent);
   border-radius: 999px;
   transform: translate(-50%, -50%) scale(0.18);
   opacity: 0.65;
-  animation: levelCardRipple 820ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  animation: buttonRipple 820ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
   mix-blend-mode: screen;
   z-index: 10;
 }
 
-@keyframes levelCardRipple {
+@keyframes buttonRipple {
   0% {
     transform: translate(-50%, -50%) scale(0.18);
     opacity: 0.65;


### PR DESCRIPTION
## Summary
- add a pointer-based ripple effect to every button and share the existing animation styling
- lock subsequent level sets until the prior set's non-secret levels are completed while still unlocking optional secrets

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fba630334c832aa150270f5ed2040b