### PR TITLE
Enable drag scrolling for hidden UI scrollbars

### DIFF
--- a/assets/dragScroll.js
+++ b/assets/dragScroll.js
@@ -1,0 +1,152 @@
+// Drag-scroll utility: replaces visible scrollbars with pointer-driven panning.
+
+// Track which containers already have drag-scroll listeners bound.
+const dragScrollRegistry = new WeakSet();
+
+// Skip drag-scroll handling when the pointer originates from interactive tower controls.
+const SKIP_DRAG_SELECTORS = ['.tower-loadout-item', '#playfield', '#playfield-canvas'];
+
+// Minimum distance (in pixels) before a movement counts as an intentional drag gesture.
+const MIN_DRAG_DISTANCE = 6;
+
+// Determine whether the element can actually scroll along either axis.
+function isScrollable(element) {
+  if (!element) {
+    return false;
+  }
+  const canScrollY = element.scrollHeight > element.clientHeight + 1;
+  const canScrollX = element.scrollWidth > element.clientWidth + 1;
+  return canScrollX || canScrollY;
+}
+
+// Attach pointer listeners that convert drag motions into scroll offsets.
+function attachDragScroll(element) {
+  const state = {
+    pointerId: null,
+    startX: 0,
+    startY: 0,
+    startScrollLeft: 0,
+    startScrollTop: 0,
+    isDragging: false,
+    suppressClick: false,
+  };
+
+  function handlePointerDown(event) {
+    if (!element) {
+      return;
+    }
+    if (event.pointerType === 'mouse' && event.button !== 0) {
+      return;
+    }
+    if (event.pointerType === 'touch') {
+      return;
+    }
+    if (!isScrollable(element)) {
+      return;
+    }
+    if (SKIP_DRAG_SELECTORS.some((selector) => event.target.closest(selector))) {
+      return;
+    }
+
+    state.pointerId = event.pointerId;
+    state.startX = event.clientX;
+    state.startY = event.clientY;
+    state.startScrollLeft = element.scrollLeft;
+    state.startScrollTop = element.scrollTop;
+    state.isDragging = false;
+    state.suppressClick = false;
+  }
+
+  function handlePointerMove(event) {
+    if (state.pointerId === null || event.pointerId !== state.pointerId) {
+      return;
+    }
+
+    const deltaX = event.clientX - state.startX;
+    const deltaY = event.clientY - state.startY;
+
+    if (!state.isDragging) {
+      if (Math.abs(deltaX) < MIN_DRAG_DISTANCE && Math.abs(deltaY) < MIN_DRAG_DISTANCE) {
+        return;
+      }
+      state.isDragging = true;
+      state.suppressClick = true;
+      element.classList.add('drag-scroll-active');
+      try {
+        element.setPointerCapture(event.pointerId);
+      } catch (error) {
+        // Ignore pointer-capture errors.
+      }
+    }
+
+    event.preventDefault();
+    // Translate pointer movement into scroll offsets for both axes.
+    element.scrollLeft = state.startScrollLeft - deltaX;
+    element.scrollTop = state.startScrollTop - deltaY;
+  }
+
+  function finishPointer(event) {
+    if (state.pointerId === null || event.pointerId !== state.pointerId) {
+      return;
+    }
+
+    const shouldSuppressClick = state.suppressClick || state.isDragging;
+
+    if (state.isDragging) {
+      try {
+        element.releasePointerCapture(event.pointerId);
+      } catch (error) {
+        // Ignore pointer-capture errors.
+      }
+    }
+
+    state.pointerId = null;
+    state.startX = 0;
+    state.startY = 0;
+    state.startScrollLeft = 0;
+    state.startScrollTop = 0;
+    // Reset gesture bookkeeping while remembering to block the imminent click.
+    state.isDragging = false;
+    state.suppressClick = shouldSuppressClick;
+    element.classList.remove('drag-scroll-active');
+  }
+
+  function handleClick(event) {
+    if (!state.suppressClick) {
+      return;
+    }
+    // Swallow the click that follows a drag so buttons do not fire unexpectedly.
+    state.suppressClick = false;
+    event.preventDefault();
+    event.stopPropagation();
+  }
+
+  // Flag the element in the DOM so CSS can provide drag affordances.
+  element.setAttribute('data-drag-scroll', 'true');
+  element.addEventListener('pointerdown', handlePointerDown);
+  element.addEventListener('pointermove', handlePointerMove);
+  element.addEventListener('pointerup', finishPointer);
+  element.addEventListener('pointercancel', finishPointer);
+  element.addEventListener('lostpointercapture', finishPointer);
+  element.addEventListener('click', handleClick, true);
+}
+
+// Public helper: enable drag-based scrolling for the provided selector list.
+export function enableDragScroll({ selectors = [] } = {}) {
+  const elements = new Set();
+  selectors.forEach((selector) => {
+    document.querySelectorAll(selector).forEach((element) => {
+      if (element instanceof HTMLElement) {
+        elements.add(element);
+      }
+    });
+  });
+
+  elements.forEach((element) => {
+    if (dragScrollRegistry.has(element)) {
+      return;
+    }
+    dragScrollRegistry.add(element);
+    attachDragScroll(element);
+  });
+}

