### PR TITLE
Add unlockable fluid mote simulation

### DIFF
--- a/assets/data/towerFluidSimulation.json
+++ b/assets/data/towerFluidSimulation.json
@@ -1,9 +1,15 @@
 {
   "id": "tower-fluid",
   "label": "Fluid Resonance Study",
-  "grainSizes": [1, 1, 2],
+  "dropSizes": [1, 1, 2, 3],
+  "dropVolumeScale": 0.85,
   "idleDrainRate": 1.6,
   "baseSpawnInterval": 150,
+  "waveStiffness": 0.22,
+  "waveDamping": 0.012,
+  "sideFlowRate": 0.6,
+  "rippleFrequency": 0.8,
+  "rippleAmplitude": 0.55,
   "palette": {
     "stops": ["#4fb8ff", "#76d5ff", "#c6f4ff"],
     "restAlpha": 0.78,


### PR DESCRIPTION
## Summary
- add a dedicated FluidSimulation class that renders water-like drops and ripples for the motes tower
- gate the fluid study behind a post-prestige sigil requirement and swap between sand and fluid simulations in code
- refresh the fluid simulation profile with new physics tuning values and palette

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ff90e0928c832a93dcaa03527f329d