### PR TITLE
Adjust powder tower markers

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -2184,7 +2184,7 @@ body.graphics-mode-low .control-button {
     filter var(--transition),
     transform 0.45s ease-out;
   will-change: transform;
-  overflow: hidden;
+  overflow: visible; /* Allow wall annotations to fully render within the basin. */
 }
 
 .powder-wall-hitbox {
@@ -2251,7 +2251,9 @@ body.graphics-mode-low .control-button {
   color: rgba(255, 196, 128, 0.92);
   background: rgba(14, 16, 24, 0.82);
   box-shadow: 0 0 8px rgba(255, 196, 128, 0.38);
-  white-space: nowrap;
+  max-width: 18ch; /* Keep the label compact enough to stay in view. */
+  white-space: normal; /* Permit wrapping so long labels stay within bounds. */
+  line-height: 1.2;
 }
 
 .powder-crest-marker {
@@ -2262,9 +2264,17 @@ body.graphics-mode-low .control-button {
 
 .powder-crest-marker::after {
   right: auto;
-  left: -2.8rem;
+  left: 0.6rem;
+  transform: translate(0, 0); /* Keep the crest label anchored inside the left wall. */
   color: rgba(80, 160, 255, 0.82);
   box-shadow: 0 0 6px rgba(80, 160, 255, 0.35);
+}
+
+.powder-wall-right .powder-wall-marker::after {
+  left: auto;
+  right: 0.6rem;
+  transform: translate(0, 0); /* Align the progress label with the right wall interior. */
+  text-align: right;
 }
 
 .powder-wall.wall-awake {

--- a/index.html
+++ b/index.html
@@ -956,7 +956,6 @@
                   aria-hidden="true"
                 ></div>
                 <div class="powder-wall powder-wall-left" id="powder-wall-left" aria-hidden="true">
-                  <div class="powder-wall-marker" id="powder-wall-marker" data-height="Peak 0.00" aria-hidden="true"></div>
                   <div
                     class="powder-wall-marker powder-crest-marker"
                     id="powder-crest-marker"
@@ -977,6 +976,8 @@
                   aria-hidden="true"
                 ></div>
                 <div class="powder-wall powder-wall-right" id="powder-wall-right" aria-hidden="true">
+                  <div class="powder-wall-marker" id="powder-wall-marker" data-height="Peak 0.00" aria-hidden="true"></div>
+                  <!-- Display the progress marker on the right wall so it no longer overlaps the crest label. -->
                   <div class="powder-glyph-column" data-powder-glyph-column="right"></div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- move the powder progress marker to the right wall to prevent overlap with the crest label
- update powder tower styles so crest and progress labels stay visible inside their walls
- allow long labels to wrap gracefully within the basin annotations

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68ffe6c0a6c4832a99edf4cf8a398281