### PR TITLE
Refine alpha tower equation presentation

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -84,7 +84,7 @@ import {
           baseValue: 1,
           step: 1,
           upgradable: true,
-          format: (value) => `${formatWholeNumber(value)} attack`,
+          format: (value) => `${formatWholeNumber(value)} atk`,
           cost: (level) => Math.max(1, 1 + level),
         },
         {
@@ -95,7 +95,7 @@ import {
           baseValue: 1,
           step: 1,
           upgradable: true,
-          format: (value) => `${formatWholeNumber(value)} per second`,
+          format: (value) => `${formatWholeNumber(value)} /s`,
           cost: (level) => Math.max(1, 1 + level),
         },
         {
@@ -106,7 +106,7 @@ import {
           baseValue: 1,
           step: 1,
           upgradable: true,
-          format: (value) => `${formatWholeNumber(value)} per second`,
+          format: (value) => `${formatWholeNumber(value)} /s`,
           cost: (level) => Math.max(1, 1 + level),
         },
       ],
@@ -116,8 +116,8 @@ import {
         const tempo = Number.isFinite(values.tempo) ? values.tempo : 0;
         return 5 * damage * rate * tempo;
       },
-      formatGoldenEquation({ symbol, formatVariable, formatResult }) {
-        return `\\( ${symbol} = 5 \\times ${formatVariable('damage')} \\times ${formatVariable('rate')} \\times ${formatVariable('tempo')} = ${formatResult()} \\)`;
+      formatGoldenEquation({ formatVariable, formatResult }) {
+        return `\\( ${formatResult()} = 5 \\times ${formatVariable('damage')} \\times ${formatVariable('rate')} \\times ${formatVariable('tempo')} \\)`;
       },
     },
     beta: {
@@ -172,8 +172,8 @@ import {
         const range = Number.isFinite(values.range) ? values.range : 0;
         return attackPower * attackSpeed * range;
       },
-      formatGoldenEquation({ symbol, formatVariable, formatResult }) {
-        return `\\( ${symbol} = ${formatVariable('attackPower')} \\times ${formatVariable('attackSpeed')} \\times ${formatVariable('range')} = ${formatResult()} \\)`;
+      formatGoldenEquation({ formatVariable, formatResult }) {
+        return `\\( ${formatResult()} = ${formatVariable('attackPower')} \\times ${formatVariable('attackSpeed')} \\times ${formatVariable('range')} \\)`;
       },
     },
     gamma: {
@@ -206,8 +206,8 @@ import {
         const betaValue = Math.max(0, Number.isFinite(values.beta) ? values.beta : 0);
         return Math.sqrt(alphaValue) * betaValue;
       },
-      formatGoldenEquation({ symbol, formatVariable, formatResult }) {
-        return `\\( ${symbol} = \\sqrt{${formatVariable('alpha')}} \\times ${formatVariable('beta')} = ${formatResult()} \\)`;
+      formatGoldenEquation({ formatVariable, formatResult }) {
+        return `\\( ${formatResult()} = \\sqrt{${formatVariable('alpha')}} \\times ${formatVariable('beta')} \\)`;
       },
     },
     delta: {
@@ -241,8 +241,8 @@ import {
         const lnComponent = Math.log(betaValue + 1);
         return gammaValue * lnComponent;
       },
-      formatGoldenEquation({ symbol, formatVariable, formatResult }) {
-        return `\\( ${symbol} = ${formatVariable('gamma')} \\times \\ln(${formatVariable('beta')} + 1) = ${formatResult()} \\)`;
+      formatGoldenEquation({ formatVariable, formatResult }) {
+        return `\\( ${formatResult()} = ${formatVariable('gamma')} \\times \\ln(${formatVariable('beta')} + 1) \\)`;
       },
     },
   };
@@ -10901,8 +10901,8 @@ import {
         const rate = Number.isFinite(values.rate) ? values.rate : 0;
         return damage * rate;
       },
-      formatGoldenEquation({ symbol, formatVariable, formatResult }) {
-        return `\\( ${symbol} = ${formatVariable('damage')} \\times ${formatVariable('rate')} = ${formatResult()} \\)`;
+      formatGoldenEquation({ formatVariable, formatResult }) {
+        return `\\( ${formatResult()} = ${formatVariable('damage')} \\times ${formatVariable('rate')} \\)`;
       },
     };
 

--- a/index.html
+++ b/index.html
@@ -176,9 +176,6 @@
                   <li>X → life (inspiration reservoir)</li>
                   <li>Y → recovery (glyph-fed renewal)</li>
                 </ul>
-                <p class="formula-line result">
-                  Defaults: \( X = Y = Z = 1 \). Each glyph invested increases a term by +1.
-                </p>
               </div>
               <ul class="upgrade-list">
                 <li>Fortify X to deepen the Mind Gate's stores of fading inspiration.</li>
@@ -196,11 +193,11 @@
               <div class="formula-block">
                 <p class="formula-line">\( \alpha = 5X \cdot YZ \)</p>
                 <ul class="formula-definition">
-                  <li>X → attack power (attack)</li>
-                  <li>Y → primary attack speed (per second)</li>
-                  <li>Z → secondary attack speed (per second)</li>
+                  <li>X → attack power (atk)</li>
+                  <li>Y → primary attack speed (/s)</li>
+                  <li>Z → secondary attack speed (/s)</li>
                 </ul>
-                <p class="formula-line result">\( \alpha = \text{Glyph pressure } (5X \times Y \times Z) \)</p>
+                <p class="formula-line result">\( \alpha = 5X \times Y \times Z \)</p>
               </div>
               <ul class="upgrade-list">
                 <li>Calibrate X for sharper projectiles (+damage)</li>


### PR DESCRIPTION
## Summary
- remove the default glyph note from the tower card
- update alpha tower labels to use atk and /s terminology
- show tower golden equations with the computed result on the left

## Testing
- not run (UI text update)


------
https://chatgpt.com/codex/tasks/task_e_68fd7f00411c832a98bf3580eaeaa0f3