### PR TITLE
Add stub levels for Lemma through Axiom sets

### DIFF
--- a/assets/data/gameplayConfig.json
+++ b/assets/data/gameplayConfig.json
@@ -656,6 +656,166 @@
       "path": "Phase-shifted archipelago of calculus islands hidden beneath modular petals.",
       "focus": "Resource siphons and reversal elites stack together—prepare universal counters.",
       "example": "Secret Corollary: The boundary integral of concealed paths equals interior flux you never saw."
+    },
+    {
+      "set": "Lemma",
+      "id": "Lemma - 11",
+      "title": "Abel Cascade",
+      "path": "Waterfall descent using commutator switches; river nodes invert projectile order, testing burst versus beam timing.",
+      "focus": "Stub focus – finalize lemma-tier enemy pacing once behaviors are scripted.",
+      "example": "Abel summation lemma: bounded partial sums paired with monotone factors keep the transformed series convergent."
+    },
+    {
+      "set": "Lemma",
+      "id": "Lemma - 12",
+      "title": "Noether Weave",
+      "path": "Symmetry-rich ringroads whose portals preserve DPS sums; enemies trade positions when struck by support glyphs.",
+      "focus": "Stub focus – finalize lemma-tier enemy pacing once behaviors are scripted.",
+      "example": "Noether's theorem ties continuous symmetries to conserved quantities in dynamical systems."
+    },
+    {
+      "set": "Lemma",
+      "id": "Lemma - 13",
+      "title": "Erdős Drift",
+      "path": "Random-graph tramlines that shuffle lane adjacency; probabilistic smugglers reroute toward the longest surviving enemy.",
+      "focus": "Stub focus – finalize lemma-tier enemy pacing once behaviors are scripted.",
+      "example": "Erdős–Rényi random graphs undergo a giant-component phase transition near edge probability p = 1/n."
+    },
+    {
+      "set": "Lemma",
+      "id": "Lemma - 14",
+      "title": "Möbius Rind",
+      "path": "Inside-out corkscrew track; sign-flip sentries grant negative armor that amplifies epsilon burn damage.",
+      "focus": "Stub focus – finalize lemma-tier enemy pacing once behaviors are scripted.",
+      "example": "Möbius inversion retrieves arithmetic functions from their summatory transforms."
+    },
+    {
+      "set": "Lemma",
+      "id": "Lemma - 15",
+      "title": "Ramanujan Bloom",
+      "path": "Lotus of nested circles keyed to modular forms; resonance echoes cause defeated foes to spawn low-HP harmonic clones.",
+      "focus": "Stub focus – finalize lemma-tier enemy pacing once behaviors are scripted.",
+      "example": "Ramanujan's mock theta functions encode hidden q-series symmetries across modular sectors."
+    },
+    {
+      "set": "Proof",
+      "id": "Proof - 16",
+      "title": "Hilbert Fold",
+      "path": "Space-filling fractal corridor; dimensional walkers slip through walls unless slowed by delta caserns.",
+      "focus": "Stub focus – stage goals will follow once proof-tier hazards are tuned.",
+      "example": "Hilbert's space-filling curve maps the unit interval continuously onto the unit square."
+    },
+    {
+      "set": "Proof",
+      "id": "Proof - 17",
+      "title": "Gödel Labyrinth",
+      "path": "Self-referencing maze with locked axioms; paradox custodians revive unless struck by three distinct tower classes.",
+      "focus": "Stub focus – stage goals will follow once proof-tier hazards are tuned.",
+      "example": "Gödel's incompleteness theorem shows consistent formal systems cannot prove every arithmetic truth."
+    },
+    {
+      "set": "Proof",
+      "id": "Proof - 18",
+      "title": "Turing Spire",
+      "path": "Vertical tape ascent with binary toggles; automaton foes flip between vulnerable and immune states based on attack parity.",
+      "focus": "Stub focus – stage goals will follow once proof-tier hazards are tuned.",
+      "example": "Turing proved no algorithm decides the halting of arbitrary programs."
+    },
+    {
+      "set": "Proof",
+      "id": "Proof - 19",
+      "title": "Cantor Verge",
+      "path": "Fragmented coastline path removing middle thirds; lacuna spirits leap gaps, forcing chained knockback to corral them.",
+      "focus": "Stub focus – stage goals will follow once proof-tier hazards are tuned.",
+      "example": "Cantor's middle-third set is uncountable despite having zero Lebesgue measure."
+    },
+    {
+      "set": "Proof",
+      "id": "Proof - 20",
+      "title": "Jordan Curve Bastion",
+      "path": "Contour fortress wrapped around the core; enclosure judges stun towers that let enemies slip past twice.",
+      "focus": "Stub focus – stage goals will follow once proof-tier hazards are tuned.",
+      "example": "Jordan curve theorem: every simple closed plane curve separates the plane into interior and exterior regions."
+    },
+    {
+      "set": "Theorem",
+      "id": "Theorem - 21",
+      "title": "Gauss Orchard",
+      "path": "Hexagonal orchard aligned to quadratic residues; orchard keepers gain bonus armor on perfect squares.",
+      "focus": "Stub focus – theorem-tier balancing will be added alongside enemy rosters.",
+      "example": "Gauss circle problem counts lattice points beneath x² + y² ≤ r² with error on the order of r."
+    },
+    {
+      "set": "Theorem",
+      "id": "Theorem - 22",
+      "title": "Fourier Aurora",
+      "path": "Polar halo with wavelength lanes; harmonics build up unless projectile types stay varied.",
+      "focus": "Stub focus – theorem-tier balancing will be added alongside enemy rosters.",
+      "example": "Fourier series decompose periodic signals into sums of sine and cosine harmonics."
+    },
+    {
+      "set": "Theorem",
+      "id": "Theorem - 23",
+      "title": "Nash Spiral",
+      "path": "Competitive spiral with alternating payoff nodes; adversary agents buff themselves when lanes sit undefended.",
+      "focus": "Stub focus – theorem-tier balancing will be added alongside enemy rosters.",
+      "example": "Nash equilibrium marks strategy profiles where no player benefits from unilateral deviation."
+    },
+    {
+      "set": "Theorem",
+      "id": "Theorem - 24",
+      "title": "Riesz Parallax",
+      "path": "Dual parabolic arches sharing intercepts; projection ghosts mirror the lead enemy unless frozen in tandem.",
+      "focus": "Stub focus – theorem-tier balancing will be added alongside enemy rosters.",
+      "example": "Riesz representation theorem identifies continuous linear functionals with measures."
+    },
+    {
+      "set": "Theorem",
+      "id": "Theorem - 25",
+      "title": "Poincaré Bloom",
+      "path": "Hypersphere cross-section with teleport seams; flarebitters detonate when they contact the seams.",
+      "focus": "Stub focus – theorem-tier balancing will be added alongside enemy rosters.",
+      "example": "Poincaré conjecture states that any simply connected closed 3-manifold is homeomorphic to the 3-sphere."
+    },
+    {
+      "set": "Axiom",
+      "id": "Axiom - 26",
+      "title": "Zorn Horizon",
+      "path": "Infinite-descending plateau where gravity reverses; maximal chain wardens swell until omega strikes topple them.",
+      "focus": "Stub focus – axiom-tier encounters will be scripted once late-game math is locked.",
+      "example": "Zorn's Lemma ensures partially ordered sets with chain upper bounds contain maximal elements."
+    },
+    {
+      "set": "Axiom",
+      "id": "Axiom - 27",
+      "title": "Löwenheim Gate",
+      "path": "Quantifier gates that rescale enemy size; shrinking glyphs slip through gaps unless sigma snares hold them.",
+      "focus": "Stub focus – axiom-tier encounters will be scripted once late-game math is locked.",
+      "example": "Löwenheim–Skolem theorem guarantees countable models for any first-order theory with an infinite model."
+    },
+    {
+      "set": "Axiom",
+      "id": "Axiom - 28",
+      "title": "Grothendieck Loom",
+      "path": "Category lattice weaving incoming paths; functor heralds copy the highest-tier tower stats once per wave.",
+      "focus": "Stub focus – axiom-tier encounters will be scripted once late-game math is locked.",
+      "example": "Grothendieck topoi generalize spaces via sheaves and geometric morphisms."
+    },
+    {
+      "set": "Axiom",
+      "id": "Axiom - 29",
+      "title": "Tarski Reflection",
+      "path": "Mirror arena with delayed reflections; spectral doubles retrace steps with inverted resistances.",
+      "focus": "Stub focus – axiom-tier encounters will be scripted once late-game math is locked.",
+      "example": "Tarski's fixed point theorem ensures monotone functions on complete lattices admit fixed points."
+    },
+    {
+      "set": "Axiom",
+      "id": "Axiom - 30",
+      "title": "Peano Genesis",
+      "path": "Final spiral built from recursive integers; successor titans rebuild lost segments unless powderfall seals flare.",
+      "focus": "Stub focus – axiom-tier encounters will be scripted once late-game math is locked.",
+      "example": "Peano axioms characterize the natural numbers through zero and a successor function."
     }
   ],
   "levels": [
@@ -2167,6 +2327,1246 @@
         {
           "x": 0.82,
           "y": 0.48
+        }
+      ]
+    },
+    {
+      "id": "Lemma - 11",
+      "displayName": "Abel Cascade",
+      "startThero": 55,
+      "theroCap": 1600,
+      "theroPerKill": 70,
+      "passiveTheroPerSecond": 34,
+      "lives": 100,
+      "waves": [
+        {
+          "label": "abel cascade placeholders",
+          "count": 6,
+          "interval": 1.5,
+          "hp": 200,
+          "speed": 0.11,
+          "reward": 24,
+          "color": "rgba(220, 220, 220, 0.6)",
+          "codexId": "etype"
+        }
+      ],
+      "rewardScore": 0,
+      "rewardFlux": 0,
+      "rewardThero": 0,
+      "rewardEnergy": 0,
+      "arcSpeed": 0.26,
+      "path": [
+        {
+          "x": 0.1,
+          "y": 0.92
+        },
+        {
+          "x": 0.24,
+          "y": 0.78
+        },
+        {
+          "x": 0.48,
+          "y": 0.52
+        },
+        {
+          "x": 0.72,
+          "y": 0.32
+        },
+        {
+          "x": 0.9,
+          "y": 0.12
+        }
+      ],
+      "autoAnchors": [
+        {
+          "x": 0.22,
+          "y": 0.82
+        },
+        {
+          "x": 0.5,
+          "y": 0.5
+        },
+        {
+          "x": 0.78,
+          "y": 0.26
+        }
+      ]
+    },
+    {
+      "id": "Lemma - 12",
+      "displayName": "Noether Weave",
+      "startThero": 55,
+      "theroCap": 1740,
+      "theroPerKill": 75,
+      "passiveTheroPerSecond": 34,
+      "lives": 100,
+      "waves": [
+        {
+          "label": "noether weave placeholders",
+          "count": 7,
+          "interval": 1.5,
+          "hp": 260,
+          "speed": 0.115,
+          "reward": 30,
+          "color": "rgba(220, 220, 220, 0.6)",
+          "codexId": "etype"
+        }
+      ],
+      "rewardScore": 0,
+      "rewardFlux": 0,
+      "rewardThero": 0,
+      "rewardEnergy": 0,
+      "arcSpeed": 0.268,
+      "path": [
+        {
+          "x": 0.1,
+          "y": 0.92
+        },
+        {
+          "x": 0.24,
+          "y": 0.78
+        },
+        {
+          "x": 0.48,
+          "y": 0.52
+        },
+        {
+          "x": 0.72,
+          "y": 0.32
+        },
+        {
+          "x": 0.9,
+          "y": 0.12
+        }
+      ],
+      "autoAnchors": [
+        {
+          "x": 0.22,
+          "y": 0.82
+        },
+        {
+          "x": 0.5,
+          "y": 0.5
+        },
+        {
+          "x": 0.78,
+          "y": 0.26
+        }
+      ]
+    },
+    {
+      "id": "Lemma - 13",
+      "displayName": "Erdős Drift",
+      "startThero": 55,
+      "theroCap": 1880,
+      "theroPerKill": 80,
+      "passiveTheroPerSecond": 34,
+      "lives": 100,
+      "waves": [
+        {
+          "label": "erdős drift placeholders",
+          "count": 8,
+          "interval": 1.5,
+          "hp": 320,
+          "speed": 0.12,
+          "reward": 36,
+          "color": "rgba(220, 220, 220, 0.6)",
+          "codexId": "etype"
+        }
+      ],
+      "rewardScore": 0,
+      "rewardFlux": 0,
+      "rewardThero": 0,
+      "rewardEnergy": 0,
+      "arcSpeed": 0.276,
+      "path": [
+        {
+          "x": 0.1,
+          "y": 0.92
+        },
+        {
+          "x": 0.24,
+          "y": 0.78
+        },
+        {
+          "x": 0.48,
+          "y": 0.52
+        },
+        {
+          "x": 0.72,
+          "y": 0.32
+        },
+        {
+          "x": 0.9,
+          "y": 0.12
+        }
+      ],
+      "autoAnchors": [
+        {
+          "x": 0.22,
+          "y": 0.82
+        },
+        {
+          "x": 0.5,
+          "y": 0.5
+        },
+        {
+          "x": 0.78,
+          "y": 0.26
+        }
+      ]
+    },
+    {
+      "id": "Lemma - 14",
+      "displayName": "Möbius Rind",
+      "startThero": 55,
+      "theroCap": 2020,
+      "theroPerKill": 85,
+      "passiveTheroPerSecond": 34,
+      "lives": 100,
+      "waves": [
+        {
+          "label": "möbius rind placeholders",
+          "count": 9,
+          "interval": 1.5,
+          "hp": 380,
+          "speed": 0.125,
+          "reward": 42,
+          "color": "rgba(220, 220, 220, 0.6)",
+          "codexId": "etype"
+        }
+      ],
+      "rewardScore": 0,
+      "rewardFlux": 0,
+      "rewardThero": 0,
+      "rewardEnergy": 0,
+      "arcSpeed": 0.284,
+      "path": [
+        {
+          "x": 0.1,
+          "y": 0.92
+        },
+        {
+          "x": 0.24,
+          "y": 0.78
+        },
+        {
+          "x": 0.48,
+          "y": 0.52
+        },
+        {
+          "x": 0.72,
+          "y": 0.32
+        },
+        {
+          "x": 0.9,
+          "y": 0.12
+        }
+      ],
+      "autoAnchors": [
+        {
+          "x": 0.22,
+          "y": 0.82
+        },
+        {
+          "x": 0.5,
+          "y": 0.5
+        },
+        {
+          "x": 0.78,
+          "y": 0.26
+        }
+      ]
+    },
+    {
+      "id": "Lemma - 15",
+      "displayName": "Ramanujan Bloom",
+      "startThero": 55,
+      "theroCap": 2160,
+      "theroPerKill": 90,
+      "passiveTheroPerSecond": 34,
+      "lives": 100,
+      "waves": [
+        {
+          "label": "ramanujan bloom placeholders",
+          "count": 10,
+          "interval": 1.5,
+          "hp": 440,
+          "speed": 0.13,
+          "reward": 48,
+          "color": "rgba(220, 220, 220, 0.6)",
+          "codexId": "etype"
+        }
+      ],
+      "rewardScore": 0,
+      "rewardFlux": 0,
+      "rewardThero": 0,
+      "rewardEnergy": 0,
+      "arcSpeed": 0.292,
+      "path": [
+        {
+          "x": 0.1,
+          "y": 0.92
+        },
+        {
+          "x": 0.24,
+          "y": 0.78
+        },
+        {
+          "x": 0.48,
+          "y": 0.52
+        },
+        {
+          "x": 0.72,
+          "y": 0.32
+        },
+        {
+          "x": 0.9,
+          "y": 0.12
+        }
+      ],
+      "autoAnchors": [
+        {
+          "x": 0.22,
+          "y": 0.82
+        },
+        {
+          "x": 0.5,
+          "y": 0.5
+        },
+        {
+          "x": 0.78,
+          "y": 0.26
+        }
+      ]
+    },
+    {
+      "id": "Proof - 16",
+      "displayName": "Hilbert Fold",
+      "startThero": 60,
+      "theroCap": 2300,
+      "theroPerKill": 95,
+      "passiveTheroPerSecond": 38,
+      "lives": 100,
+      "waves": [
+        {
+          "label": "hilbert fold placeholders",
+          "count": 11,
+          "interval": 1.5,
+          "hp": 500,
+          "speed": 0.135,
+          "reward": 54,
+          "color": "rgba(220, 220, 220, 0.6)",
+          "codexId": "etype"
+        }
+      ],
+      "rewardScore": 0,
+      "rewardFlux": 0,
+      "rewardThero": 0,
+      "rewardEnergy": 0,
+      "arcSpeed": 0.3,
+      "path": [
+        {
+          "x": 0.1,
+          "y": 0.92
+        },
+        {
+          "x": 0.24,
+          "y": 0.78
+        },
+        {
+          "x": 0.48,
+          "y": 0.52
+        },
+        {
+          "x": 0.72,
+          "y": 0.32
+        },
+        {
+          "x": 0.9,
+          "y": 0.12
+        }
+      ],
+      "autoAnchors": [
+        {
+          "x": 0.22,
+          "y": 0.82
+        },
+        {
+          "x": 0.5,
+          "y": 0.5
+        },
+        {
+          "x": 0.78,
+          "y": 0.26
+        }
+      ]
+    },
+    {
+      "id": "Proof - 17",
+      "displayName": "Gödel Labyrinth",
+      "startThero": 60,
+      "theroCap": 2440,
+      "theroPerKill": 100,
+      "passiveTheroPerSecond": 38,
+      "lives": 100,
+      "waves": [
+        {
+          "label": "gödel labyrinth placeholders",
+          "count": 12,
+          "interval": 1.5,
+          "hp": 560,
+          "speed": 0.14,
+          "reward": 60,
+          "color": "rgba(220, 220, 220, 0.6)",
+          "codexId": "etype"
+        }
+      ],
+      "rewardScore": 0,
+      "rewardFlux": 0,
+      "rewardThero": 0,
+      "rewardEnergy": 0,
+      "arcSpeed": 0.308,
+      "path": [
+        {
+          "x": 0.1,
+          "y": 0.92
+        },
+        {
+          "x": 0.24,
+          "y": 0.78
+        },
+        {
+          "x": 0.48,
+          "y": 0.52
+        },
+        {
+          "x": 0.72,
+          "y": 0.32
+        },
+        {
+          "x": 0.9,
+          "y": 0.12
+        }
+      ],
+      "autoAnchors": [
+        {
+          "x": 0.22,
+          "y": 0.82
+        },
+        {
+          "x": 0.5,
+          "y": 0.5
+        },
+        {
+          "x": 0.78,
+          "y": 0.26
+        }
+      ]
+    },
+    {
+      "id": "Proof - 18",
+      "displayName": "Turing Spire",
+      "startThero": 60,
+      "theroCap": 2580,
+      "theroPerKill": 105,
+      "passiveTheroPerSecond": 38,
+      "lives": 100,
+      "waves": [
+        {
+          "label": "turing spire placeholders",
+          "count": 13,
+          "interval": 1.5,
+          "hp": 620,
+          "speed": 0.145,
+          "reward": 66,
+          "color": "rgba(220, 220, 220, 0.6)",
+          "codexId": "etype"
+        }
+      ],
+      "rewardScore": 0,
+      "rewardFlux": 0,
+      "rewardThero": 0,
+      "rewardEnergy": 0,
+      "arcSpeed": 0.316,
+      "path": [
+        {
+          "x": 0.1,
+          "y": 0.92
+        },
+        {
+          "x": 0.24,
+          "y": 0.78
+        },
+        {
+          "x": 0.48,
+          "y": 0.52
+        },
+        {
+          "x": 0.72,
+          "y": 0.32
+        },
+        {
+          "x": 0.9,
+          "y": 0.12
+        }
+      ],
+      "autoAnchors": [
+        {
+          "x": 0.22,
+          "y": 0.82
+        },
+        {
+          "x": 0.5,
+          "y": 0.5
+        },
+        {
+          "x": 0.78,
+          "y": 0.26
+        }
+      ]
+    },
+    {
+      "id": "Proof - 19",
+      "displayName": "Cantor Verge",
+      "startThero": 60,
+      "theroCap": 2720,
+      "theroPerKill": 110,
+      "passiveTheroPerSecond": 38,
+      "lives": 100,
+      "waves": [
+        {
+          "label": "cantor verge placeholders",
+          "count": 14,
+          "interval": 1.5,
+          "hp": 680,
+          "speed": 0.15,
+          "reward": 72,
+          "color": "rgba(220, 220, 220, 0.6)",
+          "codexId": "etype"
+        }
+      ],
+      "rewardScore": 0,
+      "rewardFlux": 0,
+      "rewardThero": 0,
+      "rewardEnergy": 0,
+      "arcSpeed": 0.324,
+      "path": [
+        {
+          "x": 0.1,
+          "y": 0.92
+        },
+        {
+          "x": 0.24,
+          "y": 0.78
+        },
+        {
+          "x": 0.48,
+          "y": 0.52
+        },
+        {
+          "x": 0.72,
+          "y": 0.32
+        },
+        {
+          "x": 0.9,
+          "y": 0.12
+        }
+      ],
+      "autoAnchors": [
+        {
+          "x": 0.22,
+          "y": 0.82
+        },
+        {
+          "x": 0.5,
+          "y": 0.5
+        },
+        {
+          "x": 0.78,
+          "y": 0.26
+        }
+      ]
+    },
+    {
+      "id": "Proof - 20",
+      "displayName": "Jordan Curve Bastion",
+      "startThero": 60,
+      "theroCap": 2860,
+      "theroPerKill": 115,
+      "passiveTheroPerSecond": 38,
+      "lives": 100,
+      "waves": [
+        {
+          "label": "jordan curve bastion placeholders",
+          "count": 15,
+          "interval": 1.5,
+          "hp": 740,
+          "speed": 0.155,
+          "reward": 78,
+          "color": "rgba(220, 220, 220, 0.6)",
+          "codexId": "etype"
+        }
+      ],
+      "rewardScore": 0,
+      "rewardFlux": 0,
+      "rewardThero": 0,
+      "rewardEnergy": 0,
+      "arcSpeed": 0.332,
+      "path": [
+        {
+          "x": 0.1,
+          "y": 0.92
+        },
+        {
+          "x": 0.24,
+          "y": 0.78
+        },
+        {
+          "x": 0.48,
+          "y": 0.52
+        },
+        {
+          "x": 0.72,
+          "y": 0.32
+        },
+        {
+          "x": 0.9,
+          "y": 0.12
+        }
+      ],
+      "autoAnchors": [
+        {
+          "x": 0.22,
+          "y": 0.82
+        },
+        {
+          "x": 0.5,
+          "y": 0.5
+        },
+        {
+          "x": 0.78,
+          "y": 0.26
+        }
+      ]
+    },
+    {
+      "id": "Theorem - 21",
+      "displayName": "Gauss Orchard",
+      "startThero": 65,
+      "theroCap": 3000,
+      "theroPerKill": 120,
+      "passiveTheroPerSecond": 42,
+      "lives": 100,
+      "waves": [
+        {
+          "label": "gauss orchard placeholders",
+          "count": 16,
+          "interval": 1.5,
+          "hp": 800,
+          "speed": 0.16,
+          "reward": 84,
+          "color": "rgba(220, 220, 220, 0.6)",
+          "codexId": "etype"
+        }
+      ],
+      "rewardScore": 0,
+      "rewardFlux": 0,
+      "rewardThero": 0,
+      "rewardEnergy": 0,
+      "arcSpeed": 0.34,
+      "path": [
+        {
+          "x": 0.1,
+          "y": 0.92
+        },
+        {
+          "x": 0.24,
+          "y": 0.78
+        },
+        {
+          "x": 0.48,
+          "y": 0.52
+        },
+        {
+          "x": 0.72,
+          "y": 0.32
+        },
+        {
+          "x": 0.9,
+          "y": 0.12
+        }
+      ],
+      "autoAnchors": [
+        {
+          "x": 0.22,
+          "y": 0.82
+        },
+        {
+          "x": 0.5,
+          "y": 0.5
+        },
+        {
+          "x": 0.78,
+          "y": 0.26
+        }
+      ]
+    },
+    {
+      "id": "Theorem - 22",
+      "displayName": "Fourier Aurora",
+      "startThero": 65,
+      "theroCap": 3140,
+      "theroPerKill": 125,
+      "passiveTheroPerSecond": 42,
+      "lives": 100,
+      "waves": [
+        {
+          "label": "fourier aurora placeholders",
+          "count": 17,
+          "interval": 1.5,
+          "hp": 860,
+          "speed": 0.165,
+          "reward": 90,
+          "color": "rgba(220, 220, 220, 0.6)",
+          "codexId": "etype"
+        }
+      ],
+      "rewardScore": 0,
+      "rewardFlux": 0,
+      "rewardThero": 0,
+      "rewardEnergy": 0,
+      "arcSpeed": 0.348,
+      "path": [
+        {
+          "x": 0.1,
+          "y": 0.92
+        },
+        {
+          "x": 0.24,
+          "y": 0.78
+        },
+        {
+          "x": 0.48,
+          "y": 0.52
+        },
+        {
+          "x": 0.72,
+          "y": 0.32
+        },
+        {
+          "x": 0.9,
+          "y": 0.12
+        }
+      ],
+      "autoAnchors": [
+        {
+          "x": 0.22,
+          "y": 0.82
+        },
+        {
+          "x": 0.5,
+          "y": 0.5
+        },
+        {
+          "x": 0.78,
+          "y": 0.26
+        }
+      ]
+    },
+    {
+      "id": "Theorem - 23",
+      "displayName": "Nash Spiral",
+      "startThero": 65,
+      "theroCap": 3280,
+      "theroPerKill": 130,
+      "passiveTheroPerSecond": 42,
+      "lives": 100,
+      "waves": [
+        {
+          "label": "nash spiral placeholders",
+          "count": 18,
+          "interval": 1.5,
+          "hp": 920,
+          "speed": 0.17,
+          "reward": 96,
+          "color": "rgba(220, 220, 220, 0.6)",
+          "codexId": "etype"
+        }
+      ],
+      "rewardScore": 0,
+      "rewardFlux": 0,
+      "rewardThero": 0,
+      "rewardEnergy": 0,
+      "arcSpeed": 0.356,
+      "path": [
+        {
+          "x": 0.1,
+          "y": 0.92
+        },
+        {
+          "x": 0.24,
+          "y": 0.78
+        },
+        {
+          "x": 0.48,
+          "y": 0.52
+        },
+        {
+          "x": 0.72,
+          "y": 0.32
+        },
+        {
+          "x": 0.9,
+          "y": 0.12
+        }
+      ],
+      "autoAnchors": [
+        {
+          "x": 0.22,
+          "y": 0.82
+        },
+        {
+          "x": 0.5,
+          "y": 0.5
+        },
+        {
+          "x": 0.78,
+          "y": 0.26
+        }
+      ]
+    },
+    {
+      "id": "Theorem - 24",
+      "displayName": "Riesz Parallax",
+      "startThero": 65,
+      "theroCap": 3420,
+      "theroPerKill": 135,
+      "passiveTheroPerSecond": 42,
+      "lives": 100,
+      "waves": [
+        {
+          "label": "riesz parallax placeholders",
+          "count": 19,
+          "interval": 1.5,
+          "hp": 980,
+          "speed": 0.175,
+          "reward": 102,
+          "color": "rgba(220, 220, 220, 0.6)",
+          "codexId": "etype"
+        }
+      ],
+      "rewardScore": 0,
+      "rewardFlux": 0,
+      "rewardThero": 0,
+      "rewardEnergy": 0,
+      "arcSpeed": 0.364,
+      "path": [
+        {
+          "x": 0.1,
+          "y": 0.92
+        },
+        {
+          "x": 0.24,
+          "y": 0.78
+        },
+        {
+          "x": 0.48,
+          "y": 0.52
+        },
+        {
+          "x": 0.72,
+          "y": 0.32
+        },
+        {
+          "x": 0.9,
+          "y": 0.12
+        }
+      ],
+      "autoAnchors": [
+        {
+          "x": 0.22,
+          "y": 0.82
+        },
+        {
+          "x": 0.5,
+          "y": 0.5
+        },
+        {
+          "x": 0.78,
+          "y": 0.26
+        }
+      ]
+    },
+    {
+      "id": "Theorem - 25",
+      "displayName": "Poincaré Bloom",
+      "startThero": 65,
+      "theroCap": 3560,
+      "theroPerKill": 140,
+      "passiveTheroPerSecond": 42,
+      "lives": 100,
+      "waves": [
+        {
+          "label": "poincaré bloom placeholders",
+          "count": 20,
+          "interval": 1.5,
+          "hp": 1040,
+          "speed": 0.18,
+          "reward": 108,
+          "color": "rgba(220, 220, 220, 0.6)",
+          "codexId": "etype"
+        }
+      ],
+      "rewardScore": 0,
+      "rewardFlux": 0,
+      "rewardThero": 0,
+      "rewardEnergy": 0,
+      "arcSpeed": 0.372,
+      "path": [
+        {
+          "x": 0.1,
+          "y": 0.92
+        },
+        {
+          "x": 0.24,
+          "y": 0.78
+        },
+        {
+          "x": 0.48,
+          "y": 0.52
+        },
+        {
+          "x": 0.72,
+          "y": 0.32
+        },
+        {
+          "x": 0.9,
+          "y": 0.12
+        }
+      ],
+      "autoAnchors": [
+        {
+          "x": 0.22,
+          "y": 0.82
+        },
+        {
+          "x": 0.5,
+          "y": 0.5
+        },
+        {
+          "x": 0.78,
+          "y": 0.26
+        }
+      ]
+    },
+    {
+      "id": "Axiom - 26",
+      "displayName": "Zorn Horizon",
+      "startThero": 70,
+      "theroCap": 3700,
+      "theroPerKill": 145,
+      "passiveTheroPerSecond": 46,
+      "lives": 100,
+      "waves": [
+        {
+          "label": "zorn horizon placeholders",
+          "count": 21,
+          "interval": 1.5,
+          "hp": 1100,
+          "speed": 0.185,
+          "reward": 114,
+          "color": "rgba(220, 220, 220, 0.6)",
+          "codexId": "etype"
+        }
+      ],
+      "rewardScore": 0,
+      "rewardFlux": 0,
+      "rewardThero": 0,
+      "rewardEnergy": 0,
+      "arcSpeed": 0.38,
+      "path": [
+        {
+          "x": 0.1,
+          "y": 0.92
+        },
+        {
+          "x": 0.24,
+          "y": 0.78
+        },
+        {
+          "x": 0.48,
+          "y": 0.52
+        },
+        {
+          "x": 0.72,
+          "y": 0.32
+        },
+        {
+          "x": 0.9,
+          "y": 0.12
+        }
+      ],
+      "autoAnchors": [
+        {
+          "x": 0.22,
+          "y": 0.82
+        },
+        {
+          "x": 0.5,
+          "y": 0.5
+        },
+        {
+          "x": 0.78,
+          "y": 0.26
+        }
+      ]
+    },
+    {
+      "id": "Axiom - 27",
+      "displayName": "Löwenheim Gate",
+      "startThero": 70,
+      "theroCap": 3840,
+      "theroPerKill": 150,
+      "passiveTheroPerSecond": 46,
+      "lives": 100,
+      "waves": [
+        {
+          "label": "löwenheim gate placeholders",
+          "count": 22,
+          "interval": 1.5,
+          "hp": 1160,
+          "speed": 0.19,
+          "reward": 120,
+          "color": "rgba(220, 220, 220, 0.6)",
+          "codexId": "etype"
+        }
+      ],
+      "rewardScore": 0,
+      "rewardFlux": 0,
+      "rewardThero": 0,
+      "rewardEnergy": 0,
+      "arcSpeed": 0.388,
+      "path": [
+        {
+          "x": 0.1,
+          "y": 0.92
+        },
+        {
+          "x": 0.24,
+          "y": 0.78
+        },
+        {
+          "x": 0.48,
+          "y": 0.52
+        },
+        {
+          "x": 0.72,
+          "y": 0.32
+        },
+        {
+          "x": 0.9,
+          "y": 0.12
+        }
+      ],
+      "autoAnchors": [
+        {
+          "x": 0.22,
+          "y": 0.82
+        },
+        {
+          "x": 0.5,
+          "y": 0.5
+        },
+        {
+          "x": 0.78,
+          "y": 0.26
+        }
+      ]
+    },
+    {
+      "id": "Axiom - 28",
+      "displayName": "Grothendieck Loom",
+      "startThero": 70,
+      "theroCap": 3980,
+      "theroPerKill": 155,
+      "passiveTheroPerSecond": 46,
+      "lives": 100,
+      "waves": [
+        {
+          "label": "grothendieck loom placeholders",
+          "count": 23,
+          "interval": 1.5,
+          "hp": 1220,
+          "speed": 0.195,
+          "reward": 126,
+          "color": "rgba(220, 220, 220, 0.6)",
+          "codexId": "etype"
+        }
+      ],
+      "rewardScore": 0,
+      "rewardFlux": 0,
+      "rewardThero": 0,
+      "rewardEnergy": 0,
+      "arcSpeed": 0.396,
+      "path": [
+        {
+          "x": 0.1,
+          "y": 0.92
+        },
+        {
+          "x": 0.24,
+          "y": 0.78
+        },
+        {
+          "x": 0.48,
+          "y": 0.52
+        },
+        {
+          "x": 0.72,
+          "y": 0.32
+        },
+        {
+          "x": 0.9,
+          "y": 0.12
+        }
+      ],
+      "autoAnchors": [
+        {
+          "x": 0.22,
+          "y": 0.82
+        },
+        {
+          "x": 0.5,
+          "y": 0.5
+        },
+        {
+          "x": 0.78,
+          "y": 0.26
+        }
+      ]
+    },
+    {
+      "id": "Axiom - 29",
+      "displayName": "Tarski Reflection",
+      "startThero": 70,
+      "theroCap": 4120,
+      "theroPerKill": 160,
+      "passiveTheroPerSecond": 46,
+      "lives": 100,
+      "waves": [
+        {
+          "label": "tarski reflection placeholders",
+          "count": 24,
+          "interval": 1.5,
+          "hp": 1280,
+          "speed": 0.2,
+          "reward": 132,
+          "color": "rgba(220, 220, 220, 0.6)",
+          "codexId": "etype"
+        }
+      ],
+      "rewardScore": 0,
+      "rewardFlux": 0,
+      "rewardThero": 0,
+      "rewardEnergy": 0,
+      "arcSpeed": 0.404,
+      "path": [
+        {
+          "x": 0.1,
+          "y": 0.92
+        },
+        {
+          "x": 0.24,
+          "y": 0.78
+        },
+        {
+          "x": 0.48,
+          "y": 0.52
+        },
+        {
+          "x": 0.72,
+          "y": 0.32
+        },
+        {
+          "x": 0.9,
+          "y": 0.12
+        }
+      ],
+      "autoAnchors": [
+        {
+          "x": 0.22,
+          "y": 0.82
+        },
+        {
+          "x": 0.5,
+          "y": 0.5
+        },
+        {
+          "x": 0.78,
+          "y": 0.26
+        }
+      ]
+    },
+    {
+      "id": "Axiom - 30",
+      "displayName": "Peano Genesis",
+      "startThero": 70,
+      "theroCap": 4260,
+      "theroPerKill": 165,
+      "passiveTheroPerSecond": 46,
+      "lives": 100,
+      "waves": [
+        {
+          "label": "peano genesis placeholders",
+          "count": 25,
+          "interval": 1.5,
+          "hp": 1340,
+          "speed": 0.205,
+          "reward": 138,
+          "color": "rgba(220, 220, 220, 0.6)",
+          "codexId": "etype"
+        }
+      ],
+      "rewardScore": 0,
+      "rewardFlux": 0,
+      "rewardThero": 0,
+      "rewardEnergy": 0,
+      "arcSpeed": 0.412,
+      "path": [
+        {
+          "x": 0.1,
+          "y": 0.92
+        },
+        {
+          "x": 0.24,
+          "y": 0.78
+        },
+        {
+          "x": 0.48,
+          "y": 0.52
+        },
+        {
+          "x": 0.72,
+          "y": 0.32
+        },
+        {
+          "x": 0.9,
+          "y": 0.12
+        }
+      ],
+      "autoAnchors": [
+        {
+          "x": 0.22,
+          "y": 0.82
+        },
+        {
+          "x": 0.5,
+          "y": 0.5
+        },
+        {
+          "x": 0.78,
+          "y": 0.26
         }
       ]
     }


### PR DESCRIPTION
## Summary
- add placeholder map metadata for Lemma, Proof, Theorem, and Axiom sets
- add stub level configurations for levels 11-30 with minimal waves, paths, and anchors

## Testing
- not run (data-only change)


------
https://chatgpt.com/codex/tasks/task_e_68fbc793916c832aaa2ecef8307f9a88