### PR TITLE
Scale powder cell size with device pixel ratio

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -3168,8 +3168,13 @@ import {
     constructor(options = {}) {
       this.canvas = options.canvas || null;
       this.ctx = this.canvas ? this.canvas.getContext('2d') : null;
-      this.cellSize = Math.max(1, Math.round(options.cellSize || POWDER_CELL_SIZE_PX));
-      // One powder unit spans a single pixel to highlight fine-grained mote flow.
+      const baseCellSize = Number.isFinite(options.cellSize) && options.cellSize > 0
+        ? options.cellSize
+        : POWDER_CELL_SIZE_PX;
+      const deviceScale = window.devicePixelRatio || 1;
+      this.cellSize = Math.max(1, Math.round(baseCellSize * deviceScale));
+      this.deviceScale = deviceScale;
+      // Scale the base unit by device pixel ratio so motes stay visually consistent across screens.
       this.grainSizes = Array.isArray(options.grainSizes)
         ? options.grainSizes.filter((size) => Number.isFinite(size) && size >= 1)
         : [1, 2, 3];


### PR DESCRIPTION
## Summary
- scale the powder simulation cell size by the device pixel ratio so mote size is consistent across displays
- store the resolved device scale on the simulation instance for future use and document the new behavior

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fe44110f88832ab2fa473b63add981