### PR TITLE
Add physics-based layout to tower tree map

### DIFF
--- a/assets/towerTreeMap.js
+++ b/assets/towerTreeMap.js
@@ -8,6 +8,18 @@ import { convertMathExpressionToPlainText } from '../scripts/core/mathText.js';
 
 const SVG_NS = 'http://www.w3.org/2000/svg';
 
+const PHYSICS_CONFIG = {
+  /** Diameter of the orbit button in pixels (matches CSS width of 110px). */
+  nodeDiameter: 110,
+  /** Springs try to reach 1.5 × tower diameter per tier of separation. */
+  targetLengthMultiplier: 1.5,
+  springStrength: 9,
+  anchorStrength: 0.6,
+  repulsionStrength: 60000,
+  damping: 0.94,
+  maxDelta: 0.05,
+};
+
 const towerTreeState = {
   toggleButton: null,
   mapContainer: null,
@@ -15,7 +27,19 @@ const towerTreeState = {
   linkLayer: null,
   cardGrid: null,
   needsRefresh: false,
+  nodes: new Map(),
+  edges: [],
+  animationHandle: null,
+  lastTimestamp: null,
 };
+
+function stopSimulation() {
+  if (towerTreeState.animationHandle !== null) {
+    cancelAnimationFrame(towerTreeState.animationHandle);
+    towerTreeState.animationHandle = null;
+  }
+  towerTreeState.lastTimestamp = null;
+}
 
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -87,6 +111,9 @@ function collectTowerDependencies(equation, towers, currentId) {
 }
 
 function clearTreeLayers() {
+  stopSimulation();
+  towerTreeState.nodes.clear();
+  towerTreeState.edges = [];
   if (towerTreeState.nodeLayer) {
     towerTreeState.nodeLayer.innerHTML = '';
   }
@@ -126,35 +153,160 @@ function createTreeNode(definition, position, indexInTier) {
   return { element: node, orbit, position };
 }
 
-function buildTreeLinks(nodes, edges) {
-  if (!towerTreeState.linkLayer) {
-    return;
+function buildTreeLinks(definitions, edges) {
+  if (!towerTreeState.linkLayer || !towerTreeState.mapContainer) {
+    return [];
   }
   const rect = towerTreeState.mapContainer.getBoundingClientRect();
   towerTreeState.linkLayer.setAttribute('viewBox', `0 0 ${rect.width} ${rect.height}`);
   towerTreeState.linkLayer.setAttribute('preserveAspectRatio', 'none');
+  const tierById = new Map();
+  definitions.forEach((definition) => {
+    const tierValue = Number.isFinite(definition.tier) ? definition.tier : 0;
+    tierById.set(definition.id, tierValue);
+  });
+  const orbitSample = towerTreeState.nodeLayer?.querySelector('.tower-tree-node-orbit');
+  const measuredDiameter = orbitSample?.offsetWidth || PHYSICS_CONFIG.nodeDiameter;
+  const baseLength = measuredDiameter * PHYSICS_CONFIG.targetLengthMultiplier;
 
-  edges.forEach(([fromId, toId]) => {
-    const fromNode = nodes.get(fromId);
-    const toNode = nodes.get(toId);
+  return edges.map(([fromId, toId]) => {
+    const line = document.createElementNS(SVG_NS, 'line');
+    line.classList.add('tower-tree-link');
+    towerTreeState.linkLayer.append(line);
+    const fromTier = tierById.get(fromId) ?? 0;
+    const toTier = tierById.get(toId) ?? 0;
+    const tierDistance = Math.max(1, Math.abs(fromTier - toTier));
+    return {
+      fromId,
+      toId,
+      element: line,
+      targetLength: baseLength * tierDistance,
+    };
+  });
+}
+
+function applySpringForces() {
+  towerTreeState.edges.forEach((edge) => {
+    const nodeA = towerTreeState.nodes.get(edge.fromId);
+    const nodeB = towerTreeState.nodes.get(edge.toId);
+    if (!nodeA || !nodeB) {
+      return;
+    }
+    const dx = nodeB.position.x - nodeA.position.x;
+    const dy = nodeB.position.y - nodeA.position.y;
+    const distance = Math.hypot(dx, dy) || 0.0001;
+    const difference = distance - edge.targetLength;
+    const strength = PHYSICS_CONFIG.springStrength * difference;
+    const forceX = (dx / distance) * strength;
+    const forceY = (dy / distance) * strength;
+    nodeA.force.x += forceX;
+    nodeA.force.y += forceY;
+    nodeB.force.x -= forceX;
+    nodeB.force.y -= forceY;
+  });
+}
+
+function applyAnchorForces() {
+  towerTreeState.nodes.forEach((node) => {
+    const anchorX = node.anchor.x;
+    const anchorY = node.anchor.y;
+    node.force.x += (anchorX - node.position.x) * PHYSICS_CONFIG.anchorStrength;
+    node.force.y += (anchorY - node.position.y) * PHYSICS_CONFIG.anchorStrength;
+  });
+}
+
+function applyRepulsionForces() {
+  const nodeList = [...towerTreeState.nodes.values()];
+  for (let i = 0; i < nodeList.length; i += 1) {
+    for (let j = i + 1; j < nodeList.length; j += 1) {
+      const nodeA = nodeList[i];
+      const nodeB = nodeList[j];
+      const dx = nodeB.position.x - nodeA.position.x;
+      const dy = nodeB.position.y - nodeA.position.y;
+      const distanceSq = dx * dx + dy * dy || 0.0001;
+      const distance = Math.sqrt(distanceSq);
+      const minDistance = PHYSICS_CONFIG.nodeDiameter;
+      const strength = (PHYSICS_CONFIG.repulsionStrength / (distanceSq * Math.max(distance / minDistance, 0.35)));
+      const forceX = (dx / distance) * strength;
+      const forceY = (dy / distance) * strength;
+      nodeA.force.x -= forceX;
+      nodeA.force.y -= forceY;
+      nodeB.force.x += forceX;
+      nodeB.force.y += forceY;
+    }
+  }
+}
+
+function updateLinkPositions() {
+  towerTreeState.edges.forEach((edge) => {
+    const fromNode = towerTreeState.nodes.get(edge.fromId);
+    const toNode = towerTreeState.nodes.get(edge.toId);
     if (!fromNode || !toNode) {
       return;
     }
-    const line = document.createElementNS(SVG_NS, 'line');
-    const fromRect = fromNode.element.getBoundingClientRect();
-    const toRect = toNode.element.getBoundingClientRect();
-    const containerRect = towerTreeState.mapContainer.getBoundingClientRect();
-    const x1 = fromRect.left - containerRect.left + fromRect.width / 2;
-    const y1 = fromRect.top - containerRect.top + fromRect.height / 2;
-    const x2 = toRect.left - containerRect.left + toRect.width / 2;
-    const y2 = toRect.top - containerRect.top + toRect.height / 2;
-    line.setAttribute('x1', String(x1));
-    line.setAttribute('y1', String(y1));
-    line.setAttribute('x2', String(x2));
-    line.setAttribute('y2', String(y2));
-    line.classList.add('tower-tree-link');
-    towerTreeState.linkLayer.append(line);
+    edge.element.setAttribute('x1', String(fromNode.position.x));
+    edge.element.setAttribute('y1', String(fromNode.position.y));
+    edge.element.setAttribute('x2', String(toNode.position.x));
+    edge.element.setAttribute('y2', String(toNode.position.y));
   });
+}
+
+function stepSimulation(timestamp) {
+  if (!towerTreeState.mapContainer || towerTreeState.mapContainer.hidden) {
+    stopSimulation();
+    return;
+  }
+  if (!towerTreeState.nodes.size) {
+    stopSimulation();
+    return;
+  }
+  if (towerTreeState.lastTimestamp === null) {
+    towerTreeState.lastTimestamp = timestamp;
+  }
+  const deltaMs = timestamp - towerTreeState.lastTimestamp;
+  const delta = Math.min(deltaMs / 1000, PHYSICS_CONFIG.maxDelta);
+  towerTreeState.lastTimestamp = timestamp;
+
+  const containerWidth = towerTreeState.nodeLayer?.offsetWidth || 0;
+  const containerHeight = towerTreeState.nodeLayer?.offsetHeight || 0;
+  const boundaryPadding = PHYSICS_CONFIG.nodeDiameter * 0.75;
+
+  towerTreeState.nodes.forEach((node) => {
+    node.force.x = 0;
+    node.force.y = 0;
+  });
+
+  applySpringForces();
+  applyRepulsionForces();
+  applyAnchorForces();
+
+  towerTreeState.nodes.forEach((node) => {
+    const accelX = node.force.x;
+    const accelY = node.force.y;
+    node.velocity.x = (node.velocity.x + accelX * delta) * PHYSICS_CONFIG.damping;
+    node.velocity.y = (node.velocity.y + accelY * delta) * PHYSICS_CONFIG.damping;
+    node.position.x += node.velocity.x * delta;
+    node.position.y += node.velocity.y * delta;
+    node.position.x = Math.min(
+      Math.max(boundaryPadding, node.position.x),
+      Math.max(boundaryPadding, containerWidth - boundaryPadding),
+    );
+    node.position.y = Math.min(
+      Math.max(boundaryPadding, node.position.y),
+      Math.max(boundaryPadding, containerHeight - boundaryPadding),
+    );
+    node.element.style.left = `${node.position.x}px`;
+    node.element.style.top = `${node.position.y}px`;
+  });
+
+  updateLinkPositions();
+
+  towerTreeState.animationHandle = window.requestAnimationFrame(stepSimulation);
+}
+
+function startSimulation() {
+  stopSimulation();
+  towerTreeState.animationHandle = window.requestAnimationFrame(stepSimulation);
 }
 
 function computeNodeLayout(towers) {
@@ -234,11 +386,28 @@ function refreshTreeInternal() {
       return;
     }
     const node = createTreeNode(definition, position, indexCounter++);
-    nodes.set(towerId, node);
+    node.element.style.left = `${position.x}px`;
+    node.element.style.top = `${position.y}px`;
     towerTreeState.nodeLayer.append(node.element);
+    nodes.set(towerId, {
+      id: towerId,
+      definition,
+      element: node.element,
+      orbit: node.orbit,
+      position: { ...position },
+      anchor: { ...position },
+      velocity: {
+        x: (Math.random() - 0.5) * 40,
+        y: (Math.random() - 0.5) * 40,
+      },
+      force: { x: 0, y: 0 },
+    });
   });
 
-  buildTreeLinks(nodes, edges);
+  towerTreeState.nodes = nodes;
+  towerTreeState.edges = buildTreeLinks(definitions, edges);
+  updateLinkPositions();
+  startSimulation();
   towerTreeState.needsRefresh = false;
 }
 
@@ -256,6 +425,8 @@ function toggleTreeVisibility(forceOpen = null) {
   towerTreeState.toggleButton.setAttribute('aria-expanded', nextOpen ? 'true' : 'false');
   if (nextOpen) {
     refreshTreeInternal();
+  } else {
+    stopSimulation();
   }
 }
 


### PR DESCRIPTION
## Summary
- replace the static tower tree layout with a spring-based physics simulation that allows horizontal and vertical drift
- size connection springs by tier distance so linked towers gently seek their intended spacing
- keep SVG link positions in sync with the simulated nodes and stop the simulation when the map is hidden

## Testing
- not run (web feature)

------
https://chatgpt.com/codex/tasks/task_e_68ffeb71c104832a9589ae83352900cf