### PR TITLE
Prevent hidden overlays from intercepting playfield clicks

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -2233,6 +2233,10 @@ body.color-scheme-chromatic::before {
   z-index: 20;
 }
 
+.level-overlay:not(.active) .overlay-panel {
+  pointer-events: none;
+}
+
 .level-overlay.active {
   opacity: 1;
   pointer-events: auto;


### PR DESCRIPTION
## Summary
- disable pointer events on overlay panels whenever the overlay container is inactive
- ensure hidden field notes and other overlays no longer block interactions with the playfield

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd7b3054c4832ab5c6fa65077a72f1