### PR TITLE
Add tower tree map view for unlocked towers

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -117,6 +117,7 @@ import {
   unlockTower,
   isTowerUnlocked,
 } from './towersTab.js';
+import { initializeTowerTreeMap, refreshTowerTreeMap } from './towerTreeMap.js';
 import {
   moteGemState,
   MOTE_GEM_COLLECTION_RADIUS,
@@ -6240,6 +6241,12 @@ import {
     injectTowerCardPreviews();
     annotateTowerCardsWithCost();
     updateTowerCardVisibility();
+    initializeTowerTreeMap({
+      toggleButton: document.getElementById('tower-tree-map-toggle'),
+      mapContainer: document.getElementById('tower-tree-map'),
+      cardGrid: document.getElementById('tower-card-grid'),
+    });
+    refreshTowerTreeMap();
     initializeTowerSelection();
     bindTowerCardUpgradeInteractions();
     syncLoadoutToPlayfield();

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1451,6 +1451,187 @@ body.graphics-mode-low .control-button {
   text-align: center;
 }
 
+/* Tower tab: alternate tree map toggle and layout */
+.tower-panel-controls {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  margin-bottom: 12px;
+  gap: 12px;
+}
+
+.tower-tree-map-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 16px;
+  border-radius: 999px;
+  border: 1px solid rgba(247, 247, 245, 0.18);
+  background: rgba(10, 10, 16, 0.6);
+  color: var(--text);
+  font-family: 'Space Mono', monospace;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform var(--transition), background var(--transition), border-color var(--transition);
+}
+
+.tower-tree-map-button:hover,
+.tower-tree-map-button:focus-visible {
+  transform: translateY(-1px);
+  background: rgba(247, 247, 245, 0.12);
+  border-color: rgba(247, 247, 245, 0.3);
+  outline: none;
+}
+
+.tower-tree-map-button[aria-pressed='true'] {
+  background: rgba(247, 247, 245, 0.16);
+  border-color: rgba(255, 228, 120, 0.45);
+  box-shadow: 0 14px 26px rgba(255, 228, 120, 0.18);
+}
+
+.tower-tree-map-icon {
+  width: 42px;
+  height: 42px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, rgba(247, 247, 245, 0.2), transparent 70%);
+  color: rgba(247, 247, 245, 0.88);
+}
+
+.tower-tree-map-icon svg {
+  width: 32px;
+  height: 32px;
+}
+
+.tower-tree-map-label {
+  white-space: nowrap;
+}
+
+.tower-tree-map {
+  position: relative;
+  border: 1px solid rgba(247, 247, 245, 0.14);
+  border-radius: 18px;
+  background: linear-gradient(160deg, rgba(5, 5, 12, 0.8), rgba(16, 16, 24, 0.9));
+  padding: 24px;
+  margin-bottom: 18px;
+  min-height: 260px;
+  overflow: hidden;
+}
+
+.tower-tree-map-note {
+  position: absolute;
+  left: 50%;
+  bottom: 16px;
+  transform: translateX(-50%);
+  margin: 0;
+  text-align: center;
+  font-size: 0.85rem;
+  color: rgba(247, 247, 245, 0.65);
+  width: calc(100% - 48px);
+  pointer-events: none;
+}
+
+.tower-tree-map-links {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.tower-tree-map-nodes {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.tower-tree-node {
+  position: absolute;
+  width: 130px;
+  height: 130px;
+  left: 0;
+  top: 0;
+  transform: translate(-50%, -50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+
+.tower-tree-node-orbit {
+  pointer-events: auto;
+  width: 110px;
+  height: 110px;
+  border-radius: 999px;
+  border: 1px solid rgba(247, 247, 245, 0.14);
+  background: radial-gradient(circle at 50% 45%, rgba(247, 247, 245, 0.12), rgba(10, 10, 16, 0.8));
+  display: grid;
+  place-items: center;
+  padding: 12px;
+  text-align: center;
+  box-shadow: 0 16px 24px rgba(0, 0, 0, 0.28);
+  transition: transform 220ms ease, border-color 220ms ease, box-shadow 220ms ease;
+}
+
+.tower-tree-node-orbit:hover,
+.tower-tree-node-orbit:focus-visible {
+  transform: translateY(-6px);
+  border-color: rgba(255, 228, 120, 0.45);
+  box-shadow: 0 22px 32px rgba(255, 228, 120, 0.18);
+  outline: none;
+}
+
+.tower-tree-node-symbol {
+  font-family: 'Cormorant Garamond', serif;
+  font-size: 1.8rem;
+  color: rgba(255, 228, 120, 0.9);
+  text-shadow: 0 0 14px rgba(255, 228, 120, 0.65);
+}
+
+.tower-tree-node-name {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(247, 247, 245, 0.75);
+}
+
+.tower-tree-node-tier {
+  font-size: 0.7rem;
+  color: rgba(247, 247, 245, 0.6);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .tower-tree-node-orbit {
+    animation: tower-tree-float calc(6s + var(--tower-float-variance, 0s)) ease-in-out infinite;
+  }
+}
+
+@keyframes tower-tree-float {
+  0%,
+  100% {
+    transform: translateY(-4px);
+  }
+  50% {
+    transform: translateY(6px);
+  }
+}
+
+.tower-tree-link {
+  stroke: rgba(255, 228, 120, 0.35);
+  stroke-width: 2;
+  stroke-dasharray: 6 4;
+  transition: stroke 220ms ease, stroke-width 220ms ease;
+}
+
+.tower-tree-link[data-active='true'] {
+  stroke: rgba(255, 228, 120, 0.75);
+  stroke-width: 3;
+}
+
 .panel-grid {
   display: grid;
   gap: 18px;

--- a/assets/towerTreeMap.js
+++ b/assets/towerTreeMap.js
@@ -1,0 +1,290 @@
+// Tower Tree Map renderer: builds the alternate constellation view for unlocked towers.
+import {
+  getTowerDefinitions,
+  getTowerUnlockState,
+  getTowerEquationBlueprint,
+} from './towersTab.js';
+import { convertMathExpressionToPlainText } from '../scripts/core/mathText.js';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+const towerTreeState = {
+  toggleButton: null,
+  mapContainer: null,
+  nodeLayer: null,
+  linkLayer: null,
+  cardGrid: null,
+  needsRefresh: false,
+};
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function normalizeEquationText(rawEquation) {
+  if (!rawEquation) {
+    return '';
+  }
+  const plain = convertMathExpressionToPlainText(rawEquation) || rawEquation;
+  return plain
+    .replace(/\\/g, '')
+    .replace(/[{}]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function extractTowerEquation(towerId) {
+  const card = document.getElementById('tower-card-grid')?.querySelector(
+    `.card[data-tower-id="${towerId}"] .formula-block .formula-line`,
+  );
+  const text = card?.textContent;
+  if (text && text.trim()) {
+    return normalizeEquationText(text);
+  }
+  const blueprint = getTowerEquationBlueprint(towerId);
+  if (blueprint?.baseEquation) {
+    return normalizeEquationText(blueprint.baseEquation);
+  }
+  return '';
+}
+
+function collectTowerDependencies(equation, towers, currentId) {
+  if (!equation) {
+    return [];
+  }
+  const dependencies = new Set();
+  const normalized = equation.toLowerCase();
+  towers.forEach((definition) => {
+    if (!definition || definition.id === currentId) {
+      return;
+    }
+    const symbol = (definition.symbol || '').trim();
+    const id = (definition.id || '').trim();
+    let referenced = false;
+    if (symbol && equation.includes(symbol)) {
+      referenced = true;
+    }
+    if (!referenced && symbol) {
+      const asciiSymbol = symbol
+        .normalize('NFD')
+        .replace(/[^\p{L}\p{N}]+/gu, '')
+        .toLowerCase();
+      if (asciiSymbol && normalized.includes(asciiSymbol)) {
+        referenced = true;
+      }
+    }
+    if (!referenced && id) {
+      const idPattern = new RegExp(`\\b${escapeRegExp(id)}\\b`, 'i');
+      if (idPattern.test(normalized)) {
+        referenced = true;
+      }
+    }
+    if (referenced) {
+      dependencies.add(definition.id);
+    }
+  });
+  return [...dependencies];
+}
+
+function clearTreeLayers() {
+  if (towerTreeState.nodeLayer) {
+    towerTreeState.nodeLayer.innerHTML = '';
+  }
+  if (towerTreeState.linkLayer) {
+    while (towerTreeState.linkLayer.firstChild) {
+      towerTreeState.linkLayer.removeChild(towerTreeState.linkLayer.firstChild);
+    }
+  }
+}
+
+function createTreeNode(definition, position, indexInTier) {
+  const node = document.createElement('div');
+  node.className = 'tower-tree-node';
+  node.style.left = `${position.x}px`;
+  node.style.top = `${position.y}px`;
+
+  const orbit = document.createElement('div');
+  orbit.className = 'tower-tree-node-orbit';
+  orbit.setAttribute('tabindex', '0');
+  orbit.style.setProperty('--tower-float-variance', `${(indexInTier % 3) * 0.6}s`);
+
+  const symbolEl = document.createElement('span');
+  symbolEl.className = 'tower-tree-node-symbol';
+  symbolEl.textContent = definition.symbol || definition.id;
+
+  const nameEl = document.createElement('span');
+  nameEl.className = 'tower-tree-node-name';
+  nameEl.textContent = definition.name || definition.id;
+
+  const tierEl = document.createElement('span');
+  tierEl.className = 'tower-tree-node-tier';
+  const tierValue = Number.isFinite(definition.tier) ? definition.tier : '?';
+  tierEl.textContent = `Tier ${tierValue}`;
+
+  orbit.append(symbolEl, nameEl, tierEl);
+  node.append(orbit);
+  return { element: node, orbit, position };
+}
+
+function buildTreeLinks(nodes, edges) {
+  if (!towerTreeState.linkLayer) {
+    return;
+  }
+  const rect = towerTreeState.mapContainer.getBoundingClientRect();
+  towerTreeState.linkLayer.setAttribute('viewBox', `0 0 ${rect.width} ${rect.height}`);
+  towerTreeState.linkLayer.setAttribute('preserveAspectRatio', 'none');
+
+  edges.forEach(([fromId, toId]) => {
+    const fromNode = nodes.get(fromId);
+    const toNode = nodes.get(toId);
+    if (!fromNode || !toNode) {
+      return;
+    }
+    const line = document.createElementNS(SVG_NS, 'line');
+    const fromRect = fromNode.element.getBoundingClientRect();
+    const toRect = toNode.element.getBoundingClientRect();
+    const containerRect = towerTreeState.mapContainer.getBoundingClientRect();
+    const x1 = fromRect.left - containerRect.left + fromRect.width / 2;
+    const y1 = fromRect.top - containerRect.top + fromRect.height / 2;
+    const x2 = toRect.left - containerRect.left + toRect.width / 2;
+    const y2 = toRect.top - containerRect.top + toRect.height / 2;
+    line.setAttribute('x1', String(x1));
+    line.setAttribute('y1', String(y1));
+    line.setAttribute('x2', String(x2));
+    line.setAttribute('y2', String(y2));
+    line.classList.add('tower-tree-link');
+    towerTreeState.linkLayer.append(line);
+  });
+}
+
+function computeNodeLayout(towers) {
+  if (!towers.length) {
+    return { positions: new Map(), edges: [] };
+  }
+  const unlockedTiers = new Map();
+  towers.forEach((tower) => {
+    const tier = Number.isFinite(tower.tier) ? tower.tier : towers.indexOf(tower) + 1;
+    if (!unlockedTiers.has(tier)) {
+      unlockedTiers.set(tier, []);
+    }
+    unlockedTiers.get(tier).push(tower);
+  });
+  const tierOrder = [...unlockedTiers.keys()].sort((a, b) => a - b);
+  const mapHeight = Math.max(260, tierOrder.length * 180);
+  towerTreeState.mapContainer.style.minHeight = `${mapHeight}px`;
+  const paddingBottom = 72;
+  const availableHeight = mapHeight - paddingBottom;
+  const containerWidth = towerTreeState.nodeLayer?.offsetWidth || towerTreeState.mapContainer.clientWidth || 600;
+  const positions = new Map();
+  const equations = new Map();
+
+  tierOrder.forEach((tier, tierIndex) => {
+    const group = unlockedTiers.get(tier) || [];
+    if (!group.length) {
+      return;
+    }
+    const verticalSpacing = availableHeight / (tierOrder.length + 1);
+    const y = Math.max(72, (tierIndex + 1) * verticalSpacing);
+    const horizontalPadding = 80;
+    const usableWidth = Math.max(200, containerWidth - horizontalPadding * 2);
+    const step = group.length > 1 ? usableWidth / (group.length - 1) : 0;
+    group.forEach((tower, index) => {
+      const x = group.length > 1 ? horizontalPadding + index * step : containerWidth / 2;
+      positions.set(tower.id, { x, y });
+      equations.set(tower.id, extractTowerEquation(tower.id));
+    });
+  });
+
+  const edges = [];
+  const edgeSet = new Set();
+  towers.forEach((tower) => {
+    const dependencies = collectTowerDependencies(equations.get(tower.id), towers, tower.id);
+    dependencies.forEach((dependencyId) => {
+      const key = [tower.id, dependencyId].sort().join('::');
+      if (!edgeSet.has(key) && positions.has(tower.id) && positions.has(dependencyId)) {
+        edgeSet.add(key);
+        edges.push([tower.id, dependencyId]);
+      }
+    });
+  });
+
+  return { positions, edges };
+}
+
+function refreshTreeInternal() {
+  if (!towerTreeState.mapContainer || towerTreeState.mapContainer.hidden) {
+    towerTreeState.needsRefresh = true;
+    return;
+  }
+  const unlockState = getTowerUnlockState();
+  const unlocked = Array.from(unlockState.unlocked || []);
+  const definitions = getTowerDefinitions().filter((definition) => unlocked.includes(definition.id));
+
+  clearTreeLayers();
+  if (!definitions.length) {
+    return;
+  }
+
+  const { positions, edges } = computeNodeLayout(definitions);
+  const nodes = new Map();
+  let indexCounter = 0;
+  positions.forEach((position, towerId) => {
+    const definition = definitions.find((entry) => entry.id === towerId);
+    if (!definition || !towerTreeState.nodeLayer) {
+      return;
+    }
+    const node = createTreeNode(definition, position, indexCounter++);
+    nodes.set(towerId, node);
+    towerTreeState.nodeLayer.append(node.element);
+  });
+
+  buildTreeLinks(nodes, edges);
+  towerTreeState.needsRefresh = false;
+}
+
+function toggleTreeVisibility(forceOpen = null) {
+  if (!towerTreeState.toggleButton || !towerTreeState.mapContainer || !towerTreeState.cardGrid) {
+    return;
+  }
+  const currentlyOpen = !towerTreeState.mapContainer.hidden;
+  const nextOpen = forceOpen === null ? !currentlyOpen : Boolean(forceOpen);
+  towerTreeState.mapContainer.hidden = !nextOpen;
+  towerTreeState.mapContainer.setAttribute('aria-hidden', nextOpen ? 'false' : 'true');
+  towerTreeState.cardGrid.hidden = nextOpen;
+  towerTreeState.cardGrid.setAttribute('aria-hidden', nextOpen ? 'true' : 'false');
+  towerTreeState.toggleButton.setAttribute('aria-pressed', nextOpen ? 'true' : 'false');
+  towerTreeState.toggleButton.setAttribute('aria-expanded', nextOpen ? 'true' : 'false');
+  if (nextOpen) {
+    refreshTreeInternal();
+  }
+}
+
+function scheduleTreeRefresh() {
+  if (towerTreeState.needsRefresh) {
+    return;
+  }
+  towerTreeState.needsRefresh = true;
+  if (towerTreeState.mapContainer && !towerTreeState.mapContainer.hidden) {
+    window.requestAnimationFrame(() => refreshTreeInternal());
+  }
+}
+
+export function refreshTowerTreeMap() {
+  refreshTreeInternal();
+}
+
+export function initializeTowerTreeMap({ toggleButton = null, mapContainer = null, cardGrid = null } = {}) {
+  towerTreeState.toggleButton = toggleButton;
+  towerTreeState.mapContainer = mapContainer;
+  towerTreeState.cardGrid = cardGrid;
+  towerTreeState.nodeLayer = mapContainer?.querySelector('[data-tree-node-layer]') || null;
+  towerTreeState.linkLayer = mapContainer?.querySelector('svg') || null;
+
+  if (towerTreeState.toggleButton) {
+    towerTreeState.toggleButton.addEventListener('click', () => toggleTreeVisibility());
+  }
+
+  document.addEventListener('tower-unlocked', scheduleTreeRefresh);
+  window.addEventListener('resize', scheduleTreeRefresh);
+  scheduleTreeRefresh();
+}

--- a/assets/towersTab.js
+++ b/assets/towersTab.js
@@ -395,6 +395,17 @@ export function unlockTower(towerId, { silent = false } = {}) {
     return false;
   }
   towerTabState.unlockState.unlocked.add(towerId);
+  if (typeof document !== 'undefined') {
+    // Notify other systems (such as the tower tree map) that unlock visibility should refresh.
+    document.dispatchEvent(
+      new CustomEvent('tower-unlocked', {
+        detail: {
+          towerId,
+          unlockedTowers: Array.from(towerTabState.unlockState.unlocked),
+        },
+      }),
+    );
+  }
   if (towerId === 'beta') {
     setMergingLogicUnlocked(true);
   }

--- a/index.html
+++ b/index.html
@@ -159,7 +159,55 @@
           aria-labelledby="tab-towers"
           hidden
         >
-          <div class="panel-grid">
+          <div class="tower-panel-controls" id="tower-panel-controls">
+            <button
+              class="tower-tree-map-button"
+              type="button"
+              id="tower-tree-map-toggle"
+              aria-pressed="false"
+              aria-expanded="false"
+              aria-controls="tower-tree-map"
+              title="Open the Tower Tree Map"
+            >
+              <span class="tower-tree-map-icon" aria-hidden="true">
+                <svg viewBox="0 0 80 80" focusable="false" aria-hidden="true">
+                  <g stroke="currentColor" stroke-width="2" fill="none">
+                    <path d="M18 18 L40 10 L62 18" />
+                    <path d="M18 62 L40 70 L62 62" />
+                    <path d="M18 18 L18 62" />
+                    <path d="M62 18 L62 62" />
+                    <path d="M40 10 L40 70" />
+                  </g>
+                  <g fill="currentColor" font-family="'Times New Roman', serif" font-size="16" text-anchor="middle">
+                    <circle cx="18" cy="18" r="8" fill="rgba(255,255,255,0.15)" />
+                    <text x="18" y="22">α</text>
+                    <circle cx="40" cy="10" r="8" fill="rgba(255,255,255,0.15)" />
+                    <text x="40" y="14">β</text>
+                    <circle cx="62" cy="18" r="8" fill="rgba(255,255,255,0.15)" />
+                    <text x="62" y="22">γ</text>
+                    <circle cx="18" cy="62" r="8" fill="rgba(255,255,255,0.15)" />
+                    <text x="18" y="66">δ</text>
+                    <circle cx="62" cy="62" r="8" fill="rgba(255,255,255,0.15)" />
+                    <text x="62" y="66">ε</text>
+                  </g>
+                </svg>
+              </span>
+              <span class="tower-tree-map-label">Tower Tree Map</span>
+            </button>
+          </div>
+          <div
+            class="tower-tree-map"
+            id="tower-tree-map"
+            role="region"
+            aria-label="Tower Tree Map"
+            hidden
+            aria-hidden="true"
+          >
+            <svg class="tower-tree-map-links" aria-hidden="true" focusable="false"></svg>
+            <div class="tower-tree-map-nodes" data-tree-node-layer></div>
+            <p class="tower-tree-map-note">Only discovered towers appear in this constellation.</p>
+          </div>
+          <div class="panel-grid" id="tower-card-grid">
             <article class="card card--mind-gate" aria-hidden="false">
               <header class="tower-header">
                 <span class="tower-tier">Origin</span>


### PR DESCRIPTION
## Summary
- add a Tower Tree Map toggle and container to the Towers tab layout
- implement a reusable towerTreeMap module that builds node positions and dependency links for unlocked towers
- style the constellation view and wire it into existing unlock flows and initialization

## Testing
- manual UI verification (Tower Tree Map screenshot)

------
https://chatgpt.com/codex/tasks/task_e_68ffa9120328832a8e0a54d9b26a91c1