### PR TITLE
Align tower tree map viewport and link positions

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1559,8 +1559,9 @@ body.graphics-mode-low .control-button {
   border-radius: 18px;
   background: linear-gradient(160deg, rgba(5, 5, 12, 0.8), rgba(16, 16, 24, 0.9));
   padding: 24px;
-  margin-bottom: 18px;
-  min-height: 260px;
+  margin: 0 auto 18px;
+  width: min(420px, 100%, calc((100vh - 160px) * 9 / 16));
+  aspect-ratio: 9 / 16;
   overflow: hidden;
 }
 
@@ -1579,16 +1580,15 @@ body.graphics-mode-low .control-button {
 
 .tower-tree-map-links {
   position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
+  left: 0;
+  top: 0;
   pointer-events: none;
 }
 
 .tower-tree-map-nodes {
-  position: relative;
-  width: 100%;
-  height: 100%;
+  position: absolute;
+  left: 0;
+  top: 0;
 }
 
 .tower-tree-node {


### PR DESCRIPTION
## Summary
- resize and center the tower tree map viewport to match the tower/level playfield aspect ratio
- update camera math and svg canvas sizing so constellation links stay aligned with their towers while panning and zooming
- cache padding offsets for pointer math and keep the view centered after rebuilding nodes

## Testing
- not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_690035496354832a9a1329ca13c39044