### PR TITLE
Add quick commence control and align level preview orientation

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -887,6 +887,17 @@ import {
 
   function updatePlayfieldMenuState() {
     const interactive = Boolean(activeLevelId && activeLevelIsInteractive);
+    if (playfieldMenuCommence) {
+      // Mirror the primary commence button label/state inside the quick menu.
+      const startButton = playfieldElements.startButton;
+      const disabled = !startButton || startButton.disabled;
+      playfieldMenuCommence.disabled = disabled;
+      playfieldMenuCommence.setAttribute('aria-disabled', disabled ? 'true' : 'false');
+      const label = startButton?.textContent?.trim();
+      if (label) {
+        playfieldMenuCommence.textContent = label;
+      }
+    }
     if (playfieldMenuLevelSelect) {
       playfieldMenuLevelSelect.disabled = !interactive && !activeLevelId;
       playfieldMenuLevelSelect.setAttribute(
@@ -1054,6 +1065,17 @@ import {
     leaveActiveLevel();
   }
 
+  function handleCommenceWaveFromMenu() {
+    // Trigger the main commence button from the quick menu while respecting its state.
+    const startButton = playfieldElements.startButton;
+    if (!startButton || startButton.disabled) {
+      return;
+    }
+    startButton.click();
+    closePlayfieldMenu();
+    updatePlayfieldMenuState();
+  }
+
   function handleRetryCurrentWave() {
     resetPlayfieldMenuLevelSelect();
 
@@ -1095,6 +1117,7 @@ import {
   // Store quick menu controls for leaving an active level.
   let playfieldMenuButton = null;
   let playfieldMenuPanel = null;
+  let playfieldMenuCommence = null;
   let playfieldMenuLevelSelect = null;
   let playfieldMenuRetryWave = null;
   let playfieldMenuLevelSelectConfirming = false;
@@ -3631,10 +3654,16 @@ import {
       overlayPreview.setAttribute('aria-hidden', 'false');
       overlayPreview.classList.add('overlay-preview--active');
 
+      const preferredOrientation =
+        playfield && typeof playfield.layoutOrientation === 'string'
+          ? playfield.layoutOrientation
+          : null;
       previewPlayfield = new SimplePlayfield({
         canvas: overlayPreviewCanvas,
         container: overlayPreview,
         previewOnly: true,
+        // Align the preview orientation with the active battlefield when available.
+        preferredOrientation,
       });
       previewPlayfield.enterLevel(level, { endlessMode: false });
       previewPlayfield.draw();
@@ -6836,6 +6865,7 @@ import {
     // Store quick menu controls that surface the level selection confirmation.
     playfieldMenuButton = document.getElementById('playfield-menu-button');
     playfieldMenuPanel = document.getElementById('playfield-menu-panel');
+    playfieldMenuCommence = document.getElementById('playfield-menu-commence');
     playfieldMenuLevelSelect = document.getElementById('playfield-menu-level-select');
     playfieldMenuRetryWave = document.getElementById('playfield-menu-retry-wave');
     if (playfieldMenuLevelSelect) {
@@ -6851,6 +6881,12 @@ import {
       playfieldMenuLevelSelect.addEventListener('click', (event) => {
         event.preventDefault();
         handleReturnToLevelSelection();
+      });
+    }
+    if (playfieldMenuCommence) {
+      playfieldMenuCommence.addEventListener('click', (event) => {
+        event.preventDefault();
+        handleCommenceWaveFromMenu();
       });
     }
     if (playfieldMenuRetryWave) {

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -502,6 +502,11 @@ body.graphics-mode-low .control-button {
   box-shadow: 0 18px 36px rgba(0, 0, 0, 0.45);
 }
 
+.playfield-menu-panel[hidden] {
+  /* Guarantee the quick menu fully hides when its hidden attribute is applied. */
+  display: none !important;
+}
+
 .playfield-menu-item {
   /* Menu option styled to match existing crystalline control buttons. */
   display: inline-flex;
@@ -3777,6 +3782,13 @@ body.graphics-mode-low .control-button {
   height: 100%;
   display: block;
   filter: drop-shadow(0 12px 28px rgba(0, 0, 0, 0.45));
+}
+
+@media (max-width: 768px) {
+  .overlay-preview {
+    /* Favor a portrait preview aspect ratio on narrow/mobile layouts. */
+    aspect-ratio: 9 / 16;
+  }
 }
 
 .overlay-preview__empty {

--- a/index.html
+++ b/index.html
@@ -109,6 +109,15 @@
                   ☰
                 </button>
                 <div class="playfield-menu-panel" id="playfield-menu-panel" role="menu" hidden>
+                  <!-- Replicate the stage control commence trigger within the quick menu. -->
+                  <button
+                    class="playfield-menu-item"
+                    type="button"
+                    id="playfield-menu-commence"
+                    role="menuitem"
+                  >
+                    Commence Wave
+                  </button>
                   <button
                     class="playfield-menu-item"
                     type="button"


### PR DESCRIPTION
## Summary
- add a Commence Wave entry to the playfield quick menu and wire it to the main start control
- ensure the quick menu hides correctly when closed and mirror the start button state inside it
- let level previews respect the active playfield orientation and shift to a portrait aspect ratio on narrow screens

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690123103338832abd3e934fb408f9f6