### PR TITLE
Rotate playfield layout for desktop landscapes

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -398,9 +398,6 @@ body.graphics-mode-low .control-button {
 
 .playfield {
   position: relative;
-  width: min(420px, 100%, calc((100vh - 160px) * 9 / 16));
-  max-height: calc(100vh - 160px);
-  aspect-ratio: 9 / 16;
   border-radius: 24px;
   border: 1px solid rgba(255, 255, 255, 0.12);
   overflow: hidden;
@@ -410,6 +407,19 @@ body.graphics-mode-low .control-button {
   box-shadow: inset 0 0 30px rgba(139, 247, 255, 0.12), 0 18px 36px rgba(0, 0, 0, 0.5);
   cursor: crosshair;
   touch-action: none;
+}
+
+.playfield:not(.playfield--landscape),
+.playfield.playfield--portrait {
+  width: min(420px, 100%, calc((100vh - 160px) * 9 / 16));
+  max-height: calc(100vh - 160px);
+  aspect-ratio: 9 / 16;
+}
+
+.playfield.playfield--landscape {
+  width: min(900px, 100%, calc((100vh - 160px) * 16 / 9));
+  max-height: calc(100vh - 160px);
+  aspect-ratio: 16 / 9;
 }
 
 .playfield canvas {


### PR DESCRIPTION
## Summary
- detect the viewport orientation when entering a level and rotate the stored path/auto-anchor geometry for landscape sessions
- toggle playfield container classes so CSS can size the battlefield at 16:9 on landscape screens while preserving the original portrait styling elsewhere

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ffb2be3650832aa8d1d8712598dfa3