### PR TITLE
Update alpha tower equation to include dual attack speeds

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -40,38 +40,50 @@ import {
   const TOWER_EQUATION_BLUEPRINTS = {
     alpha: {
       mathSymbol: '\\alpha',
-      baseEquation: '\\( \\alpha = X \\cdot Y \\)',
+      baseEquation: '\\( \\alpha = 5X \\cdot YZ \\)',
       variables: [
         {
           key: 'damage',
           symbol: 'X',
           name: 'Attack Power',
           description: 'Projectile damage carried by each glyph bullet.',
-          stat: 'damage',
-          step: 4,
+          baseValue: 1,
+          step: 1,
           upgradable: true,
-          format: (value) => formatWholeNumber(value),
+          format: (value) => `${formatWholeNumber(value)} attack`,
           cost: (level) => Math.max(1, 1 + level),
         },
         {
           key: 'rate',
           symbol: 'Y',
-          name: 'Attack Speed',
+          name: 'Primary Attack Speed',
           description: 'Glyph pulses per second channelled through the lattice.',
-          stat: 'rate',
-          step: 0.1,
+          baseValue: 1,
+          step: 1,
           upgradable: true,
-          format: (value) => formatDecimal(value, 2),
-          cost: (level) => Math.max(1, 1 + Math.floor(level / 2)),
+          format: (value) => `${formatWholeNumber(value)} per second`,
+          cost: (level) => Math.max(1, 1 + level),
+        },
+        {
+          key: 'tempo',
+          symbol: 'Z',
+          name: 'Secondary Attack Speed',
+          description: 'Echo pulses per second braided into alpha tempo.',
+          baseValue: 1,
+          step: 1,
+          upgradable: true,
+          format: (value) => `${formatWholeNumber(value)} per second`,
+          cost: (level) => Math.max(1, 1 + level),
         },
       ],
       computeResult(values) {
         const damage = Number.isFinite(values.damage) ? values.damage : 0;
         const rate = Number.isFinite(values.rate) ? values.rate : 0;
-        return damage * rate;
+        const tempo = Number.isFinite(values.tempo) ? values.tempo : 0;
+        return 5 * damage * rate * tempo;
       },
       formatGoldenEquation({ symbol, formatVariable, formatResult }) {
-        return `\\( ${symbol} = ${formatVariable('damage')} \\times ${formatVariable('rate')} = ${formatResult()} \\)`;
+        return `\\( ${symbol} = 5 \\times ${formatVariable('damage')} \\times ${formatVariable('rate')} \\times ${formatVariable('tempo')} = ${formatResult()} \\)`;
       },
     },
     beta: {

--- a/index.html
+++ b/index.html
@@ -177,7 +177,7 @@
                   <li>Y → recovery (glyph-fed renewal)</li>
                 </ul>
                 <p class="formula-line result">
-                  Defaults: \( X = Y = 1 \). Each glyph invested increases a term by +1.
+                  Defaults: \( X = Y = Z = 1 \). Each glyph invested increases a term by +1.
                 </p>
               </div>
               <ul class="upgrade-list">
@@ -194,16 +194,18 @@
                 <h3>α alpha tower</h3>
               </header>
               <div class="formula-block">
-                <p class="formula-line">\( \alpha = X \cdot Y \)</p>
+                <p class="formula-line">\( \alpha = 5X \cdot YZ \)</p>
                 <ul class="formula-definition">
-                  <li>X → attack power</li>
-                  <li>Y → attack speed</li>
+                  <li>X → attack power (attack)</li>
+                  <li>Y → primary attack speed (per second)</li>
+                  <li>Z → secondary attack speed (per second)</li>
                 </ul>
-                <p class="formula-line result">\( \alpha = \text{DPS} \,(X \times Y) \)</p>
+                <p class="formula-line result">\( \alpha = \text{Glyph pressure } (5X \times Y \times Z) \)</p>
               </div>
               <ul class="upgrade-list">
                 <li>Calibrate X for sharper projectiles (+damage)</li>
                 <li>Accelerate Y through harmonic metronomes (+attack speed)</li>
+                <li>Sync Z with temporal echoes (+attack speed)</li>
               </ul>
               <footer class="card-footer">Shoots a focused glyph-bullet at the nearest foe.</footer>
               <button class="tower-equip-button" type="button" data-tower-toggle="alpha">


### PR DESCRIPTION
## Summary
- update the alpha tower blueprint to use the \(\alpha = 5X \cdot YZ\) formula with a secondary attack speed stat
- give X, Y, and Z a base value of 1 with +1 glyph upgrades while displaying attack and per-second units
- refresh the alpha tower card copy to describe the new tempo-driven variables

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68fc5c5af8b0832a95421dc4d3ade3cf