### PR TITLE
Reduce mobile tab bar blur to prevent iOS crashes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # Thero Idle – Agent Guide
 
+**Live build:** https://sethrimer3.github.io/Thero_Idle_TD/
+
 Welcome to the Thero Idle project. This document provides shared context and
 conventions for all AI collaborators working anywhere inside this repository.
 

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -3096,6 +3096,15 @@ body.color-scheme-chromatic::before {
   backdrop-filter: blur(18px);
 }
 
+@media (max-width: 768px) {
+  .tab-bar {
+    /* iOS Safari was crashing while scrolling long panels when compositing the sticky tab bar.
+       Removing the blur on smaller viewports avoids the expensive backdrop filter. */
+    backdrop-filter: none;
+    background: rgba(10, 10, 16, 0.95);
+  }
+}
+
 .tab-button {
   border: 1px solid rgba(255, 255, 255, 0.14);
   background: transparent;


### PR DESCRIPTION
## Summary
- disable the sticky tab bar's backdrop blur on narrow/mobile viewports
- document the change to clarify that it mitigates iOS Safari scroll crashes

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68fe0276eb74832ab4dd6ae6b5a3a795