### PR TITLE
Add tower equipment management with crafting assignments

### DIFF
--- a/assets/equipment.js
+++ b/assets/equipment.js
@@ -1,0 +1,365 @@
+// Manage crafted equipment records and tower socket assignments with persistence helpers.
+const EQUIPMENT_STORAGE_KEY = 'glyph-defense-idle:equipment';
+
+// Local cache of crafted equipment and their tower assignments.
+const equipmentState = {
+  crafted: new Map(),
+  assignmentByEquipment: new Map(),
+  assignmentByTower: new Map(),
+  listeners: new Set(),
+  initialized: false,
+};
+
+// Serialize the crafted equipment payload for storage.
+function serializeEquipmentState() {
+  return {
+    crafted: Array.from(equipmentState.crafted.values()),
+    assignments: Array.from(equipmentState.assignmentByEquipment.entries()).map(
+      ([equipmentId, towerId]) => ({ equipmentId, towerId }),
+    ),
+  };
+}
+
+// Attempt to read the persisted equipment state from localStorage.
+function readStoredEquipmentState() {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return null;
+  }
+  try {
+    const raw = window.localStorage.getItem(EQUIPMENT_STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') {
+      return null;
+    }
+    return parsed;
+  } catch (error) {
+    console.warn('Failed to parse stored equipment state.', error);
+    return null;
+  }
+}
+
+// Persist the current crafted equipment payload for future sessions.
+function writeStoredEquipmentState() {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return;
+  }
+  try {
+    window.localStorage.setItem(EQUIPMENT_STORAGE_KEY, JSON.stringify(serializeEquipmentState()));
+  } catch (error) {
+    console.warn('Failed to persist equipment state.', error);
+  }
+}
+
+// Broadcast state changes to any subscribed listeners and to the DOM event bus.
+function notifyEquipmentListeners() {
+  const snapshot = getEquipmentStateSnapshot();
+  equipmentState.listeners.forEach((listener) => {
+    try {
+      listener(snapshot);
+    } catch (error) {
+      console.warn('Failed to notify equipment listener.', error);
+    }
+  });
+  if (typeof document !== 'undefined' && typeof CustomEvent === 'function') {
+    document.dispatchEvent(
+      new CustomEvent('equipment-state-changed', {
+        detail: snapshot,
+      }),
+    );
+  }
+}
+
+// Normalize crafted equipment entries so downstream UIs receive predictable data.
+function normalizeEquipmentEntry(entry) {
+  if (!entry || typeof entry !== 'object') {
+    return null;
+  }
+  const id = typeof entry.id === 'string' ? entry.id.trim() : '';
+  if (!id) {
+    return null;
+  }
+  const name =
+    typeof entry.name === 'string' && entry.name.trim().length > 0 ? entry.name.trim() : 'Equipment';
+  const type = typeof entry.type === 'string' ? entry.type.trim() : '';
+  const description =
+    typeof entry.description === 'string' ? entry.description.trim() : '';
+  const symbol = typeof entry.symbol === 'string' ? entry.symbol.trim() : '';
+  const rarity = typeof entry.rarity === 'string' ? entry.rarity.trim().toLowerCase() : 'common';
+  return {
+    id,
+    name,
+    type,
+    description,
+    symbol,
+    rarity,
+  };
+}
+
+// Apply tower assignments from storage, discarding references to unknown equipment IDs.
+function applyStoredAssignments(assignments) {
+  equipmentState.assignmentByEquipment.clear();
+  equipmentState.assignmentByTower.clear();
+  if (!Array.isArray(assignments)) {
+    return false;
+  }
+  let changed = false;
+  assignments.forEach((record) => {
+    if (!record || typeof record !== 'object') {
+      return;
+    }
+    const equipmentId = typeof record.equipmentId === 'string' ? record.equipmentId.trim() : '';
+    const towerId = typeof record.towerId === 'string' ? record.towerId.trim() : '';
+    if (!equipmentId || !towerId || !equipmentState.crafted.has(equipmentId)) {
+      return;
+    }
+    equipmentState.assignmentByEquipment.set(equipmentId, towerId);
+    equipmentState.assignmentByTower.set(towerId, equipmentId);
+    changed = true;
+  });
+  return changed;
+}
+
+// Ensure invalid assignments are purged whenever the crafted list changes.
+function reconcileAssignmentsWithCraftedList() {
+  let changed = false;
+  equipmentState.assignmentByEquipment.forEach((towerId, equipmentId) => {
+    if (!equipmentState.crafted.has(equipmentId)) {
+      equipmentState.assignmentByEquipment.delete(equipmentId);
+      if (towerId) {
+        equipmentState.assignmentByTower.delete(towerId);
+      }
+      changed = true;
+    }
+  });
+  equipmentState.assignmentByTower.forEach((equipmentId, towerId) => {
+    if (!equipmentState.crafted.has(equipmentId)) {
+      equipmentState.assignmentByTower.delete(towerId);
+      changed = true;
+    }
+  });
+  return changed;
+}
+
+// Generate a snapshot describing crafted equipment and their tower bindings.
+export function getEquipmentStateSnapshot() {
+  return {
+    crafted: getCraftedEquipment(),
+    assignments: Array.from(equipmentState.assignmentByEquipment.entries()).map(
+      ([equipmentId, towerId]) => ({ equipmentId, towerId }),
+    ),
+  };
+}
+
+// Initialize the equipment subsystem by hydrating storage and optional seeds.
+export function initializeEquipmentState(initialEquipment = []) {
+  if (equipmentState.initialized) {
+    return;
+  }
+  equipmentState.initialized = true;
+
+  const stored = readStoredEquipmentState();
+  const craftedEntries = new Map();
+  const seeds = Array.isArray(initialEquipment) ? initialEquipment : [];
+  seeds.forEach((entry) => {
+    const normalized = normalizeEquipmentEntry(entry);
+    if (normalized) {
+      craftedEntries.set(normalized.id, normalized);
+    }
+  });
+
+  if (stored && Array.isArray(stored.crafted)) {
+    stored.crafted.forEach((entry) => {
+      const normalized = normalizeEquipmentEntry(entry);
+      if (!normalized) {
+        return;
+      }
+      craftedEntries.set(normalized.id, normalized);
+    });
+  }
+
+  equipmentState.crafted = craftedEntries;
+  const applied = applyStoredAssignments(stored?.assignments);
+  const reconciled = reconcileAssignmentsWithCraftedList();
+  if (craftedEntries.size || applied || reconciled) {
+    notifyEquipmentListeners();
+  }
+}
+
+// Replace the crafted equipment roster with a fresh list.
+export function setCraftedEquipment(list, { persist = true } = {}) {
+  const entries = Array.isArray(list) ? list : [];
+  const craftedEntries = new Map();
+  entries.forEach((entry) => {
+    const normalized = normalizeEquipmentEntry(entry);
+    if (normalized) {
+      craftedEntries.set(normalized.id, normalized);
+    }
+  });
+  let changed = equipmentState.crafted.size !== craftedEntries.size;
+  if (!changed) {
+    equipmentState.crafted.forEach((current, key) => {
+      const next = craftedEntries.get(key);
+      if (!next) {
+        changed = true;
+        return;
+      }
+      if (
+        next.name !== current.name ||
+        next.type !== current.type ||
+        next.description !== current.description ||
+        next.symbol !== current.symbol ||
+        next.rarity !== current.rarity
+      ) {
+        changed = true;
+      }
+    });
+  }
+  equipmentState.crafted = craftedEntries;
+  const assignmentsChanged = reconcileAssignmentsWithCraftedList();
+  if (persist) {
+    writeStoredEquipmentState();
+  }
+  if (changed || assignmentsChanged) {
+    notifyEquipmentListeners();
+  }
+}
+
+// Register a single crafted item without rebuilding the entire list.
+export function registerCraftedEquipment(entry, { persist = true } = {}) {
+  const normalized = normalizeEquipmentEntry(entry);
+  if (!normalized) {
+    return false;
+  }
+  const existing = equipmentState.crafted.get(normalized.id);
+  equipmentState.crafted.set(normalized.id, normalized);
+  const changed =
+    !existing ||
+    existing.name !== normalized.name ||
+    existing.type !== normalized.type ||
+    existing.description !== normalized.description ||
+    existing.symbol !== normalized.symbol ||
+    existing.rarity !== normalized.rarity;
+  if (persist) {
+    writeStoredEquipmentState();
+  }
+  if (changed) {
+    notifyEquipmentListeners();
+  }
+  return true;
+}
+
+// Return a sorted array of crafted equipment ready for rendering.
+export function getCraftedEquipment() {
+  return Array.from(equipmentState.crafted.values()).sort((a, b) =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }),
+  );
+}
+
+// Retrieve a specific crafted equipment record by ID.
+export function getEquipmentRecord(equipmentId) {
+  const id = typeof equipmentId === 'string' ? equipmentId.trim() : '';
+  if (!id) {
+    return null;
+  }
+  const record = equipmentState.crafted.get(id);
+  return record ? { ...record } : null;
+}
+
+// Query the tower currently socketing the provided equipment ID.
+export function getEquipmentAssignment(equipmentId) {
+  const id = typeof equipmentId === 'string' ? equipmentId.trim() : '';
+  if (!id) {
+    return null;
+  }
+  return equipmentState.assignmentByEquipment.get(id) || null;
+}
+
+// Resolve which equipment ID is assigned to a tower.
+export function getTowerEquipmentId(towerId) {
+  const id = typeof towerId === 'string' ? towerId.trim() : '';
+  if (!id) {
+    return null;
+  }
+  return equipmentState.assignmentByTower.get(id) || null;
+}
+
+// Convenience wrapper returning the full equipment record for a tower slot.
+export function getTowerEquipment(towerId) {
+  const equipmentId = getTowerEquipmentId(towerId);
+  if (!equipmentId) {
+    return null;
+  }
+  return getEquipmentRecord(equipmentId);
+}
+
+// Assign an equipment record to a tower, automatically clearing conflicting sockets.
+export function assignEquipmentToTower(equipmentId, towerId, { persist = true } = {}) {
+  const id = typeof equipmentId === 'string' ? equipmentId.trim() : '';
+  if (!id || !equipmentState.crafted.has(id)) {
+    return false;
+  }
+  const targetTower = typeof towerId === 'string' && towerId.trim().length > 0 ? towerId.trim() : null;
+  const previousTower = equipmentState.assignmentByEquipment.get(id) || null;
+  const currentEquipmentOnTower = targetTower ? equipmentState.assignmentByTower.get(targetTower) || null : null;
+
+  if (previousTower === targetTower && currentEquipmentOnTower === id) {
+    return false;
+  }
+
+  if (previousTower) {
+    equipmentState.assignmentByEquipment.delete(id);
+    equipmentState.assignmentByTower.delete(previousTower);
+  }
+
+  if (targetTower) {
+    if (currentEquipmentOnTower && currentEquipmentOnTower !== id) {
+      equipmentState.assignmentByEquipment.delete(currentEquipmentOnTower);
+    }
+    equipmentState.assignmentByTower.set(targetTower, id);
+    equipmentState.assignmentByEquipment.set(id, targetTower);
+  }
+
+  if (persist) {
+    writeStoredEquipmentState();
+  }
+  notifyEquipmentListeners();
+  return true;
+}
+
+// Remove any equipment currently socketed into the provided tower.
+export function clearTowerEquipment(towerId, { persist = true } = {}) {
+  const id = typeof towerId === 'string' ? towerId.trim() : '';
+  if (!id) {
+    return false;
+  }
+  const equipmentId = equipmentState.assignmentByTower.get(id);
+  if (!equipmentId) {
+    return false;
+  }
+  equipmentState.assignmentByTower.delete(id);
+  equipmentState.assignmentByEquipment.delete(equipmentId);
+  if (persist) {
+    writeStoredEquipmentState();
+  }
+  notifyEquipmentListeners();
+  return true;
+}
+
+// Subscribe to equipment state changes; returns an unsubscribe callback.
+export function addEquipmentListener(listener) {
+  if (typeof listener !== 'function') {
+    return () => {};
+  }
+  equipmentState.listeners.add(listener);
+  try {
+    listener(getEquipmentStateSnapshot());
+  } catch (error) {
+    console.warn('Failed to invoke equipment listener immediately.', error);
+  }
+  return () => {
+    equipmentState.listeners.delete(listener);
+  };
+}

