### PR TITLE
Shrink powder motes and stabilize wall scrolling

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -1683,6 +1683,8 @@ import {
 
   let powderBasinPulseTimer = null;
 
+  const POWDER_WALL_TEXTURE_REPEAT_PX = 192; // Mirror the tower wall sprite tile height so loops stay seamless.
+
   const idleLevelRuns = new Map();
 
   let powderSimulation = null;
@@ -4976,11 +4978,19 @@ import {
     }
 
     const wallShiftPx = scrollOffset * cellSize;
+    const textureRepeat = POWDER_WALL_TEXTURE_REPEAT_PX > 0 ? POWDER_WALL_TEXTURE_REPEAT_PX : null;
+    const rawTextureOffset = textureRepeat ? wallShiftPx % textureRepeat : wallShiftPx;
+    const wallTextureOffset = Number.isFinite(rawTextureOffset) ? rawTextureOffset : 0;
+    const wallOffsetValue = `${wallTextureOffset.toFixed(1)}px`;
+
     if (powderElements.leftWall) {
-      powderElements.leftWall.style.transform = `translateY(${wallShiftPx.toFixed(1)}px)`;
+      powderElements.leftWall.style.transform = '';
+      // Apply the offset via a CSS variable so the wall texture scrolls without breaking crest markers.
+      powderElements.leftWall.style.setProperty('--powder-wall-shift', wallOffsetValue);
     }
     if (powderElements.rightWall) {
-      powderElements.rightWall.style.transform = `translateY(${wallShiftPx.toFixed(1)}px)`;
+      powderElements.rightWall.style.transform = '';
+      powderElements.rightWall.style.setProperty('--powder-wall-shift', wallOffsetValue);
     }
 
     const basinHeight = rows * cellSize;

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -2174,7 +2174,11 @@ body.graphics-mode-low .control-button {
     url('./sprites/inspiration_tower_wall.png');
   background-repeat: no-repeat, repeat-y;
   background-size: 100% 100%, 128px 192px;
-  background-position: center, center top;
+  /* Offset the repeating tower texture so it can scroll smoothly with the dune crest. */
+  --powder-wall-shift: 0px;
+  background-position:
+    center center,
+    center var(--powder-wall-shift, 0px);
   background-blend-mode: overlay, normal;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
   z-index: 1;

--- a/scripts/features/towers/powderTower.js
+++ b/scripts/features/towers/powderTower.js
@@ -308,8 +308,9 @@ export function computeMotePaletteFromTheme() {
 }
 
 export const POWDER_CELL_SIZE_PX = 1;
-export const MOTE_RENDER_SCALE = 3;
-export const MOTE_COLLISION_SCALE = MOTE_RENDER_SCALE;
+// Render and collide motes at their base cell footprint so each grain appears one-third the previous size.
+export const MOTE_RENDER_SCALE = 1;
+export const MOTE_COLLISION_SCALE = 1;
 
 export class PowderSimulation {
   constructor(options = {}) {


### PR DESCRIPTION
## Summary
- shrink mote render and collision scaling so each grain renders at one third of its previous footprint
- drive the powder wall texture offset with a CSS variable instead of translating the entire wall element
- keep crest and glyph markers aligned by syncing the wall texture offset in the height change handler

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68ffeddfc6b8832ab6c4958cd5b9a0ce