### PR TITLE
Refactor shared math utilities into modules

### DIFF
--- a/scripts/core/formatting.js
+++ b/scripts/core/formatting.js
@@ -1,0 +1,95 @@
+/**
+ * Formatting helpers shared across UI components so numbers stay consistent.
+ */
+
+/**
+ * Lookup for scientific suffixes when presenting large numbers to players.
+ */
+const numberSuffixes = [
+  '',
+  'K',
+  'M',
+  'B',
+  'T',
+  'Qa',
+  'Qi',
+  'Sx',
+  'Sp',
+  'Oc',
+  'No',
+  'Dc',
+];
+
+/**
+ * Formats arbitrary values using the suffix table for readability.
+ * @param {number} value Raw value sourced from gameplay stats.
+ * @returns {string} Nicely formatted number string.
+ */
+export function formatGameNumber(value) {
+  if (!Number.isFinite(value)) {
+    return '0';
+  }
+
+  const absolute = Math.abs(value);
+  if (absolute < 1) {
+    return value.toFixed(2);
+  }
+
+  const tier = Math.min(
+    Math.floor(Math.log10(absolute) / 3),
+    numberSuffixes.length - 1,
+  );
+  const scaled = value / 10 ** (tier * 3);
+  const precision = scaled >= 100 ? 0 : scaled >= 10 ? 1 : 2;
+  const formatted = scaled.toFixed(precision);
+  const suffix = numberSuffixes[tier];
+  return suffix ? `${formatted} ${suffix}` : formatted;
+}
+
+/**
+ * Formats a value as a non-negative whole number with locale separators.
+ * @param {number} value Raw value provided by the engine.
+ * @returns {string} Whole number string safe for UI display.
+ */
+export function formatWholeNumber(value) {
+  if (!Number.isFinite(value)) {
+    return '0';
+  }
+  return Math.round(Math.max(0, value)).toLocaleString('en-US');
+}
+
+/**
+ * Formats floating point values with a predictable number of digits.
+ * @param {number} value Number to display.
+ * @param {number} digits Decimal precision to retain.
+ * @returns {string} Decimal formatted string.
+ */
+export function formatDecimal(value, digits = 2) {
+  if (!Number.isFinite(value)) {
+    return '0.00';
+  }
+  return value.toFixed(digits);
+}
+
+/**
+ * Formats values as percentages while picking sensible precision automatically.
+ * @param {number} value Ratio expressed as a unit interval.
+ * @returns {string} Percentage text without sign enforcement.
+ */
+export function formatPercentage(value) {
+  const percent = value * 100;
+  const digits = Math.abs(percent) >= 10 ? 1 : 2;
+  return `${percent.toFixed(digits)}%`;
+}
+
+/**
+ * Formats values as signed percentages to communicate buffs/debuffs.
+ * @param {number} value Ratio expressed as a unit interval.
+ * @returns {string} Percentage text with a + or − sign.
+ */
+export function formatSignedPercentage(value) {
+  const percent = value * 100;
+  const digits = Math.abs(percent) >= 10 ? 1 : 2;
+  const sign = percent >= 0 ? '+' : '';
+  return `${sign}${percent.toFixed(digits)}%`;
+}

