### PR TITLE
Add tower variable glossary and overlay

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1636,7 +1636,7 @@ body.graphics-mode-low .control-button {
   gap: 12px;
 }
 
-.tower-tree-map-button {
+.tower-panel-button {
   display: inline-flex;
   align-items: center;
   gap: 10px;
@@ -1653,18 +1653,38 @@ body.graphics-mode-low .control-button {
   transition: transform var(--transition), background var(--transition), border-color var(--transition);
 }
 
-.tower-tree-map-button:hover,
-.tower-tree-map-button:focus-visible {
+.tower-panel-button:hover,
+.tower-panel-button:focus-visible {
   transform: translateY(-1px);
   background: rgba(247, 247, 245, 0.12);
   border-color: rgba(247, 247, 245, 0.3);
   outline: none;
 }
 
-.tower-tree-map-button[aria-pressed='true'] {
+.tower-panel-button[aria-pressed='true'],
+.tower-panel-button[aria-expanded='true'] {
   background: rgba(247, 247, 245, 0.16);
   border-color: rgba(255, 228, 120, 0.45);
   box-shadow: 0 14px 26px rgba(255, 228, 120, 0.18);
+}
+
+.tower-panel-button-icon {
+  width: 42px;
+  height: 42px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  font-family: 'Space Mono', monospace;
+  font-size: 0.8rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  background: radial-gradient(circle at 30% 30%, rgba(247, 247, 245, 0.16), transparent 70%);
+  color: rgba(247, 247, 245, 0.85);
+}
+
+.tower-panel-button-label {
+  white-space: nowrap;
 }
 
 .tower-tree-map-icon {
@@ -1699,6 +1719,80 @@ body.graphics-mode-low .control-button {
   overflow: hidden;
   /* Let custom JS manage panning and zooming gestures within the map. */
   touch-action: none;
+}
+
+.variable-library-overlay .overlay-panel {
+  max-width: 520px;
+}
+
+.variable-library-list {
+  list-style: none;
+  margin: 24px 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.variable-library-item {
+  border: 1px solid rgba(247, 247, 245, 0.18);
+  border-radius: 14px;
+  background: linear-gradient(160deg, rgba(12, 12, 18, 0.85), rgba(22, 22, 30, 0.85));
+  padding: 16px 18px;
+  display: grid;
+  gap: 6px;
+  transition: transform var(--transition), border-color var(--transition);
+}
+
+.variable-library-item:hover {
+  transform: translateY(-2px);
+  border-color: rgba(255, 228, 120, 0.45);
+}
+
+.variable-library-header {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.variable-library-symbol {
+  font-family: 'Space Mono', monospace;
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(255, 228, 120, 0.12);
+  color: rgba(255, 228, 120, 0.95);
+}
+
+.variable-library-name {
+  font-size: 1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.variable-library-description {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+
+.variable-library-source {
+  margin: 0;
+  font-family: 'Space Mono', monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(247, 247, 245, 0.7);
+}
+
+.variable-library-empty {
+  margin: 32px 0 12px;
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.9rem;
 }
 
 .tower-tree-map-note {

--- a/docs/PROGRESSION.md
+++ b/docs/PROGRESSION.md
@@ -78,15 +78,32 @@ The tower roster now explicitly runs through the entire Greek alphabet from **α
 - **Merge ladder:** Players may still merge adjacent lowercase towers alphabetically (α into β, β into γ, and so on), but the prestige path offers a sideways option that preserves the flavor of the lowercase while unlocking late-game power spikes.
 - **Cost cadence:** Tower costs escalate exponentially with simultaneous copies. Building the `k`‑th instance of a given lowercase letter costs `(base cost)^k`. Fusing or prestiging refunds the cost pressure because active tower counts drop by four when five become one.
 
+### Universal Variable Glossary
+To keep formulas readable across the roster, every tower draws from a shared set of variable glyphs. The table below catalogs the evergreen symbols now surfaced in the in-game glossary. As new lattices unlock, additional situational variables (such as tempo `Tmp`) may join, but the core abbreviations will not change meaning from tower to tower.
+
+| Symbol | Name | Description | First Appears |
+| --- | --- | --- | --- |
+| **Atk** | Attack | Base damage delivered per strike. | α tower primary stat |
+| **m** | Range | Effective attack radius measured in meters. | Global tower stats |
+| **Spd** | Attack Speed | Primary attack cadence (attacks per second). | α tower primary stat |
+| **Dod** | Damage over Distance | Bonus damage accumulated as projectiles travel. | Soldier-focused upgrades |
+| **Def** | Defense | Flat protection applied to delta-style cohorts. | δ tower schematics |
+| **Def%** | Defense Percent | Percentage-based defense modifier for cohorts. | Soldier research trees |
+| **Atk%** | Attack Percent | Percentage multiplier applied to base attack. | Offensive upgrade suites |
+| **Prc** | Pierce | Number of enemies a strike can pierce before dissipating. | Beam-oriented towers |
+| **Chn** | Chaining | Additional enemies a projectile can arc toward. | Chain lightning variants |
+| **Slw%** | Slow Percent | Percentage slow applied to enemies within an effect. | Control-focused towers |
+| **Tot** | Total | Maximum allied units a command lattice fields simultaneously. | δ delta tower |
+
 ### Lowercase and Uppercase Glyph Index
 Each entry combines three beats: a flavorful formula, a combat mechanic, and a hidden nod to the mathematical symbol from which the glyph draws power. The uppercase prestige upgrade reiterates the same formula and layers on one decisive bonus.
 
 | Letter Pair | Lowercase Formula & Core Behavior | Symbolic Parallel & Combat Quirk | Uppercase Prestige Mutation |
 | --- | --- | --- | --- |
-| Α / α | `α = 5X · YZ` combines base damage with dual tempo controls. | Alpha launches the first strike with calibratable pulses. | **Α** keeps the triple-product core and layers a bonus burst whenever the secondary tempo levels up. |
-| Β / β | `β = α^{X}` channels α into an exponent beam. | Beta feeds on α's output, focusing it into piercing light. | **Β** locks the exponent and adds a mirrored return beam after each shot. |
+| Α / α | `α = 5 · Atk · Spd · Tmp` combines base damage with dual tempo controls. | Alpha launches the first strike with calibratable pulses. | **Α** keeps the triple-product core and layers a bonus burst whenever the secondary tempo levels up. |
+| Β / β | `β = α^{Exp}` channels α into an exponent beam. | Beta feeds on α's output, focusing it into piercing light. | **Β** locks the exponent and adds a mirrored return beam after each shot. |
 | Γ / γ | `γ = √β` tempers beta resonance into homing arcs. | Gamma softens β into agile lightning conductors. | **Γ** preserves the root pulse and fires an aftershock equal to 25% of the rooted damage. |
-| Δ / δ | `δ = γ · ln(γ + 1)` summons cohorts scaled by γ alone. | Delta embodies change, commanding glyph soldiers from pure γ strength. | **Δ** keeps the logarithmic command and leaves a slowing field keyed to the same γ value. |
+| Δ / δ | `δ = γ · ln(γ + 1)` summons cohorts scaled by γ alone. | Delta embodies change, commanding glyph soldiers from pure γ strength while `Tot` governs how many specters rally at once. | **Δ** keeps the logarithmic command and leaves a slowing field keyed to the same γ value. |
 | Ε / ε | `ε = δ^{2}` squares delta into needle storms. | Epsilon erupts when δ squads collide, doubling their force. | **Ε** sustains the squared storm and freezes enemy armor at the lowest sampled value for three seconds. |
 | Ζ / ζ | `ζ = √ε` roots the needle storm into harmonic splash. | Zeta reshapes ε's frenzy into controlled cascades. | **Ζ** reflects the rooted splash as a harmonic echo every fourth shot. |
 | Η / η | `η = ln(ζ + 1)` condenses zeta into alternating veils. | Eta flips between burn and chill as ζ rises. | **Η** doubles the duration of whichever status just triggered. |

--- a/index.html
+++ b/index.html
@@ -198,7 +198,7 @@
         >
           <div class="tower-panel-controls" id="tower-panel-controls">
             <button
-              class="tower-tree-map-button"
+              class="tower-panel-button tower-tree-map-button"
               type="button"
               id="tower-tree-map-toggle"
               aria-pressed="false"
@@ -229,7 +229,29 @@
                   </g>
                 </svg>
               </span>
-              <span class="tower-tree-map-label">Tower Tree Map</span>
+              <span class="tower-tree-map-label tower-panel-button-label">Tower Tree Map</span>
+            </button>
+            <button
+              class="tower-panel-button tower-panel-button--variables"
+              type="button"
+              id="tower-variable-library"
+              aria-haspopup="dialog"
+              aria-controls="variable-library-overlay"
+              aria-expanded="false"
+            >
+              <span class="tower-panel-button-icon" aria-hidden="true">Var</span>
+              <span class="tower-panel-button-label">Variables</span>
+            </button>
+            <button
+              class="tower-panel-button tower-panel-button--matrix"
+              type="button"
+              data-upgrade-matrix-trigger
+              aria-haspopup="dialog"
+              aria-controls="upgrade-matrix-overlay"
+              aria-expanded="false"
+            >
+              <span class="tower-panel-button-icon" aria-hidden="true">⧉</span>
+              <span class="tower-panel-button-label">Upgrade Matrix</span>
             </button>
           </div>
           <div
@@ -276,18 +298,18 @@
                 <h3>α alpha tower</h3>
               </header>
               <div class="formula-block">
-                <p class="formula-line">\( \alpha = 5X \cdot YZ \)</p>
+                <p class="formula-line">\( \alpha = 5 \times Atk \times Spd \times Tmp \)</p>
                 <ul class="formula-definition">
-                  <li>X → attack power (atk)</li>
-                  <li>Y → primary attack speed (/s)</li>
-                  <li>Z → secondary attack speed (/s)</li>
+                  <li>Atk → attack power (base glyph damage)</li>
+                  <li>Spd → primary attack speed (strikes per second)</li>
+                  <li>Tmp → tempo metronome (secondary cadence)</li>
                 </ul>
-                <p class="formula-line result">\( \alpha = 5X \times Y \times Z \)</p>
+                <p class="formula-line result">\( \alpha = 5 \times Atk \times Spd \times Tmp \)</p>
               </div>
               <ul class="upgrade-list">
-                <li>Calibrate X for sharper projectiles (+damage)</li>
-                <li>Accelerate Y through harmonic metronomes (+attack speed)</li>
-                <li>Sync Z with temporal echoes (+attack speed)</li>
+                <li>Calibrate Atk for sharper projectiles (+damage)</li>
+                <li>Accelerate Spd through harmonic metronomes (+attack speed)</li>
+                <li>Sync Tmp with temporal echoes (+tempo)</li>
               </ul>
               <footer class="card-footer">Shoots a focused glyph-bullet at the nearest foe.</footer>
               <button class="tower-equip-button" type="button" data-tower-toggle="alpha">
@@ -300,15 +322,15 @@
                 <h3>β beta tower</h3>
               </header>
               <div class="formula-block">
-                <p class="formula-line">\( \beta = \alpha^{X} \)</p>
+                <p class="formula-line">\( \beta = \alpha^{Exp} \)</p>
                 <ul class="formula-definition">
                   <li>α → flux inherited from alpha lattices</li>
-                  <li>X → exponent focus from β upgrades</li>
+                  <li>Exp → exponent focus from β upgrades</li>
                 </ul>
                 <p class="formula-line result">Refines α into a concentrated piercing beam.</p>
               </div>
               <ul class="upgrade-list">
-                <li>Sharpen X to raise the inherited α power</li>
+                <li>Sharpen Exp to raise the inherited α power</li>
                 <li>Stabilize the beam to hold α's pulse steady</li>
                 <li>Stretch the lattice to guide α farther downlane</li>
               </ul>
@@ -349,6 +371,7 @@
                 <p class="formula-line">\( \delta = \gamma \cdot \ln(\gamma + 1) \)</p>
                 <ul class="formula-definition">
                   <li>γ → conductor strength inherited from the gamma lattice</li>
+                  <li>Tot → total spectral soldiers δ can field concurrently</li>
                 </ul>
                 <p class="formula-line result">Commands spectral cohorts scaled purely by γ.</p>
               </div>
@@ -936,7 +959,7 @@
               <button
                 class="action-button ghost"
                 type="button"
-                id="open-upgrade-matrix"
+                data-upgrade-matrix-trigger
                 aria-haspopup="dialog"
                 aria-controls="upgrade-matrix-overlay"
               >
@@ -1355,6 +1378,33 @@
           <span class="tab-label">Codex</span>
         </button>
       </nav>
+    </div>
+    <div
+      class="level-overlay variable-library-overlay"
+      id="variable-library-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-hidden="true"
+      hidden
+      aria-labelledby="variable-library-title"
+    >
+      <div class="overlay-panel">
+        <button
+          class="overlay-close"
+          type="button"
+          data-variable-library-close
+          aria-label="Close variable glossary"
+        >
+          &times;
+        </button>
+        <p class="overlay-label">Glyph Variables</p>
+        <h2 class="overlay-title" id="variable-library-title">Variable Glossary</h2>
+        <p class="overlay-example">
+          Review every symbol unlocked across your towers and spectral cohorts.
+        </p>
+        <ul class="variable-library-list" id="variable-library-list" role="list"></ul>
+        <p class="overlay-instruction">Tap outside or press Esc to close.</p>
+      </div>
     </div>
     <div
       class="level-overlay upgrade-overlay"


### PR DESCRIPTION
## Summary
- introduce a universal variable library so tower equations share consistent abbreviations
- surface discovered tower variables through a new Variables overlay alongside the tree-map controls
- extend the tower upgrade matrix trigger to work from multiple buttons and refresh the tower documentation glossary

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690103dc7ad8832ab95ffdc1cd33c5c8