### PR TITLE
Fix tower tree map script redeclaration crash

### DIFF
--- a/assets/towerTreeMap.js
+++ b/assets/towerTreeMap.js
@@ -187,15 +187,6 @@ function buildTreeLinks(definitions, edges) {
       targetLength: baseLength * tierDistance,
     };
   });
-
-  updateLinkPositions();
-
-  towerTreeState.animationHandle = window.requestAnimationFrame(stepSimulation);
-}
-
-function startSimulation() {
-  stopSimulation();
-  towerTreeState.animationHandle = window.requestAnimationFrame(stepSimulation);
 }
 
 function applySpringForces() {


### PR DESCRIPTION
## Summary
- remove the redundant startSimulation helper from the tower tree map module to avoid duplicate identifier errors when loading the page

## Testing
- Manual: Loaded `index.html` in Playwright and confirmed no console errors


------
https://chatgpt.com/codex/tasks/task_e_690007f8d0cc832a85da6bf0410a7c70