### PR TITLE
Center mote wall markers and add field notes overlay

### DIFF
--- a/assets/images/field-notes-mentor.svg
+++ b/assets/images/field-notes-mentor.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 220" aria-labelledby="title desc" role="img">
+  <title id="title">Archivist Thero Illustration</title>
+  <desc id="desc">Stylized scholar in flowing robes holding a codex.</desc>
+  <defs>
+    <radialGradient id="robe-glow" cx="50%" cy="40%" r="70%">
+      <stop offset="0%" stop-color="#9fb7ff" stop-opacity="0.55" />
+      <stop offset="45%" stop-color="#5164ff" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#060914" stop-opacity="0.05" />
+    </radialGradient>
+    <linearGradient id="robe-shade" x1="0%" x2="0%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#1a1f3a" />
+      <stop offset="70%" stop-color="#0c0f1f" />
+      <stop offset="100%" stop-color="#090b18" />
+    </linearGradient>
+    <linearGradient id="codex-light" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ffe7b0" stop-opacity="0.9" />
+      <stop offset="100%" stop-color="#f5c173" stop-opacity="0.85" />
+    </linearGradient>
+  </defs>
+  <g fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <ellipse cx="80" cy="210" rx="56" ry="9" fill="rgba(16, 22, 46, 0.85)" />
+    <circle cx="80" cy="48" r="30" fill="#161b2f" stroke="#5c6bff" stroke-width="2" />
+    <path
+      d="M56 106c-10 28-16 66-16 94 18 6 36 8 56 8s38-2 56-8c0-28-6-66-16-94"
+      fill="url(#robe-shade)"
+      stroke="rgba(120, 150, 255, 0.4)"
+      stroke-width="2"
+    />
+    <path
+      d="M80 66c-12 20-32 30-36 44 10 10 22 18 36 18s26-8 36-18c-4-14-24-24-36-44z"
+      fill="url(#robe-glow)"
+      stroke="rgba(180, 200, 255, 0.45)"
+      stroke-width="1.5"
+    />
+    <path
+      d="M62 122l34 18"
+      stroke="rgba(255, 227, 168, 0.8)"
+      stroke-width="6"
+    />
+    <path
+      d="M60 118l36 20 6-10-36-20-6 10z"
+      fill="url(#codex-light)"
+      stroke="rgba(60, 40, 20, 0.65)"
+      stroke-width="1.5"
+    />
+    <path
+      d="M74 52c6-4 12-4 12 0"
+      stroke="rgba(230, 235, 255, 0.65)"
+      stroke-width="3"
+    />
+    <circle cx="68" cy="46" r="4" fill="#d4dbff" />
+    <circle cx="92" cy="46" r="4" fill="#d4dbff" />
+    <path d="M72 60c6 6 10 6 16 0" stroke="#d4dbff" stroke-width="2" />
+    <path
+      d="M48 96c8-18 20-32 32-42 12 10 24 24 32 42"
+      stroke="rgba(120, 150, 255, 0.45)"
+      stroke-width="3"
+    />
+    <path
+      d="M46 128c16 12 40 20 68 0"
+      stroke="rgba(90, 130, 255, 0.45)"
+      stroke-width="2"
+    />
+  </g>
+</svg>

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1648,9 +1648,10 @@ body.color-scheme-chromatic::before {
 .powder-wall-marker::after {
   content: attr(data-height);
   position: absolute;
-  top: -1.45rem;
-  right: -2.4rem;
-  padding: 2px 8px;
+  top: -1.75rem;
+  left: 50%;
+  transform: translate(-50%, 0);
+  padding: 2px 10px;
   border-radius: 12px;
   font-family: 'Space Mono', monospace;
   font-size: 0.7rem;
@@ -1658,6 +1659,7 @@ body.color-scheme-chromatic::before {
   color: rgba(255, 196, 128, 0.92);
   background: rgba(14, 16, 24, 0.82);
   box-shadow: 0 0 8px rgba(255, 196, 128, 0.38);
+  white-space: nowrap;
 }
 
 .powder-crest-marker {
@@ -2020,6 +2022,84 @@ body.color-scheme-chromatic::before {
 .overlay-close:focus-visible {
   outline: 2px solid var(--path-blue);
   outline-offset: 2px;
+}
+
+.field-notes-overlay .overlay-panel {
+  max-width: min(90vw, 520px);
+  width: min(90vw, 520px);
+  text-align: left;
+  gap: 20px;
+  padding: 42px 36px 34px;
+  background:
+    radial-gradient(circle at 22% 12%, rgba(130, 168, 255, 0.18), rgba(130, 168, 255, 0) 55%),
+    radial-gradient(circle at 78% 18%, rgba(255, 196, 148, 0.16), rgba(255, 196, 148, 0) 58%),
+    rgba(12, 12, 20, 0.88);
+}
+
+.field-notes-overlay .overlay-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  color: rgba(200, 210, 255, 0.85);
+}
+
+.field-notes-overlay .overlay-title {
+  font-size: clamp(1.4rem, 2vw + 0.8rem, 1.75rem);
+  margin: 0;
+}
+
+.field-notes-panel {
+  position: relative;
+}
+
+.field-notes-figure {
+  margin: 0;
+  display: grid;
+  gap: 10px;
+  justify-items: center;
+}
+
+.field-notes-figure img {
+  width: min(38vw, 180px);
+  filter: drop-shadow(0 18px 28px rgba(0, 0, 0, 0.55)) drop-shadow(0 0 32px rgba(120, 180, 255, 0.25));
+}
+
+.field-notes-figure figcaption {
+  font-family: 'Cormorant Garamond', 'Times New Roman', serif;
+  font-size: 1rem;
+  color: rgba(255, 228, 180, 0.85);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.field-notes-copy {
+  display: grid;
+  gap: 12px;
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.field-notes-copy strong {
+  color: rgba(255, 228, 160, 0.95);
+}
+
+.field-notes-list {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 8px;
+}
+
+.field-notes-list li::marker {
+  color: rgba(120, 180, 255, 0.9);
+}
+
+.field-notes-overlay .overlay-close {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.field-notes-overlay .overlay-close:hover,
+.field-notes-overlay .overlay-close:focus-visible {
+  color: rgba(255, 228, 160, 0.95);
 }
 
 .upgrade-overlay .overlay-panel {

--- a/index.html
+++ b/index.html
@@ -1208,10 +1208,10 @@
               </button>
             </article>
             <article class="card">
-              <h3>Codex</h3>
-              <p>Review mathematical lore and formulae.</p>
+              <h3>Field Notes</h3>
+              <p>Consult the archivist for a briefing on the current storyline.</p>
               <button class="action-button ghost" type="button" id="open-codex-button">
-                Open Codex
+                Field Notes
               </button>
             </article>
           </div>
@@ -1370,6 +1370,49 @@
         <p class="overlay-instruction">Tap outside or press Esc to close.</p>
       </div>
     </div>
+    <div
+      class="level-overlay field-notes-overlay"
+      id="field-notes-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-hidden="true"
+      tabindex="-1"
+    >
+      <div class="overlay-panel field-notes-panel" role="document" aria-labelledby="field-notes-title">
+        <button class="overlay-close" type="button" id="field-notes-close" aria-label="Close field notes">×</button>
+        <figure class="field-notes-figure">
+          <img src="./assets/images/field-notes-mentor.svg" alt="Archivist Thero shares the latest codex dispatch." />
+          <figcaption>Archivist Thero</figcaption>
+        </figure>
+        <p class="overlay-label">Field Notes Dispatch</p>
+        <h2 class="overlay-title" id="field-notes-title">The Tower of Inspiration Briefing</h2>
+        <div class="field-notes-copy">
+          <p>
+            Welcome, Warden. I am Thero, archivist of the glyph lattice. Your arrival coincides with a surge of
+            <strong>mote turbulence</strong> washing against the tower's perimeter.
+          </p>
+          <p>
+            Our scouts report that rival scholars have animated rogue proofs. Each wave they summon is tuned to unravel the
+            equations binding our defenses. Hold these observations close:
+          </p>
+          <ul class="field-notes-list">
+            <li>The <strong>Scintilla Glyph</strong> at the summit regulates every mote current—lose it and the lattice collapses.</li>
+            <li>
+              <strong>Chronoglyph wards</strong> along the ramparts can bend time briefly. Use their cadence to reset your
+              ordinals and stagger enemy advances.
+            </li>
+            <li>
+              When a wave fractures, sift the motes it leaves behind. Their resonance seeds new towers faster than any quarry.
+            </li>
+          </ul>
+          <p>
+            Return once the next theorem is secured. I will inscribe your progress and prepare the following expedition. The
+            codex grows because of your vigilance.
+          </p>
+        </div>
+      </div>
+    </div>
+
     <div class="level-overlay" id="level-overlay" role="dialog" aria-modal="true" aria-hidden="true">
       <div class="overlay-panel">
         <p class="overlay-label" id="overlay-level"></p>


### PR DESCRIPTION
## Summary
- center the dune height markers on the mote wall so the labels remain visible
- rename the codex quick access button to "Field Notes" and display a lore overlay with an archivist illustration
- add styling and assets for the new field notes overlay to match the game's mathematical aesthetic

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fbbf71b500832a91943174b05f39ca