### PR TITLE
Add illustrated field notes pages and page-turn audio cue

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -1447,6 +1447,7 @@ import {
       towerMerge: { file: 'tower_merge.mp3', volume: 0.75, maxConcurrent: 2 },
       towerSell: { file: 'tower_merge.mp3', volume: 0.7, maxConcurrent: 2 },
       enterLevel: { file: 'enter_level.mp3', volume: 0.75, maxConcurrent: 2 },
+      pageTurn: { file: 'page_turn.mp3', volume: 0.6, maxConcurrent: 2 },
       error: { file: 'error.mp3', volume: 0.8, maxConcurrent: 2 },
       alphaTowerFire: { file: 'alpha_tower_firing.mp3', volume: 0.55, maxConcurrent: 5 },
       noteA: { file: 'note_A.mp3', volume: 0.8, maxConcurrent: 3 },
@@ -10223,6 +10224,10 @@ import {
 
     if (!nextPage) {
       return;
+    }
+
+    if (!immediate && clampedIndex !== currentIndex && audioManager) {
+      audioManager.playSfx('pageTurn');
     }
 
     if (immediate) {

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -2135,6 +2135,28 @@ body.color-scheme-chromatic::before {
   opacity: 0;
 }
 
+.field-notes-page-figure {
+  margin: 0;
+  display: grid;
+  gap: 12px;
+  align-content: start;
+}
+
+.field-notes-page-image {
+  width: 100%;
+  height: auto;
+  border-radius: 12px;
+  box-shadow: 0 12px 36px rgba(12, 16, 26, 0.66);
+  border: 1px solid rgba(139, 247, 255, 0.12);
+}
+
+.field-notes-page-caption {
+  font-size: 0.82rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: rgba(139, 247, 255, 0.75);
+}
+
 .field-notes-copy strong {
   color: rgba(255, 228, 160, 0.95);
 }

--- a/index.html
+++ b/index.html
@@ -1401,6 +1401,39 @@
         <h2 class="overlay-title" id="field-notes-title">The Tower of Inspiration Briefing</h2>
         <div class="field-notes-copy" id="field-notes-copy">
           <article class="field-notes-page field-notes-page--active" data-page-index="0" tabindex="0">
+            <figure class="field-notes-page-figure">
+              <img
+                class="field-notes-page-image"
+                src="./assets/field notes/field_notes_page_1.png"
+                alt="Illustrated field notes detailing the sigil-laced ramparts guarding the tower."
+                loading="eager"
+              />
+              <figcaption class="field-notes-page-caption">Field Notes · Page I — Rampart lattice schematics.</figcaption>
+            </figure>
+          </article>
+          <article class="field-notes-page" data-page-index="1" tabindex="-1" aria-hidden="true">
+            <figure class="field-notes-page-figure">
+              <img
+                class="field-notes-page-image"
+                src="./assets/field notes/field_notes_page_2.png"
+                alt="Sketches cataloguing powder flow experiments and glyph reactions."
+                loading="lazy"
+              />
+              <figcaption class="field-notes-page-caption">Field Notes · Page II — Powder flow resonance studies.</figcaption>
+            </figure>
+          </article>
+          <article class="field-notes-page" data-page-index="2" tabindex="-1" aria-hidden="true">
+            <figure class="field-notes-page-figure">
+              <img
+                class="field-notes-page-image"
+                src="./assets/field notes/field_notes_page_3.png"
+                alt="Logbook page comparing enemy formations with counter-formulae."
+                loading="lazy"
+              />
+              <figcaption class="field-notes-page-caption">Field Notes · Page III — Counter-formation annotations.</figcaption>
+            </figure>
+          </article>
+          <article class="field-notes-page" data-page-index="3" tabindex="-1" aria-hidden="true">
             <p>
               Welcome, Warden. I am Thero, archivist of the glyph lattice. Your arrival coincides with a surge of
               <strong>mote turbulence</strong> washing against the tower's perimeter.
@@ -1410,7 +1443,7 @@
               equations binding our defenses. Hold these observations close:
             </p>
           </article>
-          <article class="field-notes-page" data-page-index="1" tabindex="-1" aria-hidden="true">
+          <article class="field-notes-page" data-page-index="4" tabindex="-1" aria-hidden="true">
             <ul class="field-notes-list">
               <li>The <strong>Scintilla Glyph</strong> at the summit regulates every mote current—lose it and the lattice collapses.</li>
               <li>
@@ -1431,7 +1464,7 @@
           <button class="field-notes-page-button" type="button" id="field-notes-prev" aria-label="Previous field notes page" disabled>
             ‹
           </button>
-          <span class="field-notes-page-indicator" id="field-notes-page-indicator">Page 1 of 2</span>
+          <span class="field-notes-page-indicator" id="field-notes-page-indicator">Page 1 of 5</span>
           <button class="field-notes-page-button" type="button" id="field-notes-next" aria-label="Next field notes page">
             ›
           </button>


### PR DESCRIPTION
## Summary
- embed three illustrated field note pages and extend the overlay pagination
- style the field notes view to frame new artwork with tower-themed chrome
- add a dedicated page turn sound and trigger it when switching pages

## Testing
- Manual: Served the app locally and inspected the field notes overlay

------
https://chatgpt.com/codex/tasks/task_e_68fbe240e168832a91637ff8dce42b1d