### PR TITLE
Scale mote visuals by 3x

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -3298,6 +3298,7 @@ import {
   };
 
   const POWDER_CELL_SIZE_PX = 1;
+  const MOTE_RENDER_SCALE = 3;
   const powderGlyphColumns = [];
   let powderWallMetrics = null;
 
@@ -4372,11 +4373,13 @@ import {
 
       const cellSizePx = this.cellSize;
       for (const grain of this.grains) {
-        const px = grain.x * cellSizePx;
-        const py = grain.y * cellSizePx;
-        const sizePx = grain.size * cellSizePx;
+        const baseSizePx = grain.size * cellSizePx;
+        const sizePx = baseSizePx * MOTE_RENDER_SCALE;
+        const offsetPx = (sizePx - baseSizePx) / 2;
+        const px = grain.x * cellSizePx - offsetPx;
+        const py = grain.y * cellSizePx - offsetPx;
 
-        if (py >= this.height || px >= this.width || py + sizePx <= 0) {
+        if (py >= this.height || px >= this.width || py + sizePx <= 0 || px + sizePx <= 0) {
           continue;
         }
 


### PR DESCRIPTION
## Summary
- enlarge mote rendering by introducing a configurable 3x render scale
- center mote sprites using offsets so the enlargement remains balanced
- update offscreen culling to account for the wider render footprint

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fe6bf797e0832ab542fd4381d58470