### PR TITLE
Fix playfield loadout initialization

### DIFF
--- a/assets/playfield.js
+++ b/assets/playfield.js
@@ -12,6 +12,7 @@ import {
   refreshTowerLoadoutDisplay,
   cancelTowerDrag,
   getTowerEquationBlueprint,
+  getTowerLoadoutState,
 } from './towersTab.js';
 import {
   moteGemState,


### PR DESCRIPTION
## Summary
- import the tower loadout state helper into the playfield so level entry can initialize available towers without throwing

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ffe8247280832a91d83f2ce2000857