### PR TITLE
Add tower upgrade overlay with glyph variable customization

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -37,6 +37,184 @@ import {
   const THERO_SYMBOL = 'þ';
   const COMMUNITY_DISCORD_INVITE = 'https://discord.gg/UzqhfsZQ8n'; // Reserved for future placement.
 
+  const TOWER_EQUATION_BLUEPRINTS = {
+    alpha: {
+      mathSymbol: '\\alpha',
+      baseEquation: '\\( \\alpha = X \\cdot Y \\)',
+      variables: [
+        {
+          key: 'damage',
+          symbol: 'X',
+          name: 'Attack Power',
+          description: 'Projectile damage carried by each glyph bullet.',
+          stat: 'damage',
+          step: 4,
+          upgradable: true,
+          format: (value) => formatWholeNumber(value),
+          cost: (level) => Math.max(1, 1 + level),
+        },
+        {
+          key: 'rate',
+          symbol: 'Y',
+          name: 'Attack Speed',
+          description: 'Glyph pulses per second channelled through the lattice.',
+          stat: 'rate',
+          step: 0.1,
+          upgradable: true,
+          format: (value) => formatDecimal(value, 2),
+          cost: (level) => Math.max(1, 1 + Math.floor(level / 2)),
+        },
+      ],
+      computeResult(values) {
+        const damage = Number.isFinite(values.damage) ? values.damage : 0;
+        const rate = Number.isFinite(values.rate) ? values.rate : 0;
+        return damage * rate;
+      },
+      formatGoldenEquation({ symbol, formatVariable, formatResult }) {
+        return `\\( ${symbol} = ${formatVariable('damage')} \\times ${formatVariable('rate')} = ${formatResult()} \\)`;
+      },
+    },
+    beta: {
+      mathSymbol: '\\beta',
+      baseEquation: '\\( \\beta = X \\cdot Y \\cdot Z \\)',
+      variables: [
+        {
+          key: 'damage',
+          symbol: 'X',
+          name: 'Beam Harmonics',
+          description: 'Base resonance damage produced per pulse.',
+          stat: 'damage',
+          step: 6,
+          upgradable: true,
+          format: (value) => formatWholeNumber(value),
+          cost: (level) => Math.max(1, 1 + level),
+        },
+        {
+          key: 'rate',
+          symbol: 'Y',
+          name: 'Pulse Frequency',
+          description: 'Sustained pulses emitted each second.',
+          stat: 'rate',
+          step: 0.08,
+          upgradable: true,
+          format: (value) => formatDecimal(value, 2),
+          cost: (level) => Math.max(1, 1 + Math.floor(level / 2)),
+        },
+        {
+          key: 'pierce',
+          symbol: 'Z',
+          name: 'Prism Pierce',
+          description: 'Targets threaded per beam cycle.',
+          baseValue: 1,
+          step: 0.35,
+          upgradable: true,
+          format: (value) => formatDecimal(value, 2),
+          cost: (level) => Math.max(1, 2 + Math.floor(level / 2)),
+        },
+      ],
+      computeResult(values) {
+        const damage = Number.isFinite(values.damage) ? values.damage : 0;
+        const rate = Number.isFinite(values.rate) ? values.rate : 0;
+        const pierce = Number.isFinite(values.pierce) ? values.pierce : 0;
+        return damage * rate * pierce;
+      },
+      formatGoldenEquation({ symbol, formatVariable, formatResult }) {
+        return `\\( ${symbol} = ${formatVariable('damage')} \\times ${formatVariable('rate')} \\times ${formatVariable('pierce')} = ${formatResult()} \\)`;
+      },
+    },
+    gamma: {
+      mathSymbol: '\\gamma',
+      baseEquation: '\\( \\gamma = \\alpha^{1/2} \\cdot \\beta \\)',
+      variables: [
+        {
+          key: 'alpha',
+          symbol: 'α',
+          name: 'Alpha Pulse',
+          description: 'Inherited burst cadence from α lattices.',
+          reference: 'alpha',
+          upgradable: false,
+          lockedNote: 'Upgrade α to raise this value.',
+          format: (value) => formatDecimal(value, 2),
+        },
+        {
+          key: 'beta',
+          symbol: 'β',
+          name: 'Beta Resonance',
+          description: 'Sustained beam resonance carried forward.',
+          reference: 'beta',
+          upgradable: false,
+          lockedNote: 'Upgrade β to amplify this resonance.',
+          format: (value) => formatDecimal(value, 2),
+        },
+      ],
+      computeResult(values) {
+        const alphaValue = Math.max(0, Number.isFinite(values.alpha) ? values.alpha : 0);
+        const betaValue = Math.max(0, Number.isFinite(values.beta) ? values.beta : 0);
+        return Math.sqrt(alphaValue) * betaValue;
+      },
+      formatGoldenEquation({ symbol, formatVariable, formatResult }) {
+        return `\\( ${symbol} = \\sqrt{${formatVariable('alpha')}} \\times ${formatVariable('beta')} = ${formatResult()} \\)`;
+      },
+    },
+    delta: {
+      mathSymbol: '\\delta',
+      baseEquation: '\\( \\delta = \\gamma \\cdot \\ln(\\beta + 1) \\)',
+      variables: [
+        {
+          key: 'gamma',
+          symbol: 'γ',
+          name: 'Gamma Cohort',
+          description: 'Command strength inherited from γ conductors.',
+          reference: 'gamma',
+          upgradable: false,
+          lockedNote: 'Bolster γ to empower this cohort.',
+          format: (value) => formatDecimal(value, 2),
+        },
+        {
+          key: 'beta',
+          symbol: 'β',
+          name: 'Beta Harmonics',
+          description: 'Beam resonance sustaining the summoned legion.',
+          reference: 'beta',
+          upgradable: false,
+          lockedNote: 'Infuse β to widen this harmonic.',
+          format: (value) => formatDecimal(value, 2),
+        },
+      ],
+      computeResult(values) {
+        const gammaValue = Math.max(0, Number.isFinite(values.gamma) ? values.gamma : 0);
+        const betaValue = Math.max(0, Number.isFinite(values.beta) ? values.beta : 0);
+        const lnComponent = Math.log(betaValue + 1);
+        return gammaValue * lnComponent;
+      },
+      formatGoldenEquation({ symbol, formatVariable, formatResult }) {
+        return `\\( ${symbol} = ${formatVariable('gamma')} \\times \\ln(${formatVariable('beta')} + 1) = ${formatResult()} \\)`;
+      },
+    },
+  };
+
+  const fallbackTowerBlueprints = new Map();
+
+  const towerUpgradeElements = {
+    overlay: null,
+    panel: null,
+    close: null,
+    title: null,
+    tier: null,
+    glyphs: null,
+    baseEquation: null,
+    goldenEquation: null,
+    variables: null,
+    note: null,
+    icon: null,
+  };
+
+  const towerUpgradeState = new Map();
+  const towerEquationCache = new Map();
+  let activeTowerUpgradeId = null;
+  let activeTowerUpgradeBaseEquation = '';
+  let lastTowerUpgradeTrigger = null;
+
   function isLikelyMathExpression(text) {
     if (!text) {
       return false;
@@ -9877,6 +10055,607 @@ import {
     syncLoadoutToPlayfield();
   }
 
+  function getTowerEquationBlueprint(towerId) {
+    if (!towerId) {
+      return null;
+    }
+    if (Object.prototype.hasOwnProperty.call(TOWER_EQUATION_BLUEPRINTS, towerId)) {
+      return TOWER_EQUATION_BLUEPRINTS[towerId];
+    }
+    if (fallbackTowerBlueprints.has(towerId)) {
+      return fallbackTowerBlueprints.get(towerId);
+    }
+    const definition = getTowerDefinition(towerId);
+    if (!definition) {
+      return null;
+    }
+
+    const fallbackBlueprint = {
+      mathSymbol: definition.symbol ? definition.symbol : towerId,
+      baseEquation: `\\( ${definition.symbol || towerId} = X \\times Y \\)`,
+      variables: [
+        {
+          key: 'damage',
+          symbol: 'X',
+          name: 'Damage',
+          description: 'Base strike damage coursing through the lattice.',
+          stat: 'damage',
+          upgradable: false,
+          format: (value) => formatWholeNumber(value),
+        },
+        {
+          key: 'rate',
+          symbol: 'Y',
+          name: 'Attack Speed',
+          description: 'Attacks per second released by the glyph.',
+          stat: 'rate',
+          upgradable: false,
+          format: (value) => formatDecimal(value, 2),
+        },
+      ],
+      computeResult(values) {
+        const damage = Number.isFinite(values.damage) ? values.damage : 0;
+        const rate = Number.isFinite(values.rate) ? values.rate : 0;
+        return damage * rate;
+      },
+      formatGoldenEquation({ symbol, formatVariable, formatResult }) {
+        return `\\( ${symbol} = ${formatVariable('damage')} \\times ${formatVariable('rate')} = ${formatResult()} \\)`;
+      },
+    };
+
+    fallbackTowerBlueprints.set(towerId, fallbackBlueprint);
+    return fallbackBlueprint;
+  }
+
+  function getBlueprintVariable(blueprint, key) {
+    if (!blueprint || !key) {
+      return null;
+    }
+    return (blueprint.variables || []).find((variable) => variable.key === key) || null;
+  }
+
+  function ensureTowerUpgradeState(towerId, blueprint = null) {
+    if (!towerId) {
+      return { variables: {} };
+    }
+    const effectiveBlueprint = blueprint || getTowerEquationBlueprint(towerId);
+    let state = towerUpgradeState.get(towerId);
+    if (!state) {
+      state = { variables: {} };
+      towerUpgradeState.set(towerId, state);
+    }
+    if (!state.variables) {
+      state.variables = {};
+    }
+    const variables = effectiveBlueprint?.variables || [];
+    variables.forEach((variable) => {
+      if (!state.variables[variable.key]) {
+        state.variables[variable.key] = { level: 0 };
+      }
+    });
+    return state;
+  }
+
+  function calculateTowerVariableUpgradeCost(variable, level) {
+    if (!variable) {
+      return 1;
+    }
+    if (typeof variable.cost === 'function') {
+      const value = variable.cost(level);
+      if (Number.isFinite(value) && value > 0) {
+        return Math.max(1, Math.floor(value));
+      }
+    } else if (Number.isFinite(variable.cost)) {
+      return Math.max(1, Math.floor(variable.cost));
+    }
+    return Math.max(1, 1 + level);
+  }
+
+  function computeTowerVariableValue(towerId, variableKey, blueprint = null, visited = new Set()) {
+    if (!towerId || !variableKey) {
+      return 0;
+    }
+    const effectiveBlueprint = blueprint || getTowerEquationBlueprint(towerId);
+    const variable = getBlueprintVariable(effectiveBlueprint, variableKey);
+    if (!variable) {
+      return 0;
+    }
+
+    if (variable.reference) {
+      const referencedId = variable.reference;
+      const referencedValue = calculateTowerEquationResult(referencedId, visited);
+      if (!Number.isFinite(referencedValue)) {
+        return 0;
+      }
+      if (typeof variable.transform === 'function') {
+        return variable.transform(referencedValue);
+      }
+      if (Number.isFinite(variable.exponent)) {
+        return referencedValue ** variable.exponent;
+      }
+      return referencedValue;
+    }
+
+    const definition = getTowerDefinition(towerId);
+    let baseValue = 0;
+    if (typeof variable.getBase === 'function') {
+      baseValue = variable.getBase({ definition, towerId });
+    } else if (variable.stat && Number.isFinite(definition?.[variable.stat])) {
+      baseValue = definition[variable.stat];
+    } else if (Number.isFinite(variable.baseValue)) {
+      baseValue = variable.baseValue;
+    }
+
+    if (!Number.isFinite(baseValue)) {
+      baseValue = 0;
+    }
+
+    const state = ensureTowerUpgradeState(towerId, effectiveBlueprint);
+    const level = state.variables?.[variableKey]?.level || 0;
+    if (variable.upgradable === false) {
+      return baseValue;
+    }
+
+    const step =
+      typeof variable.getStep === 'function'
+        ? variable.getStep(level, { definition, towerId })
+        : Number.isFinite(variable.step)
+        ? variable.step
+        : 0;
+
+    return baseValue + level * step;
+  }
+
+  function calculateTowerEquationResult(towerId, visited = new Set()) {
+    if (!towerId) {
+      return 0;
+    }
+    if (towerEquationCache.has(towerId)) {
+      return towerEquationCache.get(towerId);
+    }
+    if (visited.has(towerId)) {
+      return 0;
+    }
+    visited.add(towerId);
+
+    const blueprint = getTowerEquationBlueprint(towerId);
+    if (!blueprint) {
+      visited.delete(towerId);
+      return 0;
+    }
+
+    ensureTowerUpgradeState(towerId, blueprint);
+    const values = {};
+    (blueprint.variables || []).forEach((variable) => {
+      values[variable.key] = computeTowerVariableValue(towerId, variable.key, blueprint, visited);
+    });
+
+    let result = 0;
+    if (typeof blueprint.computeResult === 'function') {
+      result = blueprint.computeResult(values, { definition: getTowerDefinition(towerId) });
+    } else {
+      result = Object.values(values).reduce((total, value) => {
+        const contribution = Number.isFinite(value) ? value : 0;
+        return total === 0 ? contribution : total * contribution;
+      }, 0);
+    }
+
+    const safeResult = Number.isFinite(result) ? result : 0;
+    towerEquationCache.set(towerId, safeResult);
+    visited.delete(towerId);
+    return safeResult;
+  }
+
+  function invalidateTowerEquationCache() {
+    towerEquationCache.clear();
+  }
+
+  function formatTowerVariableValue(variable, value) {
+    if (!Number.isFinite(value)) {
+      return '0';
+    }
+    if (variable && typeof variable.format === 'function') {
+      try {
+        const formatted = variable.format(value);
+        if (typeof formatted === 'string') {
+          return formatted;
+        }
+      } catch (error) {
+        // Ignore formatting errors and fall back to default formatting.
+      }
+    }
+    return Number.isInteger(value) ? formatWholeNumber(value) : formatDecimal(value, 2);
+  }
+
+  function formatTowerEquationResultValue(value) {
+    if (!Number.isFinite(value)) {
+      return '0';
+    }
+    if (Math.abs(value) >= 1000) {
+      return formatGameNumber(value);
+    }
+    return formatDecimal(value, 2);
+  }
+
+  function extractTowerCardEquation(card) {
+    if (!(card instanceof HTMLElement)) {
+      return '';
+    }
+    const line = card.querySelector('.formula-block .formula-line');
+    if (!line) {
+      return '';
+    }
+    const text = line.textContent || '';
+    return text.trim();
+  }
+
+  function updateTowerUpgradeGlyphDisplay() {
+    if (!towerUpgradeElements.glyphs) {
+      return;
+    }
+    const available = Math.max(0, Math.floor(glyphCurrency));
+    towerUpgradeElements.glyphs.textContent = `Available Glyphs: ${formatWholeNumber(available)}`;
+  }
+
+  function setTowerUpgradeNote(message, tone = '') {
+    if (!towerUpgradeElements.note) {
+      return;
+    }
+    towerUpgradeElements.note.textContent = message || '';
+    if (tone) {
+      towerUpgradeElements.note.dataset.tone = tone;
+    } else {
+      towerUpgradeElements.note.removeAttribute('data-tone');
+    }
+  }
+
+  function renderTowerUpgradeVariables(towerId, blueprint, values = {}) {
+    if (!towerUpgradeElements.variables) {
+      return;
+    }
+    const container = towerUpgradeElements.variables;
+    container.innerHTML = '';
+    const variables = blueprint?.variables || [];
+    const state = ensureTowerUpgradeState(towerId, blueprint);
+
+    if (!variables.length) {
+      const empty = document.createElement('p');
+      empty.className = 'tower-upgrade-variable-note';
+      empty.textContent = 'This lattice has no adjustable variables yet.';
+      container.append(empty);
+      return;
+    }
+
+    const fragment = document.createDocumentFragment();
+    variables.forEach((variable) => {
+      const value = Number.isFinite(values[variable.key]) ? values[variable.key] : 0;
+      const item = document.createElement('div');
+      item.className = 'tower-upgrade-variable';
+      item.setAttribute('role', 'listitem');
+
+      const header = document.createElement('div');
+      header.className = 'tower-upgrade-variable-header';
+
+      const symbol = document.createElement('span');
+      symbol.className = 'tower-upgrade-variable-symbol';
+      symbol.textContent = variable.symbol || variable.key.toUpperCase();
+      header.append(symbol);
+
+      const summary = document.createElement('div');
+      const name = document.createElement('p');
+      name.className = 'tower-upgrade-variable-name';
+      name.textContent = variable.name || `Variable ${variable.symbol || variable.key}`;
+      summary.append(name);
+
+      if (variable.description) {
+        const description = document.createElement('p');
+        description.className = 'tower-upgrade-variable-description';
+        description.textContent = variable.description;
+        summary.append(description);
+      }
+
+      header.append(summary);
+      item.append(header);
+
+      const footer = document.createElement('div');
+      footer.className = 'tower-upgrade-variable-footer';
+
+      const valueEl = document.createElement('span');
+      valueEl.className = 'tower-upgrade-variable-value';
+      valueEl.textContent = formatTowerVariableValue(variable, value);
+      footer.append(valueEl);
+
+      const level = state.variables?.[variable.key]?.level || 0;
+      const levelEl = document.createElement('span');
+      levelEl.className = 'tower-upgrade-variable-level';
+      levelEl.textContent = level ? `+${level}` : 'Base';
+      footer.append(levelEl);
+
+      if (variable.upgradable !== false) {
+        const cost = calculateTowerVariableUpgradeCost(variable, level);
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'tower-upgrade-variable-button';
+        button.dataset.upgradeVariable = variable.key;
+        button.textContent = cost === 1 ? 'Upgrade · 1 Glyph' : `Upgrade · ${cost} Glyphs`;
+        button.disabled = glyphCurrency < cost;
+        button.addEventListener('click', () => handleTowerVariableUpgrade(towerId, variable.key));
+        footer.append(button);
+      } else {
+        const note = document.createElement('span');
+        note.className = 'tower-upgrade-variable-note';
+        note.textContent = variable.lockedNote || 'Inherited from allied lattices.';
+        footer.append(note);
+      }
+
+      item.append(footer);
+      fragment.append(item);
+    });
+
+    container.append(fragment);
+  }
+
+  function renderTowerUpgradeOverlay(towerId, options = {}) {
+    if (!towerUpgradeElements.overlay) {
+      return;
+    }
+    const definition = getTowerDefinition(towerId);
+    if (!definition) {
+      return;
+    }
+
+    const blueprint = options.blueprint || getTowerEquationBlueprint(towerId);
+    if (!blueprint) {
+      return;
+    }
+
+    ensureTowerUpgradeState(towerId, blueprint);
+
+    const baseEquationText =
+      typeof options.baseEquationText === 'string' && options.baseEquationText.trim()
+        ? options.baseEquationText.trim()
+        : activeTowerUpgradeBaseEquation || blueprint.baseEquation || '';
+    activeTowerUpgradeBaseEquation = baseEquationText;
+
+    if (towerUpgradeElements.title) {
+      const label = `${definition.symbol ? `${definition.symbol} ` : ''}${definition.name || 'Tower'}`.trim();
+      towerUpgradeElements.title.textContent = label || 'Tower Equation';
+    }
+
+    if (towerUpgradeElements.tier) {
+      const tierLabel = Number.isFinite(definition.tier) ? `Tier ${definition.tier}` : '';
+      towerUpgradeElements.tier.textContent = tierLabel;
+    }
+
+    if (towerUpgradeElements.icon) {
+      towerUpgradeElements.icon.innerHTML = '';
+      if (definition.icon) {
+        const img = document.createElement('img');
+        img.src = definition.icon;
+        const iconLabel = `${definition.symbol ? `${definition.symbol} ` : ''}${definition.name || 'tower'}`.trim();
+        img.alt = iconLabel ? `${iconLabel} icon` : 'Tower icon';
+        img.loading = 'lazy';
+        img.decoding = 'async';
+        towerUpgradeElements.icon.hidden = false;
+        towerUpgradeElements.icon.append(img);
+      } else {
+        towerUpgradeElements.icon.hidden = true;
+      }
+    }
+
+    if (towerUpgradeElements.baseEquation) {
+      towerUpgradeElements.baseEquation.textContent = baseEquationText;
+      renderMathElement(towerUpgradeElements.baseEquation);
+    }
+
+    const values = {};
+    (blueprint.variables || []).forEach((variable) => {
+      values[variable.key] = computeTowerVariableValue(towerId, variable.key, blueprint);
+    });
+
+    let result = 0;
+    if (typeof blueprint.computeResult === 'function') {
+      result = blueprint.computeResult(values, { definition });
+    }
+    if (!Number.isFinite(result)) {
+      result = 0;
+    }
+
+    if (towerUpgradeElements.goldenEquation) {
+      const mathSymbol = blueprint.mathSymbol || definition.symbol || towerId;
+      const formatVariable = (key) => formatTowerVariableValue(getBlueprintVariable(blueprint, key), values[key]);
+      const formatResult = () => formatTowerEquationResultValue(result);
+      const goldenEquation =
+        typeof blueprint.formatGoldenEquation === 'function'
+          ? blueprint.formatGoldenEquation({
+              symbol: mathSymbol,
+              values,
+              result,
+              formatVariable,
+              formatResult,
+            })
+          : `\\( ${mathSymbol} = ${formatVariable('damage')} \\times ${formatVariable('rate')} = ${formatResult()} \\)`;
+      towerUpgradeElements.goldenEquation.textContent = goldenEquation;
+      renderMathElement(towerUpgradeElements.goldenEquation);
+    }
+
+    renderTowerUpgradeVariables(towerId, blueprint, values);
+    updateTowerUpgradeGlyphDisplay();
+  }
+
+  function openTowerUpgradeOverlay(towerId, options = {}) {
+    if (!towerId || !towerUpgradeElements.overlay) {
+      return;
+    }
+    const definition = getTowerDefinition(towerId);
+    if (!definition) {
+      return;
+    }
+
+    activeTowerUpgradeId = towerId;
+    invalidateTowerEquationCache();
+
+    const blueprint = getTowerEquationBlueprint(towerId);
+    ensureTowerUpgradeState(towerId, blueprint);
+
+    const sourceCard = options.sourceCard || null;
+    const baseEquationText =
+      blueprint?.baseEquation || (sourceCard ? extractTowerCardEquation(sourceCard) : '') || activeTowerUpgradeBaseEquation;
+    activeTowerUpgradeBaseEquation = baseEquationText;
+
+    const trigger = options.trigger && typeof options.trigger.focus === 'function' ? options.trigger : document.activeElement;
+    lastTowerUpgradeTrigger = trigger && typeof trigger.focus === 'function' ? trigger : null;
+
+    setTowerUpgradeNote('Invest glyphs to sculpt each variable toward your preferred proof.');
+
+    towerUpgradeElements.overlay.setAttribute('aria-hidden', 'false');
+    if (!towerUpgradeElements.overlay.classList.contains('active')) {
+      requestAnimationFrame(() => {
+        towerUpgradeElements.overlay.classList.add('active');
+      });
+    } else {
+      towerUpgradeElements.overlay.classList.add('active');
+    }
+
+    renderTowerUpgradeOverlay(towerId, { blueprint, baseEquationText, sourceCard });
+
+    const focusTarget = towerUpgradeElements.close || towerUpgradeElements.overlay;
+    if (focusTarget && typeof focusTarget.focus === 'function') {
+      try {
+        focusTarget.focus({ preventScroll: true });
+      } catch (error) {
+        focusTarget.focus();
+      }
+    }
+  }
+
+  function closeTowerUpgradeOverlay() {
+    if (!towerUpgradeElements.overlay) {
+      return;
+    }
+    towerUpgradeElements.overlay.classList.remove('active');
+    towerUpgradeElements.overlay.setAttribute('aria-hidden', 'true');
+
+    if (lastTowerUpgradeTrigger && typeof lastTowerUpgradeTrigger.focus === 'function') {
+      try {
+        lastTowerUpgradeTrigger.focus({ preventScroll: true });
+      } catch (error) {
+        lastTowerUpgradeTrigger.focus();
+      }
+    }
+    lastTowerUpgradeTrigger = null;
+    activeTowerUpgradeId = null;
+  }
+
+  function handleTowerVariableUpgrade(towerId, variableKey) {
+    const blueprint = getTowerEquationBlueprint(towerId);
+    if (!blueprint) {
+      return;
+    }
+    const variable = getBlueprintVariable(blueprint, variableKey);
+    if (!variable || variable.upgradable === false) {
+      return;
+    }
+
+    const state = ensureTowerUpgradeState(towerId, blueprint);
+    const currentLevel = state.variables?.[variableKey]?.level || 0;
+    const cost = calculateTowerVariableUpgradeCost(variable, currentLevel);
+    const normalizedCost = Math.max(1, cost);
+
+    if (glyphCurrency < normalizedCost) {
+      setTowerUpgradeNote('Not enough glyphs to reinforce this variable.', 'warning');
+      updateTowerUpgradeGlyphDisplay();
+      renderTowerUpgradeOverlay(towerId, { blueprint });
+      if (audioManager) {
+        audioManager.playSfx?.('error');
+      }
+      return;
+    }
+
+    glyphCurrency -= normalizedCost;
+    state.variables[variableKey].level = currentLevel + 1;
+    invalidateTowerEquationCache();
+    setTowerUpgradeNote(
+      `Invested ${normalizedCost} ${normalizedCost === 1 ? 'glyph' : 'glyphs'} into ${variable.symbol}.`,
+      'success',
+    );
+    if (audioManager) {
+      audioManager.playSfx?.('upgrade');
+    }
+    renderTowerUpgradeOverlay(towerId, { blueprint });
+  }
+
+  function bindTowerUpgradeOverlay() {
+    towerUpgradeElements.overlay = document.getElementById('tower-upgrade-overlay');
+    if (!towerUpgradeElements.overlay) {
+      return;
+    }
+    towerUpgradeElements.panel = towerUpgradeElements.overlay.querySelector('.tower-upgrade-panel');
+    towerUpgradeElements.close = towerUpgradeElements.overlay.querySelector('[data-tower-upgrade-close]');
+    towerUpgradeElements.title = document.getElementById('tower-upgrade-title');
+    towerUpgradeElements.tier = document.getElementById('tower-upgrade-tier');
+    towerUpgradeElements.glyphs = document.getElementById('tower-upgrade-glyphs');
+    towerUpgradeElements.baseEquation = document.getElementById('tower-upgrade-base');
+    towerUpgradeElements.goldenEquation = document.getElementById('tower-upgrade-golden');
+    towerUpgradeElements.variables = document.getElementById('tower-upgrade-variables');
+    towerUpgradeElements.note = document.getElementById('tower-upgrade-note');
+    towerUpgradeElements.icon = document.getElementById('tower-upgrade-icon');
+
+    if (!towerUpgradeElements.overlay.hasAttribute('tabindex')) {
+      towerUpgradeElements.overlay.setAttribute('tabindex', '-1');
+    }
+
+    if (towerUpgradeElements.close) {
+      towerUpgradeElements.close.addEventListener('click', () => {
+        closeTowerUpgradeOverlay();
+      });
+    }
+
+    towerUpgradeElements.overlay.addEventListener('click', (event) => {
+      if (event.target === towerUpgradeElements.overlay) {
+        closeTowerUpgradeOverlay();
+      }
+    });
+  }
+
+  function bindTowerCardUpgradeInteractions() {
+    const cards = document.querySelectorAll('[data-tower-id]');
+    cards.forEach((card) => {
+      if (!(card instanceof HTMLElement)) {
+        return;
+      }
+      if (card.dataset.upgradeBound === 'true') {
+        return;
+      }
+      card.dataset.upgradeBound = 'true';
+
+      card.addEventListener('click', (event) => {
+        if (event.target.closest('button')) {
+          return;
+        }
+        const towerId = card.dataset.towerId;
+        if (!towerId || card.dataset.locked === 'true') {
+          return;
+        }
+        openTowerUpgradeOverlay(towerId, { sourceCard: card, trigger: card });
+      });
+
+      card.addEventListener('keydown', (event) => {
+        if (event.target !== card) {
+          return;
+        }
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          const towerId = card.dataset.towerId;
+          if (!towerId || card.dataset.locked === 'true') {
+            return;
+          }
+          openTowerUpgradeOverlay(towerId, { sourceCard: card, trigger: card });
+        }
+      });
+    });
+  }
+
   function updateTowerCardVisibility() {
     const cards = document.querySelectorAll('[data-tower-id]');
     cards.forEach((card) => {
@@ -9888,6 +10667,8 @@ import {
         return;
       }
       const unlocked = isTowerUnlocked(towerId);
+      card.dataset.locked = unlocked ? 'false' : 'true';
+      card.setAttribute('tabindex', unlocked ? '0' : '-1');
       card.hidden = !unlocked;
       if (unlocked) {
         card.style.removeProperty('display');
@@ -10718,6 +11499,14 @@ import {
     const normalized = Math.max(0, Math.floor(count));
     gameStats.powderSigilsReached = Math.max(gameStats.powderSigilsReached, normalized);
     glyphCurrency = Math.max(glyphCurrency, normalized);
+    updateTowerUpgradeGlyphDisplay();
+    if (
+      activeTowerUpgradeId &&
+      towerUpgradeElements.overlay &&
+      towerUpgradeElements.overlay.classList.contains('active')
+    ) {
+      renderTowerUpgradeOverlay(activeTowerUpgradeId, {});
+    }
     updateStatusDisplays();
     evaluateAchievements();
   }
@@ -11773,6 +12562,8 @@ import {
 
     mergingLogicElements.card = document.getElementById('merging-logic-card');
 
+    bindTowerUpgradeOverlay();
+
     initializeTabs();
     initializeFieldNotesOverlay();
     bindCodexControls();
@@ -11851,6 +12642,7 @@ import {
     annotateTowerCardsWithCost();
     updateTowerCardVisibility();
     initializeTowerSelection();
+    bindTowerCardUpgradeInteractions();
     syncLoadoutToPlayfield();
     renderEnemyCodex();
 
@@ -11882,6 +12674,19 @@ import {
   window.addEventListener('beforeunload', markLastActive);
 
   document.addEventListener('keydown', (event) => {
+    if (towerUpgradeElements.overlay && towerUpgradeElements.overlay.classList.contains('active')) {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        closeTowerUpgradeOverlay();
+        return;
+      }
+      if ((event.key === 'Enter' || event.key === ' ') && event.target === towerUpgradeElements.overlay) {
+        event.preventDefault();
+        closeTowerUpgradeOverlay();
+        return;
+      }
+    }
+
     if (upgradeOverlay && upgradeOverlay.classList.contains('active')) {
       if (event.key === 'Escape') {
         event.preventDefault();

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1307,6 +1307,23 @@ body.color-scheme-chromatic::before {
   gap: 12px;
 }
 
+.card[data-tower-id][data-locked='false'] {
+  cursor: pointer;
+  transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
+}
+
+.card[data-tower-id][data-locked='false']:hover,
+.card[data-tower-id][data-locked='false']:focus-visible {
+  border-color: rgba(255, 215, 0, 0.35);
+  box-shadow: 0 18px 40px rgba(255, 215, 0, 0.18), var(--shadow);
+  transform: translateY(-4px);
+}
+
+.card[data-tower-id][data-locked='true'] {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
 .card--mind-gate {
   position: relative;
   overflow: hidden;
@@ -2304,6 +2321,211 @@ body.color-scheme-chromatic::before {
 
 .upgrade-overlay .overlay-instruction {
   margin-top: 18px;
+}
+
+.tower-upgrade-overlay .overlay-panel {
+  max-width: 600px;
+  width: min(92vw, 600px);
+  text-align: left;
+}
+
+.tower-upgrade-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.tower-upgrade-header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.tower-upgrade-icon {
+  width: 72px;
+  height: 72px;
+  margin: 0;
+  border-radius: 16px;
+  background: radial-gradient(circle at 50% 35%, rgba(255, 255, 255, 0.35), transparent 60%),
+    rgba(16, 16, 24, 0.82);
+  border: 1px solid rgba(255, 215, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.tower-upgrade-icon img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  filter: drop-shadow(0 0 12px rgba(255, 215, 0, 0.45));
+}
+
+.tower-upgrade-heading {
+  flex: 1;
+  min-width: 0;
+}
+
+.tower-upgrade-tier {
+  margin: 4px 0 8px;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.tower-upgrade-glyphs {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(255, 215, 0, 0.85);
+}
+
+.tower-upgrade-equations {
+  display: grid;
+  gap: 20px;
+}
+
+.tower-upgrade-equation {
+  padding: 18px 22px;
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(18, 18, 28, 0.88), rgba(26, 26, 40, 0.68));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.tower-upgrade-equation--gold {
+  background: linear-gradient(135deg, rgba(48, 32, 0, 0.9), rgba(88, 64, 12, 0.65));
+  border-color: rgba(255, 215, 0, 0.45);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
+}
+
+.tower-upgrade-equation-label {
+  margin: 0 0 6px;
+  font-size: 0.95rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.68);
+}
+
+.tower-upgrade-formula {
+  margin: 0;
+  font-size: 1.15rem;
+  color: rgba(255, 255, 255, 0.92);
+  font-family: 'Cormorant Garamond', 'Times New Roman', serif;
+}
+
+.tower-upgrade-variables {
+  display: grid;
+  gap: 16px;
+}
+
+.tower-upgrade-variable {
+  display: grid;
+  gap: 12px;
+  padding: 18px 22px;
+  border-radius: 18px;
+  background: rgba(16, 16, 24, 0.78);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.tower-upgrade-variable-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+}
+
+.tower-upgrade-variable-symbol {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 999px;
+  background: rgba(255, 215, 0, 0.18);
+  color: rgba(255, 215, 0, 0.95);
+  font-size: 1.1rem;
+  font-weight: 600;
+  font-family: 'Cormorant Garamond', 'Times New Roman', serif;
+}
+
+.tower-upgrade-variable-name {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.tower-upgrade-variable-description {
+  margin: 4px 0 0;
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.68);
+}
+
+.tower-upgrade-variable-footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.tower-upgrade-variable-value {
+  font-size: 1.05rem;
+  color: rgba(255, 255, 255, 0.9);
+  font-family: 'Space Mono', 'Courier New', monospace;
+}
+
+.tower-upgrade-variable-level {
+  font-size: 0.9rem;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(255, 215, 0, 0.18);
+  color: rgba(255, 215, 0, 0.9);
+}
+
+.tower-upgrade-variable-button {
+  margin-left: auto;
+  padding: 8px 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 215, 0, 0.42);
+  background: rgba(46, 34, 8, 0.75);
+  color: rgba(255, 215, 0, 0.96);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.tower-upgrade-variable-button:hover:not(:disabled),
+.tower-upgrade-variable-button:focus-visible:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 14px rgba(255, 215, 0, 0.28);
+}
+
+.tower-upgrade-variable-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.tower-upgrade-variable-note {
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.66);
+}
+
+.tower-upgrade-note {
+  margin: -8px 0 0;
+  min-height: 1.25rem;
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.tower-upgrade-note[data-tone='warning'] {
+  color: rgba(255, 180, 0, 0.85);
+}
+
+.tower-upgrade-note[data-tone='success'] {
+  color: rgba(108, 255, 208, 0.88);
 }
 
 .upgrade-matrix-grid {

--- a/index.html
+++ b/index.html
@@ -1418,6 +1418,50 @@
       </div>
     </div>
     <div
+      class="level-overlay tower-upgrade-overlay"
+      id="tower-upgrade-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-hidden="true"
+      aria-labelledby="tower-upgrade-title"
+    >
+      <div class="overlay-panel tower-upgrade-panel">
+        <button
+          class="overlay-close"
+          type="button"
+          data-tower-upgrade-close
+          aria-label="Close tower upgrade menu"
+        >
+          &times;
+        </button>
+        <p class="overlay-label">Glyph Variable Lattice</p>
+        <div class="tower-upgrade-header">
+          <figure class="tower-upgrade-icon" id="tower-upgrade-icon" aria-hidden="true"></figure>
+          <div class="tower-upgrade-heading">
+            <h2 class="overlay-title" id="tower-upgrade-title">Tower Equation</h2>
+            <p class="tower-upgrade-tier" id="tower-upgrade-tier"></p>
+            <p class="tower-upgrade-glyphs" id="tower-upgrade-glyphs">Available Glyphs: 0</p>
+          </div>
+        </div>
+        <div class="tower-upgrade-equations">
+          <section class="tower-upgrade-equation" aria-labelledby="tower-upgrade-base-label">
+            <h3 class="tower-upgrade-equation-label" id="tower-upgrade-base-label">Base Equation</h3>
+            <p class="tower-upgrade-formula" id="tower-upgrade-base"></p>
+          </section>
+          <section
+            class="tower-upgrade-equation tower-upgrade-equation--gold"
+            aria-labelledby="tower-upgrade-golden-label"
+          >
+            <h3 class="tower-upgrade-equation-label" id="tower-upgrade-golden-label">Golden Equation</h3>
+            <p class="tower-upgrade-formula" id="tower-upgrade-golden"></p>
+          </section>
+        </div>
+        <div class="tower-upgrade-variables" id="tower-upgrade-variables" role="list"></div>
+        <p class="tower-upgrade-note" id="tower-upgrade-note"></p>
+        <p class="overlay-instruction">Tap outside or press Esc to close.</p>
+      </div>
+    </div>
+    <div
       class="level-overlay field-notes-overlay"
       id="field-notes-overlay"
       role="dialog"


### PR DESCRIPTION
## Summary
- add a dedicated tower upgrade overlay that displays each tower's base and golden equations alongside glyph availability
- implement reusable equation blueprints and glyph-powered variable upgrades, including fallbacks for towers without bespoke math data
- update tower card interactions and styling to open the upgrade menu and reflect hover/focus affordances

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fc4d2e91dc832a8e09f9387e300a99