### PR TITLE
Add dynamic powder walls and fluid mode toggle

### DIFF
--- a/assets/data/towerFluidSimulation.json
+++ b/assets/data/towerFluidSimulation.json
@@ -1,0 +1,14 @@
+{
+  "id": "tower-fluid",
+  "label": "Fluid Resonance Study",
+  "grainSizes": [1, 1, 2],
+  "idleDrainRate": 1.6,
+  "baseSpawnInterval": 150,
+  "palette": {
+    "stops": ["#4fb8ff", "#76d5ff", "#c6f4ff"],
+    "restAlpha": 0.78,
+    "freefallAlpha": 0.5,
+    "backgroundTop": "#0b1324",
+    "backgroundBottom": "#10213a"
+  }
+}

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1467,6 +1467,33 @@ body.color-scheme-chromatic::before {
   color: rgba(247, 247, 245, 0.65);
 }
 
+.powder-mode-toggle {
+  align-self: center;
+  padding: 10px 24px;
+  font-family: "Space Mono", monospace;
+  font-size: 0.78rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent);
+  background: rgba(12, 14, 20, 0.85);
+  border: 1px solid rgba(139, 247, 255, 0.45);
+  border-radius: 999px;
+  transition: transform var(--transition), box-shadow var(--transition), color var(--transition);
+}
+
+.powder-mode-toggle:focus-visible,
+.powder-mode-toggle:hover {
+  color: rgba(255, 228, 120, 0.9);
+  box-shadow: 0 0 20px rgba(139, 247, 255, 0.25);
+  transform: translateY(-2px);
+}
+
+.powder-mode-toggle:disabled {
+  opacity: 0.6;
+  cursor: progress;
+  transform: none;
+}
+
 .powder-intro {
   margin: 0;
   font-size: 0.98rem;
@@ -1690,9 +1717,37 @@ body.color-scheme-chromatic::before {
   background-blend-mode: overlay, normal;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
   z-index: 1;
-  transition: box-shadow var(--transition), filter var(--transition), transform 0.45s ease-out;
+  transition:
+    width 0.6s ease,
+    box-shadow var(--transition),
+    filter var(--transition),
+    transform 0.45s ease-out;
   will-change: transform;
   overflow: hidden;
+}
+
+.powder-wall-hitbox {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  background: linear-gradient(180deg, rgba(120, 190, 255, 0.22), rgba(120, 190, 255, 0.04));
+  border: 1px dashed rgba(120, 190, 255, 0.45);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  z-index: 2;
+}
+
+.powder-wall-hitbox-left {
+  left: 0;
+}
+
+.powder-wall-hitbox-right {
+  right: 0;
+}
+
+.powder-wall-hitbox--visible {
+  opacity: 1;
 }
 
 .powder-wall-left {

--- a/index.html
+++ b/index.html
@@ -922,6 +922,11 @@
             <article class="card powder-simulation">
               <h3>Motefall Basin</h3>
               <div class="powder-basin" id="powder-basin">
+                <div
+                  class="powder-wall-hitbox powder-wall-hitbox-left"
+                  id="powder-wall-hitbox-left"
+                  aria-hidden="true"
+                ></div>
                 <div class="powder-wall powder-wall-left" id="powder-wall-left" aria-hidden="true">
                   <div class="powder-wall-marker" id="powder-wall-marker" data-height="Peak 0.00" aria-hidden="true"></div>
                   <div
@@ -938,6 +943,11 @@
                   role="img"
                   aria-label="Motefall basin simulation"
                 ></canvas>
+                <div
+                  class="powder-wall-hitbox powder-wall-hitbox-right"
+                  id="powder-wall-hitbox-right"
+                  aria-hidden="true"
+                ></div>
                 <div class="powder-wall powder-wall-right" id="powder-wall-right" aria-hidden="true">
                   <div class="powder-glyph-column" data-powder-glyph-column="right"></div>
                 </div>
@@ -945,6 +955,9 @@
               <p class="powder-footnote" id="powder-simulation-note">
                 Captured crest: 0.0% full · dune height h = 1.00 · largest grain —.
               </p>
+              <button class="powder-mode-toggle" type="button" id="powder-mode-toggle">
+                Switch to Fluid Study
+              </button>
             </article>
           </section>
           <section class="panel-grid powder-summary" aria-label="Flux overview reference">


### PR DESCRIPTION
## Summary
- implement dynamic tower wall spacing that responds to glyph progress and expose developer hitboxes for collision debugging
- add a fluid simulation profile with a UI toggle to swap between sand and water behaviors in the Motefall basin
- style the new mode toggle control and developer wall overlays to match the tower aesthetic

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fc7abb6f50832a942388dabdf99fb7