### PR TITLE
Display mote storage and dispensing rate in status HUD

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,10 +73,10 @@
           </span>
         </div>
         <div class="status-group">
-          <span class="status-label">Motefall Rate</span>
+          <span class="status-label">Motes Stored</span>
           <span class="status-value status-value--stacked">
-            <span id="status-powder-rate">+0 Motes/min</span>
-            <span class="status-subvalue status-subvalue--gold" id="status-achievement-count">(0 achievements)</span>
+            <span id="status-mote-storage">0 Motes</span>
+            <span class="status-subvalue status-subvalue--gold" id="status-dispense-rate">1 Mote/sec</span>
           </span>
         </div>
       </header>
@@ -940,6 +940,19 @@
                 <div>
                   <dt>Mote Stockpile</dt>
                   <dd id="powder-stockpile">0 Motes</dd>
+                </div>
+              </dl>
+            </article>
+            <article class="card powder-mote-stats">
+              <h3>Mote Bank Stats</h3>
+              <dl class="powder-metrics">
+                <div>
+                  <dt>Idle Multiplier</dt>
+                  <dd id="powder-idle-multiplier">0 achievements</dd>
+                </div>
+                <div>
+                  <dt>Dispensing Rate</dt>
+                  <dd id="powder-dispense-rate">1 Mote/sec</dd>
                 </div>
               </dl>
             </article>


### PR DESCRIPTION
## Summary
- replace the motefall rate HUD readout with the current mote bank storage and dispensing rate
- add a mote bank stats card in the motes tab to surface the idle multiplier and dispensing rate
- centralize mote bank calculations so stored motes drain at 1 mote/sec by default and keep the UI in sync

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68fbce6405e4832aa86d55dd9fc7b835