--- a/assets/main.js
+++ b/assets/main.js
@@ -112,6 +112,7 @@ import {
   injectTowerCardPreviews,
   annotateTowerCardsWithCost,
   initializeTowerSelection,
+  initializeTowerEquipmentInterface,
   syncLoadoutToPlayfield,
   pruneLockedTowersFromLoadout,
   unlockTower,
@@ -120,6 +121,7 @@ import {
   addDiscoveredVariablesListener,
   getDiscoveredVariables,
 } from './towersTab.js';
+import { initializeEquipmentState } from './equipment.js';
 import { initializeTowerTreeMap, refreshTowerTreeMap } from './towerTreeMap.js';
 // Bring in drag-scroll support so hidden scrollbars remain usable.
 import { enableDragScroll } from './dragScroll.js';
@@ -7037,6 +7039,7 @@ import {
 
     bindStatusElements();
     bindPowderControls();
+    initializeEquipmentState();
     initializeCraftingOverlay({
       revealOverlay,
       scheduleOverlayHide,
@@ -7052,6 +7055,7 @@ import {
 
     injectTowerCardPreviews();
     annotateTowerCardsWithCost();
+    initializeTowerEquipmentInterface();
     updateTowerCardVisibility();
     initializeTowerTreeMap({
       toggleButton: document.getElementById('tower-tree-map-toggle'),

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1517,6 +1517,149 @@ body.graphics-mode-low .control-button {
   border-color: rgba(255, 255, 255, 0.08);
 }
 
+/* Introduce an octagonal socket for crafted relics beneath each tower card. */
+.tower-equipment-slot {
+  position: relative;
+  margin-top: 14px;
+  display: grid;
+  gap: 10px;
+  justify-items: center;
+}
+
+.tower-equipment-slot[data-locked='true'] {
+  opacity: 0.55;
+}
+
+.tower-equipment-button {
+  position: relative;
+  width: 96px;
+  height: 96px;
+  display: grid;
+  gap: 6px;
+  justify-items: center;
+  align-content: center;
+  border: 1px solid rgba(139, 247, 255, 0.3);
+  background: linear-gradient(140deg, rgba(8, 10, 16, 0.92), rgba(20, 26, 40, 0.92));
+  color: var(--text);
+  clip-path: polygon(30% 0, 70% 0, 100% 30%, 100% 70%, 70% 100%, 30% 100%, 0 70%, 0 30%);
+  cursor: pointer;
+  transition: border-color var(--transition), box-shadow var(--transition), color var(--transition);
+}
+
+.tower-equipment-button:focus-visible {
+  outline: 2px solid rgba(139, 247, 255, 0.75);
+  outline-offset: 4px;
+}
+
+.tower-equipment-slot[data-filled='true'] .tower-equipment-button {
+  border-color: rgba(255, 228, 120, 0.72);
+  color: rgba(255, 228, 120, 0.92);
+  box-shadow: 0 12px 26px rgba(255, 228, 120, 0.18);
+}
+
+.tower-equipment-slot[data-menu-open='true'] .tower-equipment-button {
+  border-color: rgba(139, 247, 255, 0.6);
+  box-shadow: 0 12px 28px rgba(139, 247, 255, 0.22);
+}
+
+.tower-equipment-button__icon {
+  font-size: 1.6rem;
+  font-family: 'Space Mono', monospace;
+  letter-spacing: 0.18em;
+}
+
+.tower-equipment-button__label {
+  font-size: 0.62rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(247, 247, 245, 0.68);
+}
+
+.tower-equipment-button__name {
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.tower-equipment-menu {
+  position: absolute;
+  top: calc(100% + 12px);
+  z-index: 5;
+  width: max(220px, 88%);
+  border-radius: 16px;
+  border: 1px solid rgba(139, 247, 255, 0.25);
+  background: rgba(8, 10, 16, 0.96);
+  box-shadow: 0 18px 32px rgba(0, 0, 0, 0.45);
+  padding: 12px;
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+.tower-equipment-menu[hidden] {
+  display: none;
+}
+
+.tower-equipment-menu__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.tower-equipment-menu__item {
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text);
+  text-align: left;
+  display: grid;
+  gap: 4px;
+  font-family: 'Space Mono', monospace;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.tower-equipment-menu__item:hover,
+.tower-equipment-menu__item:focus-visible {
+  border-color: rgba(139, 247, 255, 0.35);
+  background: rgba(139, 247, 255, 0.12);
+  outline: none;
+}
+
+.tower-equipment-menu__item[aria-selected='true'] {
+  border-color: rgba(255, 228, 120, 0.7);
+  background: rgba(255, 228, 120, 0.16);
+}
+
+.tower-equipment-menu__symbol {
+  font-size: 1.2rem;
+}
+
+.tower-equipment-menu__label {
+  display: block;
+}
+
+.tower-equipment-menu__note {
+  font-size: 0.65rem;
+  letter-spacing: 0.08em;
+  color: rgba(247, 247, 245, 0.65);
+}
+
+.tower-equipment-menu__empty {
+  margin: 0;
+  padding: 8px 10px;
+  border-radius: 12px;
+  border: 1px dashed rgba(247, 247, 245, 0.25);
+  font-size: 0.76rem;
+  text-align: center;
+  color: rgba(247, 247, 245, 0.6);
+}
+
 .play-button {
   font-size: 0.9rem;
   padding: 12px 42px;
@@ -3060,6 +3203,112 @@ body.graphics-mode-low .control-button {
   margin: 0;
   font-size: 0.9rem;
   color: rgba(247, 247, 245, 0.8);
+}
+
+/* Present crafted equipment management controls above the recipe ledger. */
+.crafted-equipment-section {
+  display: grid;
+  gap: 14px;
+  padding: 18px 20px;
+  border-radius: 18px;
+  border: 1px solid rgba(139, 247, 255, 0.18);
+  background: rgba(10, 14, 22, 0.72);
+}
+
+/* Align the crafted equipment heading with its descriptive note. */
+.crafted-equipment-header {
+  display: grid;
+  gap: 6px;
+}
+
+.crafted-equipment-title {
+  margin: 0;
+  font-size: 1.05rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.crafted-equipment-note {
+  margin: 0;
+  font-size: 0.82rem;
+  color: rgba(247, 247, 245, 0.7);
+}
+
+/* Display crafted relics in a vertical stack for quick assignment. */
+.crafted-equipment-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.crafted-equipment-item {
+  padding: 14px 16px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(6, 8, 14, 0.72);
+  display: grid;
+  gap: 8px;
+}
+
+.crafted-equipment-item__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.crafted-equipment-item__title {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.crafted-equipment-item__type {
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(139, 247, 255, 0.85);
+}
+
+.crafted-equipment-item__description {
+  margin: 0;
+  font-size: 0.82rem;
+  color: rgba(247, 247, 245, 0.7);
+}
+
+.crafted-equipment-item__summary {
+  margin: 0;
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
+  color: rgba(255, 228, 120, 0.78);
+}
+
+.crafted-equipment-item__select {
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: 12px;
+  border: 1px solid rgba(139, 247, 255, 0.28);
+  background: rgba(3, 5, 10, 0.9);
+  color: var(--text);
+  font-family: 'Space Mono', monospace;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.crafted-equipment-item__select:focus-visible {
+  outline: 2px solid rgba(139, 247, 255, 0.75);
+  outline-offset: 2px;
+}
+
+.crafted-equipment-empty {
+  margin: 0;
+  text-align: center;
+  font-size: 0.85rem;
+  color: rgba(247, 247, 245, 0.62);
 }
 
 /* Stack discovered variable recipes vertically so each blueprint remains readable. */

--- a/index.html
+++ b/index.html
@@ -1560,6 +1560,28 @@
           Forge amplifiers and pylons by channeling mote gems into latent tower schematics. Recipes below are
           prototypes awaiting balance.
         </p>
+        <section
+          class="crafted-equipment-section"
+          id="crafted-equipment-section"
+          aria-labelledby="crafted-equipment-title"
+        >
+          <header class="crafted-equipment-header">
+            <h3 class="crafted-equipment-title" id="crafted-equipment-title">Crafted Equipment</h3>
+            <p class="crafted-equipment-note">
+              Assign relics to towers to reshape their glyph lattice. Selecting a new tower automatically frees the previous socket.
+            </p>
+          </header>
+          <ul
+            class="crafted-equipment-list"
+            id="crafted-equipment-list"
+            role="list"
+            aria-live="polite"
+            aria-label="Crafted equipment"
+          ></ul>
+          <p class="crafted-equipment-empty" id="crafted-equipment-empty" aria-hidden="true">
+            No equipment forged yet.
+          </p>
+        </section>
         <ul class="crafting-list" id="crafting-list" role="list"></ul>
         <p class="overlay-instruction">Tap outside or press Esc to close.</p>
       </div>


### PR DESCRIPTION
## Summary
- add a dedicated equipment state module to persist crafted relics and their tower assignments
- expose crafted equipment controls in the crafting overlay so relics can be reassigned across towers
- add octagonal equipment sockets to tower cards with interactive menus for selecting crafted gear

## Testing
- not run (UI changes)


------
https://chatgpt.com/codex/tasks/task_e_6901453f47a8832a8eeccd1abedd5963