### PR TITLE
Add codex options button and audio volume controls

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -956,6 +956,10 @@ body.color-scheme-chromatic::before {
   padding: 4px 0 2px;
 }
 
+.codex-controls .action-button {
+  align-self: flex-start;
+}
+
 .developer-mode-toggle {
   display: flex;
   align-items: center;
@@ -1313,6 +1317,71 @@ body.color-scheme-chromatic::before {
   margin: 0;
   font-size: 0.95rem;
   color: var(--muted);
+}
+
+.slider-group {
+  display: grid;
+  gap: 14px;
+}
+
+.slider-row {
+  display: grid;
+  gap: 8px;
+}
+
+.slider-row-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.slider-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(247, 247, 245, 0.7);
+}
+
+.slider-value {
+  font-family: "Space Mono", monospace;
+  font-size: 0.85rem;
+  color: var(--accent);
+}
+
+.slider-input {
+  appearance: none;
+  width: 100%;
+  height: 4px;
+  border-radius: 999px;
+  background: rgba(247, 247, 245, 0.18);
+  cursor: pointer;
+  accent-color: var(--accent);
+}
+
+.slider-input::-webkit-slider-thumb {
+  appearance: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 8px rgba(139, 247, 255, 0.5);
+  border: none;
+}
+
+.slider-input::-moz-range-thumb {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 8px rgba(139, 247, 255, 0.5);
+  border: none;
+}
+
+.slider-input::-moz-range-track {
+  height: 4px;
+  border-radius: 999px;
+  background: rgba(247, 247, 245, 0.18);
 }
 
 .powder-footnote {

--- a/index.html
+++ b/index.html
@@ -1162,10 +1162,43 @@
         >
           <header class="panel-header">Options &amp; Codex</header>
           <div class="panel-grid">
-            <article class="card">
-              <h3>Sound</h3>
+            <article class="card" id="sound-card">
+              <h3 id="sound-card-title">Sound</h3>
               <p>Adjust harmonic resonance levels.</p>
-              <button class="action-button ghost" type="button">Tune</button>
+              <div class="slider-group" role="group" aria-labelledby="sound-card-title">
+                <div class="slider-row">
+                  <div class="slider-row-header">
+                    <label class="slider-label" for="music-volume">Music</label>
+                    <span class="slider-value" id="music-volume-value">60%</span>
+                  </div>
+                  <input
+                    class="slider-input"
+                    type="range"
+                    id="music-volume"
+                    min="0"
+                    max="100"
+                    step="1"
+                    value="60"
+                    aria-label="Music volume"
+                  />
+                </div>
+                <div class="slider-row">
+                  <div class="slider-row-header">
+                    <label class="slider-label" for="sfx-volume">Sound Effects</label>
+                    <span class="slider-value" id="sfx-volume-value">85%</span>
+                  </div>
+                  <input
+                    class="slider-input"
+                    type="range"
+                    id="sfx-volume"
+                    min="0"
+                    max="100"
+                    step="1"
+                    value="85"
+                    aria-label="Sound effects volume"
+                  />
+                </div>
+              </div>
             </article>
             <article class="card">
               <h3>Visual Theme</h3>
@@ -1217,6 +1250,9 @@
           <section class="enemy-codex" id="enemy-codex-section" aria-live="polite" tabindex="-1">
             <header class="subsection-title">Enemy Codex</header>
             <div class="codex-controls">
+              <button class="action-button ghost" type="button" id="codex-options-button">
+                Open Options
+              </button>
               <label class="developer-mode-toggle" for="codex-developer-mode">
                 <input type="checkbox" id="codex-developer-mode" />
                 Developer Mode — unlock all towers, levels, and entries


### PR DESCRIPTION
## Summary
- replace the codex sound card with music and SFX volume sliders that persist via local storage
- wire the sliders to live-update the audio manager and expose setters for music and effect levels
- add an "Open Options" shortcut inside the codex controls and smooth scrolling helpers for the panel

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68fbad42b3b8832aa3bd073947bbfbd1