### PR TITLE
Reduce mobile blur effects to stabilize Safari

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -3110,6 +3110,18 @@ body.color-scheme-chromatic::before {
     backdrop-filter: none;
     background: rgba(10, 10, 16, 0.95);
   }
+
+  .offline-overlay {
+    /* Disable heavy blur layers on mobile Safari to avoid GPU exhaustion when scrolling overlays. */
+    backdrop-filter: none;
+    background: rgba(3, 3, 5, 0.96);
+  }
+
+  .playfield-stats {
+    /* Mirroring the blur removal elsewhere so the mobile renderer keeps compositing costs low. */
+    backdrop-filter: none;
+    background: rgba(10, 10, 16, 0.82);
+  }
 }
 
 .tab-button {


### PR DESCRIPTION
## Summary
- disable the remaining backdrop-filter layers on mobile panels that were triggering Safari crashes
- provide opaque fallback backgrounds for the offline overlay and playfield stats so text stays legible without the blur

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68fe3beb00a0832aa17f3fac7dd681af