### PR TITLE
Prevent powder basin resize from collapsing hidden motes

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -3703,10 +3703,32 @@ import {
       }
       const hadGrains = Array.isArray(this.grains) && this.grains.length > 0;
       const ratio = window.devicePixelRatio || 1;
+      const rect =
+        typeof this.canvas.getBoundingClientRect === 'function'
+          ? this.canvas.getBoundingClientRect()
+          : null;
+      const measuredWidth = rect && Number.isFinite(rect.width) ? rect.width : this.canvas.clientWidth;
+      const measuredHeight = rect && Number.isFinite(rect.height) ? rect.height : this.canvas.clientHeight;
+      const previousWidth = Number.isFinite(this.width) ? this.width : 0;
+      const previousHeight = Number.isFinite(this.height) ? this.height : 0;
       const attrWidth = Number.parseFloat(this.canvas.getAttribute('width')) || 0;
       const attrHeight = Number.parseFloat(this.canvas.getAttribute('height')) || 0;
-      const displayWidth = Math.max(200, this.canvas.clientWidth || attrWidth || 240);
-      const displayHeight = Math.max(260, this.canvas.clientHeight || attrHeight || 320);
+      const normalizedAttrWidth =
+        attrWidth && previousWidth > 0 ? attrWidth / ratio : attrWidth;
+      const normalizedAttrHeight =
+        attrHeight && previousHeight > 0 ? attrHeight / ratio : attrHeight;
+
+      let displayWidth = Number.isFinite(measuredWidth) && measuredWidth > 0 ? measuredWidth : 0;
+      if (displayWidth <= 0) {
+        displayWidth = previousWidth || normalizedAttrWidth || 240;
+      }
+      let displayHeight = Number.isFinite(measuredHeight) && measuredHeight > 0 ? measuredHeight : 0;
+      if (displayHeight <= 0) {
+        displayHeight = previousHeight || normalizedAttrHeight || 320;
+      }
+
+      displayWidth = Math.max(200, displayWidth);
+      displayHeight = Math.max(260, displayHeight);
 
       this.canvas.width = Math.max(1, Math.floor(displayWidth * ratio));
       this.canvas.height = Math.max(1, Math.floor(displayHeight * ratio));


### PR DESCRIPTION
## Summary
- preserve the previous canvas size when the powder basin is hidden so wall metrics do not collapse
- fall back to the last measured width/height instead of zero measurements to avoid squishing stored motes

## Testing
- not run (UI change)

------
https://chatgpt.com/codex/tasks/task_e_68fe7ff94094832a9375cd78c991a5df