--- a/scripts/core/mathText.js
+++ b/scripts/core/mathText.js
@@ -1,0 +1,199 @@
+/**
+ * Provides helpers for rendering and parsing math flavoured text so the rest of the
+ * UI code can stay focused on gameplay concerns.
+ */
+
+/**
+ * Regular expression that captures characters typically associated with math
+ * expressions so we can quickly decide if text needs special formatting.
+ */
+export const MATH_SYMBOL_REGEX = /[\\^_=+\-*{}]|[0-9]|[×÷±√∞∑∏∆∇∂→←↺⇥]|[α-ωΑ-Ωℵ℘ℏℙℚℝℤℂℑℜητβγΩΣΨΔφϕλψρμνσπθ]/u;
+
+/**
+ * Sends a DOM element through MathJax so TeX expressions render elegantly.
+ * @param {HTMLElement|null} element Element that potentially contains TeX text.
+ */
+export function renderMathElement(element) {
+  if (!element) {
+    return;
+  }
+
+  const mathJax = window.MathJax;
+  if (!mathJax) {
+    return;
+  }
+
+  const typeset = () => {
+    if (typeof mathJax.typesetPromise === 'function') {
+      mathJax.typesetPromise([element]).catch((error) => {
+        console.warn('MathJax typeset failed', error);
+      });
+    }
+  };
+
+  if (mathJax.startup && mathJax.startup.promise) {
+    mathJax.startup.promise.then(typeset);
+  } else {
+    typeset();
+  }
+}
+
+/**
+ * Determines if the provided string should be treated as a math expression.
+ * @param {string} text Text pulled from tooltips or blueprint metadata.
+ * @returns {boolean} True when the text likely contains math markup.
+ */
+export function isLikelyMathExpression(text) {
+  if (!text) {
+    return false;
+  }
+  if (text.startsWith('\\(') || text.startsWith('\\[')) {
+    return true;
+  }
+  if (MATH_SYMBOL_REGEX.test(text)) {
+    return true;
+  }
+  if (/\b(?:sin|cos|tan|log|exp|sqrt)\b/i.test(text)) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Converts inline parenthetical expressions into MathJax friendly delimiters.
+ * @param {string} text Source string supplied by designers.
+ * @returns {string} Annotated text ready for MathJax.
+ */
+export function annotateMathText(text) {
+  if (typeof text !== 'string' || text.indexOf('(') === -1) {
+    return text;
+  }
+
+  let output = '';
+  let outsideBuffer = '';
+  let insideBuffer = '';
+  let depth = 0;
+
+  const flushOutside = () => {
+    if (outsideBuffer) {
+      output += outsideBuffer;
+      outsideBuffer = '';
+    }
+  };
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+
+    if (char === '(') {
+      if (depth === 0) {
+        flushOutside();
+        insideBuffer = '';
+      } else {
+        insideBuffer += char;
+      }
+      depth += 1;
+      continue;
+    }
+
+    if (char === ')') {
+      if (depth === 0) {
+        outsideBuffer += char;
+        continue;
+      }
+      depth -= 1;
+      if (depth === 0) {
+        const content = insideBuffer;
+        const trimmed = content.trim();
+        if (!trimmed) {
+          output += '()';
+        } else if (isLikelyMathExpression(trimmed)) {
+          output += `\\(${trimmed}\\)`;
+        } else {
+          output += `(${content})`;
+        }
+        insideBuffer = '';
+      } else {
+        insideBuffer += char;
+      }
+      continue;
+    }
+
+    if (depth === 0) {
+      outsideBuffer += char;
+    } else {
+      insideBuffer += char;
+    }
+  }
+
+  if (insideBuffer && depth > 0) {
+    output += `(${insideBuffer}`;
+  }
+
+  if (outsideBuffer) {
+    output += outsideBuffer;
+  }
+
+  return output;
+}
+
+/**
+ * Converts simple TeX commands into plain text so we can generate fallbacks.
+ * @param {string} expression MathJax flavoured expression.
+ * @returns {string} Plain text version for DOM inspection.
+ */
+export function convertMathExpressionToPlainText(expression) {
+  if (typeof expression !== 'string') {
+    return '';
+  }
+
+  let text = expression;
+  text = text.replace(/\\\(|\\\)|\\\[|\\\]/g, '');
+  text = text.replace(/\\frac\{([^}]*)\}\{([^}]*)\}/g, '$1/$2');
+  text = text.replace(/\\sqrt\{([^}]*)\}/g, '√($1)');
+  text = text.replace(/\\cdot/g, '·');
+  text = text.replace(/\\times/g, '×');
+  text = text.replace(/\\ln/g, 'ln');
+  text = text.replace(/\\log/g, 'log');
+  text = text.replace(/\\left|\\right/g, '');
+  text = text.replace(/\\mathcal\{([^}]*)\}/g, '$1');
+  text = text.replace(/\\text\{([^}]*)\}/g, '$1');
+  text = text.replace(/\\operatorname\{([^}]*)\}/g, '$1');
+  text = text.replace(/\\,|\\!|\\;/g, ' ');
+  text = text.replace(/\\([a-zA-Z]+)/g, (match, command) => {
+    const lookupKey = `\\${command}`;
+    if (GREEK_SYMBOL_LOOKUP.has(lookupKey)) {
+      return GREEK_SYMBOL_LOOKUP.get(lookupKey);
+    }
+    return command;
+  });
+  text = text.replace(/[{}]/g, '');
+  text = text.replace(/\s+/g, ' ').trim();
+  return text;
+}
+
+/**
+ * Normalised map between TeX commands and human friendly Greek symbols.
+ */
+const GREEK_SYMBOL_LOOKUP = new Map([
+  ['\\alpha', 'α'],
+  ['\\beta', 'β'],
+  ['\\gamma', 'γ'],
+  ['\\delta', 'δ'],
+  ['\\epsilon', 'ε'],
+  ['\\theta', 'θ'],
+  ['\\lambda', 'λ'],
+  ['\\mu', 'μ'],
+  ['\\nu', 'ν'],
+  ['\\pi', 'π'],
+  ['\\phi', 'φ'],
+  ['\\psi', 'ψ'],
+  ['\\sigma', 'σ'],
+  ['\\tau', 'τ'],
+  ['\\omega', 'ω'],
+  ['\\Omega', 'Ω'],
+  ['\\Gamma', 'Γ'],
+  ['\\Delta', 'Δ'],
+  ['\\Lambda', 'Λ'],
+  ['\\Phi', 'Φ'],
+  ['\\Psi', 'Ψ'],
+]);

