### PR TITLE
Fix field notes overlay initial state and tower cost symbol

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -10053,7 +10053,7 @@ import {
 
       const cost = document.createElement('span');
       cost.className = 'upgrade-matrix-cost';
-      cost.textContent = `${formatGameNumber(definition.baseCost)} Ψ`;
+      cost.textContent = `${formatGameNumber(definition.baseCost)} ${THERO_SYMBOL}`;
 
       const nextTier = document.createElement('span');
       nextTier.className = 'upgrade-matrix-next';
@@ -11532,7 +11532,7 @@ import {
         return;
       }
 
-      const formattedCost = `${formatGameNumber(definition.baseCost)} Ψ`;
+      const formattedCost = `${formatGameNumber(definition.baseCost)} ${THERO_SYMBOL}`;
       let costEl = card.querySelector('.tower-cost');
       if (!costEl) {
         costEl = document.createElement('p');

--- a/index.html
+++ b/index.html
@@ -1480,6 +1480,7 @@
       aria-modal="true"
       aria-hidden="true"
       tabindex="-1"
+      hidden
     >
       <div class="overlay-panel field-notes-panel" role="document" aria-labelledby="field-notes-title">
         <button class="overlay-close" type="button" id="field-notes-close" aria-label="Close field notes">×</button>


### PR DESCRIPTION
## Summary
- hide the field notes overlay by default so it cannot intercept pointer events when scripts are inactive
- show tower base costs with the Thero currency symbol instead of the glyph currency

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd84736140832a9d906d53f295fc5a