### PR TITLE
Document main.js refactor targets and add module stubs

### DIFF
--- a/assets/alephUpgradeState.js
+++ b/assets/alephUpgradeState.js
@@ -1,0 +1,2 @@
+// Placeholder for Aleph chain upgrade state utilities covering mutation helpers,
+// formatting routines, and integration hooks connecting upgrades to the playfield state.

--- a/assets/audioSystem.js
+++ b/assets/audioSystem.js
@@ -1,0 +1,2 @@
+// Placeholder for the audio system module responsible for the AudioManager wiring,
+// slider bindings, persistence, activation logic, and contextual music selection.

--- a/assets/colorSchemeUtils.js
+++ b/assets/colorSchemeUtils.js
@@ -1,0 +1,2 @@
+// Placeholder for color-scheme utilities covering tier-based hue math, palette definitions,
+// scheme cycling, and persistence of the player's active chromatic selection.

--- a/assets/developerControls.js
+++ b/assets/developerControls.js
@@ -1,0 +1,2 @@
+// Placeholder for developer controls and sandbox adjustments, including panel bindings,
+// value formatters, mutation handlers, and visibility toggles for debugging utilities.

--- a/assets/gameplayConfigLoaders.js
+++ b/assets/gameplayConfigLoaders.js
@@ -1,0 +1,2 @@
+// Placeholder for gameplay and simulation configuration loaders, including fetch helpers,
+// embedded-config fallbacks, fluid profile normalization, and the applyGameplayConfig bootstrap logic.

--- a/assets/offlinePersistence.js
+++ b/assets/offlinePersistence.js
@@ -1,0 +1,2 @@
+// Placeholder for offline overlay and persistence plumbing, covering storage constants,
+// powder log bookkeeping, animation state, and timer coordination for idle rewards.

--- a/assets/playfield.js
+++ b/assets/playfield.js
@@ -1,0 +1,2 @@
+// Placeholder for the Playfield gameplay class including constructor wiring, UI bindings,
+// input handling, geometry calculations, floater animations, and tower placement logic.

--- a/assets/powderSimulationBridge.js
+++ b/assets/powderSimulationBridge.js
@@ -1,0 +1,2 @@
+// Placeholder for powder simulation bridging logic that manages mote drop queues,
+// idle mote banking, powder save throttling, and integration with the simulation instance.

--- a/assets/resourceHud.js
+++ b/assets/resourceHud.js
@@ -1,0 +1,2 @@
+// Placeholder for the resource HUD and powder-economy state management, including resource
+// snapshots, powder configuration, UI element caches, and glyph-wall synchronization routines.

--- a/assets/uiTabManager.js
+++ b/assets/uiTabManager.js
@@ -1,0 +1,2 @@
+// Placeholder for tab, overlay, and level-preview management helpers handling tab caching,
+// overlay visibility, level editor state, and shared hide/reveal utilities.

--- a/docs/main_refactor_contexts.md
+++ b/docs/main_refactor_contexts.md
@@ -1,0 +1,33 @@
+# Main.js Refactor Contexts
+
+This document captures the major logical groupings still embedded in `assets/main.js` that are good candidates for extraction into their own modules. Each proposed module currently exists as a stub file alongside the rest of the `assets/` scripts.
+
+## Gameplay and Simulation Config Loaders
+Responsible for fetching gameplay configuration files, handling embedded fallbacks, normalizing the fluid profile, and applying the aggregated configuration to bootstrap towers, levels, and achievements.
+
+## Color-Scheme and Chromatic Styling Utilities
+Owns tier-based hue calculations, palette definitions, color scheme cycling, and persistence of the player's selection.
+
+## Tab/Overlay and Level-Preview UI Management
+Coordinates tab caching, overlay visibility toggles, level preview wiring, and shared helpers for showing or hiding the various overlays.
+
+## Developer Controls and Sandbox Adjustments
+Bundles the developer panel bindings, value formatters, mutation handlers, and visibility toggles that expose sandbox controls.
+
+## Aleph Chain Upgrade State Utilities
+Provides upgrade state mutations, formatting helpers, and integration hooks that synchronize Aleph chain upgrades with the playfield.
+
+## Audio System
+Manages the `AudioManager` wiring, slider bindings, audio persistence, activation gating, and contextual music selection for the game's tabs.
+
+## Resource HUD and Powder-Economy State
+Maintains base resource snapshots, powder configuration/state, UI element caches, and glyph-wall math/visual synchronization routines.
+
+## Offline Overlay & Persistence Plumbing
+Handles storage key constants, powder log bookkeeping, offline overlay animation state, and timer coordination for idle rewards.
+
+## Powder Simulation Bridging
+Acts as the bridge between the powder simulation and the rest of the game by managing mote drop queues, idle mote banking, powder save throttling, and integration points for the simulation instance.
+
+## Playfield Gameplay Class
+Isolates the `Playfield` class definition, its constructor wiring, UI bindings, input handling, geometry calculations, floater animation scaffolding, and tower placement logic.


### PR DESCRIPTION
## Summary
- document the major contexts in `assets/main.js` that are candidates for extraction
- add placeholder modules under `assets/` for each identified context with descriptive comments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fee0a85534832a8a7dddf9507e3035