--- a/scripts/core/mathTokens.js
+++ b/scripts/core/mathTokens.js
@@ -1,0 +1,58 @@
+/**
+ * Tokenisation helpers used to split upgrade equations into highlightable spans.
+ */
+
+/**
+ * Escapes special characters so dynamically built regular expressions stay valid.
+ * @param {string} value Symbol text supplied by blueprint metadata.
+ * @returns {string} Regex safe symbol string.
+ */
+export function escapeRegExp(value) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  return value.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&');
+}
+
+/**
+ * Breaks equation text into tokens so the UI can bind spans to upgrade cards.
+ * @param {string} equationText Base equation pulled from the blueprint.
+ * @param {Array<{key: string, symbol: string}>} variableTokens Upgradable variable metadata.
+ * @returns {Array<{text: string, variableKey: string|null}>} Token list for DOM generation.
+ */
+export function tokenizeEquationParts(equationText, variableTokens = []) {
+  if (!equationText || !variableTokens.length) {
+    return [{ text: equationText, variableKey: null }];
+  }
+
+  const tokenLookup = new Map();
+  const patterns = variableTokens
+    .filter((token) => token && token.symbol)
+    .map((token) => {
+      tokenLookup.set(token.symbol, token.key);
+      return escapeRegExp(token.symbol);
+    });
+
+  if (!patterns.length) {
+    return [{ text: equationText, variableKey: null }];
+  }
+
+  const regex = new RegExp(`(${patterns.join('|')})`, 'g');
+  const tokens = [];
+  let lastIndex = 0;
+
+  equationText.replace(regex, (match, _token, offset) => {
+    if (offset > lastIndex) {
+      tokens.push({ text: equationText.slice(lastIndex, offset), variableKey: null });
+    }
+    tokens.push({ text: match, variableKey: tokenLookup.get(match) || null });
+    lastIndex = offset + match.length;
+    return match;
+  });
+
+  if (lastIndex < equationText.length) {
+    tokens.push({ text: equationText.slice(lastIndex), variableKey: null });
+  }
+
+  return tokens;
+}

--- a/scripts/features/towers/betaMath.js
+++ b/scripts/features/towers/betaMath.js
@@ -1,0 +1,56 @@
+/**
+ * Houses the exponent based Beta lattice math so other modules can import the same
+ * calculations without duplicating formulas.
+ */
+
+/**
+ * Baseline constants chosen to keep the Beta progression stable.
+ */
+export const BETA_BASE_ATTACK = 10;
+export const BETA_BASE_ATTACK_SPEED = 2;
+export const BETA_BASE_RANGE = 5;
+
+/**
+ * Ensures the exponent can never drop below one or become `NaN`.
+ * @param {number} value Exponent supplied by upgrade state.
+ * @returns {number} Normalised exponent value.
+ */
+export function clampBetaExponent(value) {
+  if (!Number.isFinite(value)) {
+    return 1;
+  }
+  return Math.max(1, value);
+}
+
+/**
+ * Computes the Beta attack power using the exponential growth rule.
+ * @param {number} exponent Exponent pulled from the upgrade tree.
+ * @returns {number} Attack power suitable for display and simulation.
+ */
+export function calculateBetaAttack(exponent) {
+  const normalized = clampBetaExponent(exponent);
+  const attack = BETA_BASE_ATTACK ** normalized;
+  return Number.isFinite(attack) ? attack : Number.MAX_VALUE;
+}
+
+/**
+ * Computes the Beta attack speed which slows as the exponent grows.
+ * @param {number} exponent Exponent pulled from the upgrade tree.
+ * @returns {number} Attacks per second for the beta beam.
+ */
+export function calculateBetaAttackSpeed(exponent) {
+  const normalized = clampBetaExponent(exponent);
+  const speed = BETA_BASE_ATTACK_SPEED / normalized;
+  return Number.isFinite(speed) ? speed : 0;
+}
+
+/**
+ * Computes the effective range for Beta beams which contracts with higher exponents.
+ * @param {number} exponent Exponent pulled from the upgrade tree.
+ * @returns {number} Range value used for placement logic.
+ */
+export function calculateBetaRange(exponent) {
+  const normalized = clampBetaExponent(exponent);
+  const range = BETA_BASE_RANGE / normalized;
+  return Number.isFinite(range) ? range : 0;
+}


### PR DESCRIPTION
## Summary
- extract math text helpers into `scripts/core` modules so the upgrade UI can reuse them
- move Beta lattice calculations into a dedicated feature module
- pull numeric formatting helpers into a shared formatting module and update `assets/main.js` imports

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68fe8f8b8d24832aba928eacb8ee5036