### PR TITLE
Add level achievements grid and developer resource controls

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -2156,53 +2156,79 @@ body.color-scheme-chromatic::before {
   text-align: center;
 }
 
-.achievement-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+.achievement-grid {
+  margin-top: 18px;
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.achievement-tile {
+  appearance: none;
+  border: 1px solid var(--panel-border);
+  border-radius: 16px;
+  background: rgba(10, 10, 16, 0.65);
+  box-shadow: var(--shadow);
+  color: inherit;
+  padding: 18px 16px;
   display: flex;
   flex-direction: column;
-  gap: 16px;
-}
-
-.achievement-list li {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 18px;
   align-items: center;
-  padding: 16px 20px;
-  border-radius: 16px;
-  border: 1px solid var(--panel-border);
-  background: rgba(10, 10, 16, 0.7);
-  box-shadow: var(--shadow);
+  gap: 10px;
+  text-align: center;
   transition: border-color 160ms ease, background 160ms ease, transform 160ms ease;
+  cursor: pointer;
 }
 
-.achievement-badge {
-  width: 48px;
-  height: 48px;
+.achievement-tile:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.achievement-icon {
+  width: 54px;
+  height: 54px;
+  border-radius: 50%;
   display: grid;
   place-items: center;
-  border-radius: 50%;
   background: linear-gradient(120deg, var(--accent), var(--accent-2));
   color: var(--bg);
   font-family: "Space Mono", monospace;
-  font-size: 1.4rem;
+  font-size: 1.5rem;
 }
 
-.achievement-title {
+.achievement-label {
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.achievement-detail {
+  width: 100%;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.achievement-subtitle {
   margin: 0;
-  font-size: 1.2rem;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(247, 247, 245, 0.6);
 }
 
-.achievement-sub {
-  margin: 4px 0 0;
+.achievement-description {
+  margin: 0;
   font-size: 0.9rem;
   color: var(--muted);
 }
 
 .achievement-status {
-  margin: 6px 0 0;
+  margin: 0;
   font-size: 0.85rem;
   color: var(--muted);
   font-family: "Space Mono", monospace;
@@ -2210,14 +2236,71 @@ body.color-scheme-chromatic::before {
   text-transform: uppercase;
 }
 
-.achievement-list li.achievement-unlocked {
+.achievement-tile.achievement-unlocked {
   border-color: rgba(255, 228, 120, 0.6);
   background: rgba(32, 28, 12, 0.75);
   transform: translateY(-2px);
 }
 
-.achievement-list li.achievement-unlocked .achievement-status {
+.achievement-tile.achievement-unlocked .achievement-status {
   color: rgba(255, 228, 120, 0.95);
+}
+
+.achievement-tile.expanded {
+  grid-column: 1 / -1;
+  align-items: flex-start;
+  text-align: left;
+}
+
+.developer-control-panel {
+  margin-top: 12px;
+  padding: 16px;
+  border-radius: 14px;
+  border: 1px solid var(--panel-border);
+  background: rgba(10, 10, 16, 0.6);
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.developer-control-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.developer-control-field label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(247, 247, 245, 0.7);
+}
+
+.developer-control-field input {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(6, 6, 10, 0.8);
+  color: inherit;
+  font-family: "Space Mono", monospace;
+  font-size: 0.95rem;
+}
+
+.developer-control-field input:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.developer-control-field input:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.developer-control-hint {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--muted);
 }
 
 .level-overlay {

--- a/index.html
+++ b/index.html
@@ -859,23 +859,6 @@
               </button>
             </article>
 
-            <article class="card developer-card" id="developer-mote-tower" hidden aria-hidden="true">
-              <header class="tower-header">
-                <span class="tower-tier">Developer Utility</span>
-                <h3>Σ mote tower</h3>
-              </header>
-              <div class="formula-block">
-                <p class="formula-line">\( \Delta m = 1000 \)</p>
-                <p class="formula-line result">Instant mote deposit for rapid flux calibration.</p>
-              </div>
-              <p class="tower-utility-note" id="developer-mote-tower-status" aria-live="polite">
-                Developer mote tower ready—store +1,000 motes in the idle bank.
-              </p>
-              <button class="tower-equip-button" type="button" id="developer-mote-tower-button">
-                Store +1,000 motes
-              </button>
-            </article>
-
             <article class="card" id="merging-logic-card" hidden aria-hidden="true">
               <header class="tower-header">
                 <span class="tower-tier">Convergence</span>
@@ -1118,91 +1101,10 @@
         >
           <header class="panel-header">Achievements</header>
           <p class="achievement-note">
-            Each seal increases motefall by <strong>+1 grain per minute</strong>.
-            Idle minutes are multiplied by unlocked seals and dumped when you return.
+            Each sealed proof adds <strong>+1 mote per minute</strong> to the idle bank. Tap an icon to
+            review its victory details.
           </p>
-          <ul class="achievement-list">
-            <li data-achievement-id="first-orbit">
-              <span class="achievement-badge">∞</span>
-              <div>
-                <p class="achievement-title">First Orbit</p>
-                <p class="achievement-sub">
-                  Seal the Lemniscate Hypothesis once to prove you can hold the spiral.
-                </p>
-                <p class="achievement-status">Locked · +1 Motes/min on unlock.</p>
-              </div>
-            </li>
-            <li data-achievement-id="circle-seer">
-              <span class="achievement-badge">π</span>
-              <div>
-                <p class="achievement-title">Circle Seer</p>
-                <p class="achievement-sub">
-                  Maintain three α towers at once—concentric glyph rings stabilize your vision.
-                </p>
-                <p class="achievement-status">Locked · +1 Motes/min on unlock.</p>
-              </div>
-            </li>
-            <li data-achievement-id="series-summoner">
-              <span class="achievement-badge">∑</span>
-              <div>
-                <p class="achievement-title">Series Summoner</p>
-                <p class="achievement-sub">
-                  Drive the mote rituals to a ×1.25 total multiplier or higher.
-                </p>
-                <p class="achievement-status">Locked · +1 Motes/min on unlock.</p>
-              </div>
-            </li>
-            <li data-achievement-id="zero-hunter">
-              <span class="achievement-badge">ζ</span>
-              <div>
-                <p class="achievement-title">Zero Hunter</p>
-                <p class="achievement-sub">
-                  Defeat 30 invading glyphs—zeros fall when persistence converges.
-                </p>
-                <p class="achievement-status">Locked · +1 Motes/min on unlock.</p>
-              </div>
-            </li>
-            <li data-achievement-id="golden-mentor">
-              <span class="achievement-badge">Φ</span>
-              <div>
-                <p class="achievement-title">Golden Mentor</p>
-                <p class="achievement-sub">
-                  Auto-lattice every suggested anchor to teach the grid your golden ratios.
-                </p>
-                <p class="achievement-status">Locked · +1 Motes/min on unlock.</p>
-              </div>
-            </li>
-            <li data-achievement-id="powder-archivist">
-              <span class="achievement-badge">Ψ</span>
-              <div>
-                <p class="achievement-title">Mote Archivist</p>
-                <p class="achievement-sub">
-                  Illuminate three sand sigils on the wall to archive the dunes.
-                </p>
-                <p class="achievement-status">Locked · +1 Motes/min on unlock.</p>
-              </div>
-            </li>
-            <li data-achievement-id="keystone-keeper">
-              <span class="achievement-badge">Ω</span>
-              <div>
-                <p class="achievement-title">Keystone Keeper</p>
-                <p class="achievement-sub">
-                  Complete any idle auto-run to bind a keystone into the archives.
-                </p>
-                <p class="achievement-status">Locked · +1 Motes/min on unlock.</p>
-              </div>
-            </li>
-            <li data-achievement-id="temporal-sifter">
-              <span class="achievement-badge">Δ</span>
-              <div>
-                <p class="achievement-title">Temporal Sifter</p>
-                <p class="achievement-sub">
-                  Maintain idle auto-runs for 10 cumulative minutes and sift the bonus motes.
-                </p>
-                <p class="achievement-status">Locked · +1 Motes/min on unlock.</p>
-              </div>
-            </li>
-          </ul>
+          <div class="achievement-grid" id="achievement-grid" role="list"></div>
         </section>
 
         <section
@@ -1313,6 +1215,56 @@
               <p class="developer-mode-note" id="codex-developer-note" hidden>
                 Developer mode active: all content is unlocked for rapid iteration.
               </p>
+              <div class="developer-control-panel" id="developer-control-panel" hidden aria-hidden="true">
+                <div class="developer-control-field">
+                  <label for="developer-mote-bank">Idle mote bank</label>
+                  <input
+                    type="number"
+                    id="developer-mote-bank"
+                    data-developer-field="moteBank"
+                    min="0"
+                    step="1"
+                    inputmode="numeric"
+                  />
+                  <p class="developer-control-hint">Override the stored mote reserve.</p>
+                </div>
+                <div class="developer-control-field">
+                  <label for="developer-mote-rate">Mote fall rate</label>
+                  <input
+                    type="number"
+                    id="developer-mote-rate"
+                    data-developer-field="moteRate"
+                    min="0"
+                    step="0.01"
+                    inputmode="decimal"
+                  />
+                  <p class="developer-control-hint">Set motes dispensed per second.</p>
+                </div>
+                <div class="developer-control-field">
+                  <label for="developer-start-thero">Base start þ</label>
+                  <input
+                    type="number"
+                    id="developer-start-thero"
+                    data-developer-field="startThero"
+                    min="0"
+                    step="1"
+                    inputmode="numeric"
+                  />
+                  <p class="developer-control-hint">Adjust starting Thero before multipliers.</p>
+                </div>
+                <div class="developer-control-field">
+                  <label for="developer-glyphs">Glyph reserves</label>
+                  <input
+                    type="number"
+                    id="developer-glyphs"
+                    data-developer-field="glyphs"
+                    min="0"
+                    step="1"
+                    inputmode="numeric"
+                  />
+                  <p class="developer-control-hint">Set total glyph currency available.</p>
+                </div>
+              </div>
             </div>
             <p class="enemy-codex-note" id="enemy-codex-empty">Encounter enemies to unlock their entries.</p>
             <p class="enemy-codex-note" id="enemy-codex-note" hidden>


### PR DESCRIPTION
## Summary
- replace the developer mote tower with an adjustable resource control panel for idle motes, fall rate, base Thero, and glyph reserves
- generate one achievement per level and render them as an expandable icon grid linked to level completion
- refresh styles and markup to support the new achievements matrix and developer controls

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fe56c9def8832a86c4c52f0a282d36