### PR TITLE
Add Mind Gate origin tower presentation

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -6540,6 +6540,64 @@ import {
       ctx.restore();
     }
 
+    drawMindGateSymbol(ctx, position) {
+      if (!ctx || !position) {
+        return;
+      }
+
+      const dimension = Math.min(this.renderWidth || 0, this.renderHeight || 0) || 0;
+      const baseRadius = dimension ? dimension * 0.035 : 0;
+      const radius = Math.max(14, Math.min(24, baseRadius || 18));
+
+      ctx.save();
+      ctx.translate(position.x, position.y);
+
+      const glow = ctx.createRadialGradient(0, 0, radius * 0.2, 0, 0, radius);
+      glow.addColorStop(0, 'rgba(255, 248, 220, 0.9)');
+      glow.addColorStop(0.6, 'rgba(255, 196, 150, 0.35)');
+      glow.addColorStop(1, 'rgba(255, 158, 88, 0.15)');
+      ctx.fillStyle = glow;
+      ctx.beginPath();
+      ctx.arc(0, 0, radius, 0, Math.PI * 2);
+      ctx.fill();
+
+      ctx.shadowColor = 'rgba(255, 196, 150, 0.55)';
+      ctx.shadowBlur = radius * 0.9;
+      ctx.strokeStyle = 'rgba(255, 158, 88, 0.88)';
+      ctx.lineWidth = Math.max(2, radius * 0.16);
+      ctx.beginPath();
+      ctx.arc(0, 0, radius * 0.82, 0, Math.PI * 2);
+      ctx.stroke();
+
+      ctx.shadowColor = 'rgba(139, 247, 255, 0.55)';
+      ctx.shadowBlur = radius * 0.7;
+      ctx.strokeStyle = 'rgba(139, 247, 255, 0.85)';
+      ctx.lineWidth = Math.max(1.4, radius * 0.12);
+      ctx.beginPath();
+      ctx.moveTo(0, radius * 0.64);
+      ctx.lineTo(0, -radius * 0.6);
+      ctx.stroke();
+
+      ctx.beginPath();
+      ctx.arc(0, 0, radius * 0.28, 0, Math.PI * 2);
+      ctx.stroke();
+
+      ctx.strokeStyle = 'rgba(255, 228, 120, 0.92)';
+      ctx.shadowColor = 'rgba(255, 228, 120, 0.55)';
+      ctx.shadowBlur = radius * 0.8;
+      ctx.lineWidth = Math.max(1.6, radius * 0.14);
+      ctx.beginPath();
+      const gateWidth = radius * 0.58;
+      const gateBase = radius * 0.62;
+      ctx.moveTo(-gateWidth, gateBase);
+      ctx.lineTo(-gateWidth, -radius * 0.18);
+      ctx.quadraticCurveTo(0, -radius * 0.95, gateWidth, -radius * 0.18);
+      ctx.lineTo(gateWidth, gateBase);
+      ctx.stroke();
+
+      ctx.restore();
+    }
+
     drawNodes() {
       if (!this.ctx || !this.pathSegments.length) {
         return;
@@ -6553,10 +6611,7 @@ import {
       ctx.beginPath();
       ctx.arc(startPoint.x, startPoint.y, 10, 0, Math.PI * 2);
       ctx.fill();
-      ctx.fillStyle = 'rgba(255, 158, 88, 0.95)';
-      ctx.beginPath();
-      ctx.arc(endPoint.x, endPoint.y, 12, 0, Math.PI * 2);
-      ctx.fill();
+      this.drawMindGateSymbol(ctx, endPoint);
     }
 
     setDeveloperPathMarkers(markers) {

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1307,6 +1307,65 @@ body.color-scheme-chromatic::before {
   gap: 12px;
 }
 
+.card--mind-gate {
+  position: relative;
+  overflow: hidden;
+  border-color: rgba(255, 228, 120, 0.32);
+  background: linear-gradient(160deg, rgba(16, 16, 26, 0.9), rgba(34, 22, 40, 0.88));
+  box-shadow: 0 18px 40px rgba(255, 158, 88, 0.16), var(--shadow);
+}
+
+.card--mind-gate::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 50% 0, rgba(255, 228, 120, 0.18), transparent 58%),
+    radial-gradient(circle at 46% 110%, rgba(139, 247, 255, 0.16), transparent 62%);
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+.card--mind-gate > * {
+  position: relative;
+  z-index: 1;
+}
+
+.mind-gate-symbol {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.65em;
+  height: 1.65em;
+  margin-right: 0.4em;
+  border-radius: 999px;
+  font-family: "Cormorant Garamond", serif;
+  font-size: 1.5rem;
+  line-height: 1;
+  background: linear-gradient(140deg, rgba(255, 228, 120, 0.26), rgba(139, 247, 255, 0.18));
+  color: rgba(255, 228, 120, 0.92);
+  box-shadow: 0 0 18px rgba(255, 228, 120, 0.55), 0 0 32px rgba(139, 247, 255, 0.3);
+  text-shadow: 0 0 20px rgba(255, 228, 120, 0.65);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .mind-gate-symbol {
+    animation: mind-gate-pulse 3.2s ease-in-out infinite;
+  }
+}
+
+@keyframes mind-gate-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 14px rgba(255, 228, 120, 0.45), 0 0 32px rgba(139, 247, 255, 0.22);
+    transform: scale(1);
+  }
+  50% {
+    box-shadow: 0 0 20px rgba(255, 228, 120, 0.65), 0 0 40px rgba(139, 247, 255, 0.35);
+    transform: scale(1.08);
+  }
+}
+
 .card h3 {
   margin: 0;
   font-size: 1.3rem;

--- a/index.html
+++ b/index.html
@@ -160,6 +160,34 @@
           hidden
         >
           <div class="panel-grid">
+            <article class="card card--mind-gate" aria-hidden="false">
+              <header class="tower-header">
+                <span class="tower-tier">Origin</span>
+                <h3>
+                  <span class="mind-gate-symbol" aria-hidden="true">⟟</span>
+                  mind gate
+                </h3>
+              </header>
+              <div class="formula-block">
+                <p class="formula-line">
+                  \( \mathcal{G}_{\text{Mind}} = 10 \times X_{\text{life}} + \frac{Y_{\text{recovery}}}{1 / X_{\text{life}}} \)
+                </p>
+                <ul class="formula-definition">
+                  <li>X → life (inspiration reservoir)</li>
+                  <li>Y → recovery (glyph-fed renewal)</li>
+                </ul>
+                <p class="formula-line result">
+                  Defaults: \( X = Y = 1 \). Each glyph invested increases a term by +1.
+                </p>
+              </div>
+              <ul class="upgrade-list">
+                <li>Fortify X to deepen the Mind Gate's stores of fading inspiration.</li>
+                <li>Amplify Y so recovery surges restore the gate between waves.</li>
+              </ul>
+              <footer class="card-footer">
+                The original tower—anchoring the lane's finale. When the Mind Gate collapses, inspiration runs dry.
+              </footer>
+            </article>
             <article class="card" data-tower-id="alpha" aria-hidden="false">
               <header class="tower-header">
                 <span class="tower-tier">Tier I</span>


### PR DESCRIPTION
## Summary
- add a Mind Gate origin card to the towers tab with its life and recovery equation and glyph guidance
- style the Mind Gate card with a pulsing sigil treatment to highlight the original tower
- render a Mind Gate sigil at the end of the defense track to visualize the inspiration core

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68fbe6f64cd4832aa4d5eb297067ae03