### PR TITLE
Align motes with palette gradient and adjust defaults

### DIFF
--- a/index.html
+++ b/index.html
@@ -1222,7 +1222,7 @@
                 <div class="slider-row">
                   <div class="slider-row-header">
                     <label class="slider-label" for="music-volume">Music</label>
-                    <span class="slider-value" id="music-volume-value">60%</span>
+                    <span class="slider-value" id="music-volume-value">50%</span>
                   </div>
                   <input
                     class="slider-input"
@@ -1231,14 +1231,14 @@
                     min="0"
                     max="100"
                     step="1"
-                    value="60"
+                    value="50"
                     aria-label="Music volume"
                   />
                 </div>
                 <div class="slider-row">
                   <div class="slider-row-header">
                     <label class="slider-label" for="sfx-volume">Sound Effects</label>
-                    <span class="slider-value" id="sfx-volume-value">85%</span>
+                    <span class="slider-value" id="sfx-volume-value">50%</span>
                   </div>
                   <input
                     class="slider-input"
@@ -1247,7 +1247,7 @@
                     min="0"
                     max="100"
                     step="1"
-                    value="85"
+                    value="50"
                     aria-label="Sound effects volume"
                   />
                 </div>


### PR DESCRIPTION
## Summary
- set the idle mote bank to start at 100 and default both music and sfx volumes to 50%
- derive mote colors from the active palette gradient so grain size follows the selected color scheme

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fe13db80b4832a83a06554dafdf671