### PR TITLE
Fix level preview sizing when overlay opens

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -5441,6 +5441,24 @@ import {
         this.hoverPlacement = null;
         this.pointerPosition = null;
         this.syncCanvasSize();
+        if (typeof window !== 'undefined') {
+          const activeLevelId = this.levelConfig?.id;
+          const attemptSync = () => {
+            if (!this.previewOnly) {
+              return;
+            }
+            if (!this.levelConfig || this.levelConfig.id !== activeLevelId) {
+              return;
+            }
+            const rect = this.canvas ? this.canvas.getBoundingClientRect() : null;
+            if (!rect || rect.width < 2 || rect.height < 2) {
+              window.requestAnimationFrame(attemptSync);
+              return;
+            }
+            this.syncCanvasSize();
+          };
+          window.requestAnimationFrame(attemptSync);
+        }
         return;
       }
 


### PR DESCRIPTION
## Summary
- ensure the simple playfield preview resizes after the overlay becomes visible so canvases are larger than 1×1

## Testing
- Manual: Verified the Lemniscate Hypothesis overlay shows the animated path preview.


------
https://chatgpt.com/codex/tasks/task_e_68fe797135ac832ab9db7881f46294db