### PR TITLE
Clarify idle motes versus mote gem rewards

### DIFF
--- a/assets/data/gameplayConfig.json
+++ b/assets/data/gameplayConfig.json
@@ -381,7 +381,7 @@
       "traits": [
         "Display as (E^{k}) with a crimson exponent tied to (10^{k}) maximum health; even reduced health never hides the power tier.",
         "March in geometric platoons whose health resolves to (H(k) = H_0 \times 10^{k}) for rank k within the current set.",
-        "Reward Σ motes on defeat using the same multiplier, making them ideal calibration targets for lattice tuning."
+        "Reward Σ mote gems on defeat using the same multiplier, making them ideal calibration targets for lattice tuning."
       ],
       "counter": "Layer multiplicative auras and β/γ towers so burst and splash damage keep pace with the exponential swell before specialist glyphs appear.",
       "lore": "Archivists open every defense proof against E glyphs; when their sigils begin to blur, heavier conjectures are on approach.",
@@ -426,7 +426,7 @@
       "traits": [
         "Carry the mark (↺^{k})—the exponent glows brighter after conversion to highlight the retained ten-power health tier.",
         "Upon collapse they sprint to the start of the path; if unblocked they respawn as allies with (H_{ally} = lfloor 0.5 H_{foe} \rfloor).",
-        "Allied reversals inherit your active tower modifiers and pulse Σ motes while retracing enemy ground."
+        "Allied reversals inherit your active tower modifiers and pulse Σ mote gems while retracing enemy ground."
       ],
       "counter": "Catch them near choke points so the conversion occurs within supportive auras, otherwise their retreat might breach the core first.",
       "lore": "Legend says each sentinel carries a mirrored proof; persuade it to turn the page and the margin glows with your sigil.",

--- a/assets/enemies.js
+++ b/assets/enemies.js
@@ -1,5 +1,5 @@
 // Shared enemy utilities and mote gem state management for Thero Idle.
-// This module centralizes enemy drop handling so the main game loop can remain focused on orchestration.
+// Enemy defeats mint mote gems—a special, color-coded currency distinct from idle motes—while this module centralizes drop handling so the main game loop can remain focused on orchestration.
 
 // Track mote gem drops, inventory totals, and the upgrade-driven auto collector.
 export const moteGemState = {

--- a/assets/main.js
+++ b/assets/main.js
@@ -5111,20 +5111,20 @@ import {
 
   function formatMoteDispenseRate(rate) {
     if (!Number.isFinite(rate)) {
-      return '0.00 Mote Gems/sec'; // Present the mote gem flow rate even when values are invalid.
+      return '0.00 Motes/sec'; // Present the idle mote flow rate even when values are invalid.
     }
     const safeRate = Math.max(0, rate);
     const formatted = safeRate >= 1
       ? (Number.isInteger(safeRate) ? formatWholeNumber(safeRate) : formatDecimal(safeRate, 2))
       : formatDecimal(safeRate, 2);
-    const unit = safeRate === 1 ? 'Mote Gem' : 'Mote Gems';
-    return `${formatted} ${unit}/sec`; // Display the mote gem label consistently across quantities.
+    const unit = safeRate === 1 ? 'Mote' : 'Motes';
+    return `${formatted} ${unit}/sec`; // Display the idle mote label consistently across quantities.
   }
 
   function updateMoteStatsDisplays() {
     const storedMotes = getCurrentIdleMoteBank();
     if (resourceElements.moteStorage) {
-      resourceElements.moteStorage.textContent = `${formatGameNumber(storedMotes)} Mote Gems`; // Reflect the mote gem currency in the HUD.
+      resourceElements.moteStorage.textContent = `${formatGameNumber(storedMotes)} Motes`; // Reflect the idle mote reserves in the HUD.
     }
 
     const dispenseRate = getCurrentMoteDispenseRate();
@@ -5448,7 +5448,7 @@ import {
       }
       case 'achievement-unlocked': {
         const { title = 'Achievement' } = context;
-        entry = `${title} seal unlocked · +1 Mote Gems/min secured.`;
+        entry = `${title} seal unlocked · +1 Motes/min secured.`;
         break;
       }
       case 'offline-reward': {
@@ -5456,7 +5456,7 @@ import {
         const minutesLabel = formatWholeNumber(minutes);
         entry = `Idle harvest · ${minutesLabel}m × ${formatGameNumber(rate)} = +${formatGameNumber(
           powder,
-        )} Mote Gems.`;
+        )} Motes.`;
         break;
       }
       case 'developer-adjust': {

--- a/index.html
+++ b/index.html
@@ -73,10 +73,10 @@
           </span>
         </div>
         <div class="status-group">
-          <span class="status-label">Mote Gems Stored</span>
+          <span class="status-label">Motes Stored</span>
           <span class="status-value status-value--stacked">
-            <span id="status-mote-storage">0 Mote Gems</span>
-            <span class="status-subvalue status-subvalue--gold" id="status-dispense-rate">1 Mote Gem/sec</span>
+            <span id="status-mote-storage">0 Motes</span>
+            <span class="status-subvalue status-subvalue--gold" id="status-dispense-rate">1 Mote/sec</span>
           </span>
         </div>
       </header>
@@ -961,7 +961,7 @@
                   <dd id="powder-crystal-bonus">+0.00%</dd>
                 </div>
                 <div>
-                  <dt>Mote Stockpile</dt>
+                  <dt>Mote Gem Stockpile</dt>
                   <dd id="powder-stockpile">0 Mote Gems</dd>
                 </div>
               </dl>
@@ -975,7 +975,7 @@
                 </div>
                 <div>
                     <dt>Dispensing Rate</dt>
-                    <dd id="powder-dispense-rate">1 Mote Gem/sec</dd>
+                    <dd id="powder-dispense-rate">1 Mote/sec</dd>
                 </div>
               </dl>
             </article>
@@ -1101,7 +1101,7 @@
         >
           <header class="panel-header">Achievements</header>
           <p class="achievement-note">
-              Each sealed proof adds <strong>+1 mote gem per minute</strong> to the idle bank. Tap an icon to
+              Each sealed proof adds <strong>+1 mote per minute</strong> to the idle bank. Tap an icon to
             review its victory details.
           </p>
           <div class="achievement-grid" id="achievement-grid" role="list"></div>


### PR DESCRIPTION
## Summary
- label HUD and powder screens with the correct mote terminology so idle reserves no longer reference mote gems
- update idle log messaging and achievement rewards to describe mote payouts accurately
- reinforce enemy documentation and helpers to emphasize mote gems as color-coded drops from defeated foes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fef96fb710832ab838efd6190c9796