### PR TITLE
Fix enemy exponent labels and touch placement

### DIFF
--- a/assets/data/gameplayConfig.json
+++ b/assets/data/gameplayConfig.json
@@ -31,7 +31,7 @@
       "baseCost": 100,
       "damage": 10,
       "rate": 2,
-      "range": 5,
+      "range": 0.36,
       "icon": "assets/images/tower-beta.svg",
       "nextTierId": "gamma"
     },

--- a/assets/playfield.js
+++ b/assets/playfield.js
@@ -4171,7 +4171,9 @@ export class SimplePlayfield {
       ctx.font = `${metrics.exponentSize}px "Space Mono", monospace`;
       ctx.textAlign = 'left';
       ctx.textBaseline = 'top';
-      ctx.fillText('k', metrics.coreRadius * 0.35, -metrics.coreRadius * 0.6);
+      const exponentLabel = String(exponent);
+      // Display the precise exponent so each glyph telegraphs its ten-power health tier.
+      ctx.fillText(exponentLabel, metrics.coreRadius * 0.35, -metrics.coreRadius * 0.6);
 
       if (this.focusedEnemyId === enemy.id) {
         // Draw a rotating focus marker so players can track the prioritized enemy.

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -622,6 +622,8 @@ body.graphics-mode-low .control-button {
   justify-items: center;
   gap: 10px;
   cursor: grab;
+  /* Disable default touch scrolling so drag gestures focus on lattice placement. */
+  touch-action: none;
   transition: transform var(--transition), border-color var(--transition), box-shadow var(--transition),
     opacity var(--transition);
   min-height: 116px;

--- a/scripts/features/towers/betaMath.js
+++ b/scripts/features/towers/betaMath.js
@@ -8,7 +8,7 @@
  */
 export const BETA_BASE_ATTACK = 10;
 export const BETA_BASE_ATTACK_SPEED = 2;
-export const BETA_BASE_RANGE = 5;
+export const BETA_BASE_RANGE = 0.36;
 
 /**
  * Ensures the exponent can never drop below one or become `NaN`.


### PR DESCRIPTION
## Summary
- render the calculated enemy health exponent instead of a placeholder so power tiers are visible again
- normalize the beta tower base range to a fractional board scale so placement previews stay within the field
- prevent touch scrolling on loadout buttons to allow tower dragging on mobile

## Testing
- Manual verification of canvas rendering

------
https://chatgpt.com/codex/tasks/task_e_690018047e04832aaab67047a9df7ea3