### PR TITLE
Disable status bar blur on mobile to avoid Safari crash

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -3103,6 +3103,13 @@ body.color-scheme-chromatic::before {
     backdrop-filter: none;
     background: rgba(10, 10, 16, 0.95);
   }
+
+  .status-bar {
+    /* Matching the tab bar workaround above: iOS Safari was still crashing when
+       long tower/stage/codex panels scrolled behind the blurred status bar. */
+    backdrop-filter: none;
+    background: rgba(10, 10, 16, 0.95);
+  }
 }
 
 .tab-button {


### PR DESCRIPTION
## Summary
- remove the status bar backdrop blur on small viewports to match the existing tab bar workaround
- avoid iOS Safari crashes that occurred when scrolling long tower, stage, and codex panels

## Testing
- not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68fe38e32928832a99889037ba09b606