### PR TITLE
Remove variable source info from glossary entries

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -4493,15 +4493,6 @@ import {
         item.append(description);
       }
 
-      if (entry.sources && entry.sources.length) {
-        const source = document.createElement('p');
-        source.className = 'variable-library-source';
-        const label =
-          entry.sources.length > 1 ? 'Revealed by towers' : 'Revealed by tower';
-        source.textContent = `${label} ${entry.sources.join(', ')}`;
-        item.append(source);
-      }
-
       fragment.append(item);
     });
 

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1784,15 +1784,6 @@ body.graphics-mode-low .control-button {
   line-height: 1.4;
 }
 
-.variable-library-source {
-  margin: 0;
-  font-family: 'Space Mono', monospace;
-  font-size: 0.72rem;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: rgba(247, 247, 245, 0.7);
-}
-
 .variable-library-empty {
   margin: 32px 0 12px;
   text-align: center;


### PR DESCRIPTION
## Summary
- remove the "Revealed by tower(s)" line from each variable glossary entry
- delete the unused style rules associated with the removed text

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690132f356c0832aa6fd0ac56d8296eb