### PR TITLE
Fix level exit flow and enhance enemy exponent readability

### DIFF
--- a/assets/playfield.js
+++ b/assets/playfield.js
@@ -5256,17 +5256,26 @@ export class SimplePlayfield {
       ctx.textBaseline = 'middle';
       ctx.fillText(symbol || '?', 0, 0);
 
-      ctx.font = `${metrics.exponentSize}px "Cormorant Garamond", serif`;
+      ctx.font = `700 ${metrics.exponentSize}px "Cormorant Garamond", serif`;
       ctx.textAlign = 'right';
       ctx.textBaseline = 'top';
       const exponentLabel = exponent.toFixed(1);
       const exponentColor = this.resolveEnemyExponentColor(enemy);
-      // Paint the exponent with the threat-informed palette so players grasp incoming danger immediately.
-      ctx.fillStyle = exponentColor;
+      // Match the outline width to a single CSS pixel so exponents stay crisp on high-DPI displays.
+      const pixelRatio = Number.isFinite(this.pixelRatio) && this.pixelRatio > 0 ? this.pixelRatio : 1;
+      const outlineWidth = Math.max(1, Math.round(pixelRatio));
+      ctx.lineJoin = 'round';
+      ctx.miterLimit = 2;
+      ctx.strokeStyle = 'rgba(6, 8, 14, 0.85)';
+      ctx.lineWidth = outlineWidth;
       // Display the precise exponent so each glyph telegraphs its ten-power health tier.
       const exponentOffsetX = metrics.ringRadius * 0.94;
       const exponentOffsetY = -metrics.ringRadius * 0.98;
       // Anchor the exponent to the enemy's top-right quadrant so the scientific notation reads cleanly above the glyph.
+      // Outline the exponent before filling so it remains legible over bright projectile bursts.
+      ctx.strokeText(exponentLabel, exponentOffsetX, exponentOffsetY);
+      // Paint the exponent with the threat-informed palette so players grasp incoming danger immediately.
+      ctx.fillStyle = exponentColor;
       ctx.fillText(exponentLabel, exponentOffsetX, exponentOffsetY);
 
       if (this.focusedEnemyId === enemy.id) {

--- a/index.html
+++ b/index.html
@@ -180,11 +180,6 @@
               </div>
             </div>
           </section>
-          <div class="stage-controls" id="stage-controls" role="group" aria-label="Defense controls">
-            <button class="play-button" type="button" id="playfield-start" disabled>
-              Commence Wave
-            </button>
-          </div>
           <section class="level-section" id="level-selection">
             <header class="subsection-title">Conjecture Set</header>
             <p class="level-intro">


### PR DESCRIPTION
## Summary
- remove the redundant commence wave button below the playfield and treat the quick menu control as the primary start trigger
- ensure the level-selection confirmation reliably leaves active encounters and keep the quick menu state in sync afterward
- align desktop level previews with the rotated battlefield layout and outline bold enemy exponents for better readability

## Testing
- not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_690129e68448832a9fe3defde965dff5