### PR TITLE
Add paginated field notes and theme-aware mote visuals

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -2072,10 +2072,67 @@ body.color-scheme-chromatic::before {
 }
 
 .field-notes-copy {
+  position: relative;
+  display: block;
+  min-height: clamp(220px, 48vh, 360px);
+  max-height: min(60vh, 420px);
+  overflow: hidden;
+  border-radius: 14px;
+  background: linear-gradient(180deg, rgba(12, 16, 26, 0.6), rgba(18, 20, 32, 0.75));
+  box-shadow: inset 0 0 0 1px rgba(139, 247, 255, 0.05);
+}
+
+.field-notes-page {
+  position: absolute;
+  inset: 0;
+  padding: 4px 16px 8px 6px;
   display: grid;
   gap: 12px;
   font-size: 0.95rem;
   line-height: 1.6;
+  color: inherit;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(139, 247, 255, 0.3) rgba(12, 16, 26, 0.4);
+  touch-action: pan-y;
+  overscroll-behavior: contain;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateX(24px);
+  transition: transform 280ms ease, opacity 240ms ease;
+  pointer-events: none;
+}
+
+.field-notes-page::-webkit-scrollbar {
+  width: 6px;
+}
+
+.field-notes-page::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.field-notes-page::-webkit-scrollbar-thumb {
+  background: linear-gradient(180deg, rgba(139, 247, 255, 0.4), rgba(255, 228, 160, 0.35));
+  border-radius: 999px;
+}
+
+.field-notes-page.field-notes-page--active {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(0);
+  pointer-events: auto;
+}
+
+.field-notes-page.field-notes-page--from-right,
+.field-notes-page.field-notes-page--to-right {
+  transform: translateX(42px);
+  opacity: 0;
+}
+
+.field-notes-page.field-notes-page--from-left,
+.field-notes-page.field-notes-page--to-left {
+  transform: translateX(-42px);
+  opacity: 0;
 }
 
 .field-notes-copy strong {
@@ -2100,6 +2157,52 @@ body.color-scheme-chromatic::before {
 .field-notes-overlay .overlay-close:hover,
 .field-notes-overlay .overlay-close:focus-visible {
   color: rgba(255, 228, 160, 0.95);
+}
+
+.field-notes-pagination {
+  margin-top: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  font-family: 'Space Mono', monospace;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(200, 210, 255, 0.7);
+}
+
+.field-notes-page-button {
+  display: grid;
+  place-items: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 999px;
+  border: 1px solid rgba(139, 247, 255, 0.35);
+  background: transparent;
+  color: rgba(255, 255, 255, 0.82);
+  font-size: 1.4rem;
+  font-family: 'Cormorant Garamond', serif;
+  cursor: pointer;
+  transition: background var(--transition), color var(--transition), border-color var(--transition);
+}
+
+.field-notes-page-button:hover,
+.field-notes-page-button:focus-visible {
+  border-color: rgba(255, 228, 160, 0.75);
+  background: rgba(255, 228, 160, 0.18);
+  color: rgba(255, 228, 160, 0.95);
+}
+
+.field-notes-page-button:disabled {
+  opacity: 0.4;
+  cursor: default;
+  border-color: rgba(139, 247, 255, 0.2);
+}
+
+.field-notes-page-indicator {
+  flex: 1;
+  text-align: center;
 }
 
 .upgrade-overlay .overlay-panel {

--- a/index.html
+++ b/index.html
@@ -839,13 +839,13 @@
               </header>
               <div class="formula-block">
                 <p class="formula-line">\( \Delta m = 1000 \)</p>
-                <p class="formula-line result">Instant mote drop for rapid flux calibration.</p>
+                <p class="formula-line result">Instant mote deposit for rapid flux calibration.</p>
               </div>
               <p class="tower-utility-note" id="developer-mote-tower-status" aria-live="polite">
-                Developer mote tower ready—click to release +1,000 motes.
+                Developer mote tower ready—store +1,000 motes in the idle bank.
               </p>
               <button class="tower-equip-button" type="button" id="developer-mote-tower-button">
-                Release +1,000 motes
+                Store +1,000 motes
               </button>
             </article>
 
@@ -1399,29 +1399,42 @@
         </figure>
         <p class="overlay-label">Field Notes Dispatch</p>
         <h2 class="overlay-title" id="field-notes-title">The Tower of Inspiration Briefing</h2>
-        <div class="field-notes-copy">
-          <p>
-            Welcome, Warden. I am Thero, archivist of the glyph lattice. Your arrival coincides with a surge of
-            <strong>mote turbulence</strong> washing against the tower's perimeter.
-          </p>
-          <p>
-            Our scouts report that rival scholars have animated rogue proofs. Each wave they summon is tuned to unravel the
-            equations binding our defenses. Hold these observations close:
-          </p>
-          <ul class="field-notes-list">
-            <li>The <strong>Scintilla Glyph</strong> at the summit regulates every mote current—lose it and the lattice collapses.</li>
-            <li>
-              <strong>Chronoglyph wards</strong> along the ramparts can bend time briefly. Use their cadence to reset your
-              ordinals and stagger enemy advances.
-            </li>
-            <li>
-              When a wave fractures, sift the motes it leaves behind. Their resonance seeds new towers faster than any quarry.
-            </li>
-          </ul>
-          <p>
-            Return once the next theorem is secured. I will inscribe your progress and prepare the following expedition. The
-            codex grows because of your vigilance.
-          </p>
+        <div class="field-notes-copy" id="field-notes-copy">
+          <article class="field-notes-page field-notes-page--active" data-page-index="0" tabindex="0">
+            <p>
+              Welcome, Warden. I am Thero, archivist of the glyph lattice. Your arrival coincides with a surge of
+              <strong>mote turbulence</strong> washing against the tower's perimeter.
+            </p>
+            <p>
+              Our scouts report that rival scholars have animated rogue proofs. Each wave they summon is tuned to unravel the
+              equations binding our defenses. Hold these observations close:
+            </p>
+          </article>
+          <article class="field-notes-page" data-page-index="1" tabindex="-1" aria-hidden="true">
+            <ul class="field-notes-list">
+              <li>The <strong>Scintilla Glyph</strong> at the summit regulates every mote current—lose it and the lattice collapses.</li>
+              <li>
+                <strong>Chronoglyph wards</strong> along the ramparts can bend time briefly. Use their cadence to reset your
+                ordinals and stagger enemy advances.
+              </li>
+              <li>
+                When a wave fractures, sift the motes it leaves behind. Their resonance seeds new towers faster than any quarry.
+              </li>
+            </ul>
+            <p>
+              Return once the next theorem is secured. I will inscribe your progress and prepare the following expedition. The
+              codex grows because of your vigilance.
+            </p>
+          </article>
+        </div>
+        <div class="field-notes-pagination" id="field-notes-pagination">
+          <button class="field-notes-page-button" type="button" id="field-notes-prev" aria-label="Previous field notes page" disabled>
+            ‹
+          </button>
+          <span class="field-notes-page-indicator" id="field-notes-page-indicator">Page 1 of 2</span>
+          <button class="field-notes-page-button" type="button" id="field-notes-next" aria-label="Next field notes page">
+            ›
+          </button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- enable the Field Notes overlay to paginate with scrollable pages, swipe gestures, and keyboard navigation
- make the developer mote tower store motes in the idle bank instead of spawning drops and adjust messaging
- tie mote rendering to the active color palette with a size-based gradient and refreshed powder visuals

## Testing
- python3 -m http.server 8000 (manual verification)

------
https://chatgpt.com/codex/tasks/task_e_68fbd2648b34832a9e02d9b4a7e6ae36