### PR TITLE
Fix tower tree map gesture handling and jitter

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1681,6 +1681,8 @@ body.graphics-mode-low .control-button {
   width: min(420px, 100%, calc((100vh - 160px) * 9 / 16));
   aspect-ratio: 9 / 16;
   overflow: hidden;
+  /* Let custom JS manage panning and zooming gestures within the map. */
+  touch-action: none;
 }
 
 .tower-tree-map-note {
@@ -1742,6 +1744,8 @@ body.graphics-mode-low .control-button {
   /* Animate a gentle drift so the tower constellation feels alive. */
   animation: tower-tree-node-float calc(7s + var(--tower-float-variance, 0s)) ease-in-out infinite;
   transition: transform 220ms ease, border-color 220ms ease, box-shadow 220ms ease;
+  /* Allow node drags to override native scrolling and zooming on touch devices. */
+  touch-action: none;
 }
 
 .tower-tree-node-orbit:hover,


### PR DESCRIPTION
## Summary
- update the tower tree toggle to swap labels and hide the card list while the constellation is open
- fix drag and pinch math while allowing touch gestures to be handled by the custom logic
- persist horizontal jitter so the constellation no longer reshuffles on scroll

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6900e3a8b380832a9d1203ff43e881f4