--- a/assets/main.js
+++ b/assets/main.js
@@ -118,6 +118,8 @@ import {
   isTowerUnlocked,
 } from './towersTab.js';
 import { initializeTowerTreeMap, refreshTowerTreeMap } from './towerTreeMap.js';
+// Bring in drag-scroll support so hidden scrollbars remain usable.
+import { enableDragScroll } from './dragScroll.js';
 import {
   moteGemState,
   MOTE_GEM_COLLECTION_RADIUS,
@@ -6110,6 +6112,11 @@ import {
     if (overlayInstruction) {
       overlayInstruction.textContent = overlayInstructionDefault;
     }
+
+    // Enable drag gestures on scrollable shells to replace the hidden scrollbars.
+    enableDragScroll({
+      selectors: ['.panel', '.field-notes-page', '.upgrade-matrix-grid'],
+    });
 
     initializeLevelEditorElements();
 

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -20,6 +20,33 @@
   box-sizing: border-box;
 }
 
+/* Conceal scrollbars globally so drag-scrolling keeps the interface polished. */
+html,
+body,
+body * {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+/* Collapse WebKit scrollbars so hidden tracks do not consume layout space. */
+html::-webkit-scrollbar,
+body::-webkit-scrollbar,
+body *::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+}
+
+/* Signal draggable surfaces and suppress text selection while panning. */
+[data-drag-scroll] {
+  cursor: grab;
+}
+
+/* Lock text selection during an active drag-scroll gesture. */
+[data-drag-scroll].drag-scroll-active {
+  cursor: grabbing;
+  user-select: none;
+}
+
 .screen-reader-only {
   border: 0;
   clip: rect(0 0 0 0);
@@ -272,6 +299,9 @@ body.graphics-mode-low .control-button {
   overscroll-behavior: contain;
   -webkit-overflow-scrolling: touch;
   scrollbar-gutter: stable both-edge;
+  /* Hide the panel scrollbar; drag gestures now handle navigation. */
+  scrollbar-width: none;
+  -ms-overflow-style: none;
 }
 
 .panel.active {
@@ -2823,8 +2853,9 @@ body.graphics-mode-low .control-button {
   line-height: 1.6;
   color: inherit;
   overflow-y: auto;
-  scrollbar-width: thin;
-  scrollbar-color: rgba(139, 247, 255, 0.3) rgba(12, 16, 26, 0.4);
+  /* Remove the visual scrollbar so drag gestures remain immersive. */
+  scrollbar-width: none;
+  -ms-overflow-style: none;
   touch-action: pan-y;
   overscroll-behavior: contain;
   opacity: 0;
@@ -2832,19 +2863,6 @@ body.graphics-mode-low .control-button {
   transform: translateX(0);
   transition: transform 280ms ease, opacity 240ms ease;
   pointer-events: none;
-}
-
-.field-notes-page::-webkit-scrollbar {
-  width: 6px;
-}
-
-.field-notes-page::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.field-notes-page::-webkit-scrollbar-thumb {
-  background: linear-gradient(180deg, rgba(139, 247, 255, 0.4), rgba(255, 228, 160, 0.35));
-  border-radius: 999px;
 }
 
 .field-notes-page.field-notes-page--active {
@@ -3304,6 +3322,9 @@ body.graphics-mode-low .control-button {
   flex: 1 1 auto;
   overflow-y: auto;
   padding-right: 4px;
+  /* Hide the upgrade overlay scrollbar to rely on drag-based panning. */
+  scrollbar-width: none;
+  -ms-overflow-style: none;
 }
 
 .upgrade-matrix-row {


### PR DESCRIPTION
## Summary
- hide scrollbars throughout the interface to keep the presentation clean
- add a reusable drag-scroll helper that converts pointer drags into scroll offsets
- wire drag scrolling into the main UI panels so tower menus and overlays can be panned without scrollbars

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ffae95191c832aad640960f39db292