### PR TITLE
Hide playfield until level start and add in-game menu

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -365,6 +365,11 @@ body.graphics-mode-low .control-button {
   }
 }
 
+.is-hidden {
+  /* Utility class that fully hides interactive shells when inactive. */
+  display: none !important;
+}
+
 .track-caption {
   text-align: center;
   max-width: 520px;
@@ -407,6 +412,72 @@ body.graphics-mode-low .control-button {
   box-shadow: inset 0 0 30px rgba(139, 247, 255, 0.12), 0 18px 36px rgba(0, 0, 0, 0.5);
   cursor: crosshair;
   touch-action: none;
+}
+
+.playfield-menu-button {
+  /* Compact hamburger control that anchors in the playfield's top-right corner. */
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  z-index: 4;
+  width: 38px;
+  height: 38px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(14, 17, 26, 0.86);
+  color: rgba(255, 255, 255, 0.86);
+  font-size: 1.3rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: background var(--transition), transform var(--transition);
+}
+
+.playfield-menu-button:focus,
+.playfield-menu-button:hover {
+  /* Gently highlight the menu activator on hover or focus. */
+  background: rgba(24, 28, 42, 0.95);
+  transform: translateY(-1px);
+}
+
+.playfield-menu-panel {
+  /* Floating panel that reveals quick navigation commands for the battlefield. */
+  position: absolute;
+  top: 62px;
+  right: 14px;
+  z-index: 4;
+  display: grid;
+  gap: 10px;
+  padding: 14px 16px;
+  min-width: 180px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(10, 12, 20, 0.96);
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.45);
+}
+
+.playfield-menu-item {
+  /* Menu option styled to match existing crystalline control buttons. */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(20, 24, 38, 0.92);
+  color: rgba(255, 255, 255, 0.9);
+  font-family: 'Space Mono', monospace;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background var(--transition), color var(--transition);
+}
+
+.playfield-menu-item:hover,
+.playfield-menu-item:focus {
+  /* Elevate the menu command when players highlight it. */
+  background: rgba(36, 40, 60, 0.96);
+  color: rgba(139, 247, 255, 0.92);
 }
 
 .playfield:not(.playfield--landscape),

--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
           role="tabpanel"
           aria-labelledby="tab-tower"
         >
-          <section class="playfield-wrapper" aria-live="polite">
+          <section class="playfield-wrapper" id="playfield-wrapper" aria-live="polite">
             <div class="playfield-shell">
               <div
                 class="playfield"
@@ -97,6 +97,27 @@
                 role="img"
                 aria-label="Interactive glyph defense lane"
               >
+                <!-- Playfield menu surfaces layout toggles when a level is active. -->
+                <button
+                  class="playfield-menu-button"
+                  type="button"
+                  id="playfield-menu-button"
+                  aria-label="Open playfield menu"
+                  aria-controls="playfield-menu-panel"
+                  aria-expanded="false"
+                >
+                  ☰
+                </button>
+                <div class="playfield-menu-panel" id="playfield-menu-panel" role="menu" hidden>
+                  <button
+                    class="playfield-menu-item"
+                    type="button"
+                    id="playfield-menu-level-select"
+                    role="menuitem"
+                  >
+                    Level Selection
+                  </button>
+                </div>
                 <canvas id="playfield-canvas" width="560" height="360"></canvas>
                 <dl class="playfield-stats" aria-live="polite">
                   <div class="playfield-stats__item">
@@ -122,7 +143,7 @@
               <div class="tower-loadout-grid" id="tower-loadout-grid" role="list"></div>
             </div>
           </section>
-          <div class="stage-controls" role="group" aria-label="Defense controls">
+          <div class="stage-controls" id="stage-controls" role="group" aria-label="Defense controls">
             <button class="play-button" type="button" id="playfield-start" disabled>
               Commence Wave
             </button>
@@ -139,7 +160,7 @@
               Auto-send next wave
             </label>
           </div>
-          <section class="level-section">
+          <section class="level-section" id="level-selection">
             <header class="subsection-title">Conjecture Set</header>
             <p class="level-intro">
               The opening proofs trace immortal-defense style figure-eights,


### PR DESCRIPTION
## Summary
- hide the playfield shell and stage controls until an interactive level is running, ensuring the level grid returns when leaving a map
- add a playfield menu button that confirms before returning to the level selection screen and resizes the battlefield when reopened
- style the menu control to match the existing aesthetic and keep it anchored to the playfield corner

## Testing
- not run (project lacks automated tests)


------
https://chatgpt.com/codex/tasks/task_e_690059d035b4832aa006466ffffc9d0e