### PR TITLE
Add animated sub-equations for tower upgrades

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -3794,7 +3794,7 @@ body.graphics-mode-low .control-button {
   gap: 16px;
 }
 
-.tower-upgrade-variable {
+.tower-upgrade-variable { 
   display: grid;
   gap: 12px;
   padding: 18px 22px;
@@ -3810,6 +3810,42 @@ body.graphics-mode-low .control-button {
 .tower-upgrade-variable--upgradable {
   border-color: rgba(255, 215, 0, 0.24);
   box-shadow: inset 0 0 0 1px rgba(255, 215, 0, 0.12);
+}
+
+.tower-upgrade-variable-equations {
+  display: grid;
+  gap: 6px;
+  padding: 10px 16px;
+  border-radius: 14px;
+  border-left: 3px solid rgba(255, 215, 0, 0.28);
+  background: rgba(255, 255, 255, 0.04);
+  font-family: 'Space Mono', 'Courier New', monospace;
+  color: rgba(255, 255, 255, 0.82);
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity 240ms ease, transform 240ms ease;
+}
+
+.tower-upgrade-variable.is-visible .tower-upgrade-variable-equations {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.tower-upgrade-variable.is-incoming .tower-upgrade-variable-equations,
+.tower-upgrade-variable.is-outgoing .tower-upgrade-variable-equations {
+  opacity: 0;
+  transform: translateY(6px);
+}
+
+.tower-upgrade-variable-equation-line {
+  margin: 0;
+  font-size: 0.92rem;
+  letter-spacing: 0.04em;
+  text-align: left;
+}
+
+.tower-upgrade-variable-equations mjx-container {
+  justify-content: flex-start;
 }
 
 .tower-upgrade-variable.is-visible {

--- a/docs/PROGRESSION.md
+++ b/docs/PROGRESSION.md
@@ -100,7 +100,7 @@ Each entry combines three beats: a flavorful formula, a combat mechanic, and a h
 
 | Letter Pair | Lowercase Formula & Core Behavior | Symbolic Parallel & Combat Quirk | Uppercase Prestige Mutation |
 | --- | --- | --- | --- |
-| Α / α | `α = 5 · Atk · Spd · Tmp` combines base damage with dual tempo controls. | Alpha launches the first strike with calibratable pulses. | **Α** keeps the triple-product core and layers a bonus burst whenever the secondary tempo levels up. |
+| Α / α | `α = Atk` channels a glyph-forged baseline where `Atk = 5·Glyph₁`. | Alpha launches the first strike with calibratable pulses. | **Α** channels the same glyph surge and layers a bonus burst whenever Glyph₁ levels up. |
 | Β / β | `β = α^{Exp}` channels α into an exponent beam. | Beta feeds on α's output, focusing it into piercing light. | **Β** locks the exponent and adds a mirrored return beam after each shot. |
 | Γ / γ | `γ = √β` tempers beta resonance into homing arcs. | Gamma softens β into agile lightning conductors. | **Γ** preserves the root pulse and fires an aftershock equal to 25% of the rooted damage. |
 | Δ / δ | `δ = γ · ln(γ + 1)` summons cohorts scaled by γ alone. | Delta embodies change, commanding glyph soldiers from pure γ strength while `Tot` governs how many specters rally at once. | **Δ** keeps the logarithmic command and leaves a slowing field keyed to the same γ value. |

--- a/index.html
+++ b/index.html
@@ -302,18 +302,16 @@
                 <h3>α alpha tower</h3>
               </header>
               <div class="formula-block">
-                <p class="formula-line">\( \alpha = 5 \times Atk \times Spd \times Tmp \)</p>
+                <p class="formula-line">\( \alpha = Atk \)</p>
                 <ul class="formula-definition">
-                  <li>Atk → attack power (base glyph damage)</li>
-                  <li>Spd → primary attack speed (strikes per second)</li>
-                  <li>Tmp → tempo metronome (secondary cadence)</li>
+                  <li>Atk → attack power channelled from Glyph<sub>1</sub></li>
+                  <li>Glyph<sub>1</sub> → upgradeable glyph charge powering α</li>
                 </ul>
-                <p class="formula-line result">\( \alpha = 5 \times Atk \times Spd \times Tmp \)</p>
+                <p class="formula-line result">\( Atk = 5 \times Glyph_{1} \)</p>
               </div>
               <ul class="upgrade-list">
-                <li>Calibrate Atk for sharper projectiles (+damage)</li>
-                <li>Accelerate Spd through harmonic metronomes (+attack speed)</li>
-                <li>Sync Tmp with temporal echoes (+tempo)</li>
+                <li>Invest collected glyphs into Glyph<sub>1</sub> to amplify Atk (+damage)</li>
+                <li>Hold steady tempo—Atk inherits all α glyph pacing.</li>
               </ul>
               <footer class="card-footer">Shoots a focused glyph-bullet at the nearest foe.</footer>
               <button class="tower-equip-button" type="button" data-tower-toggle="alpha">


### PR DESCRIPTION
## Summary
- show tower variable sub-equations when upgrade cards animate into place
- refactor the alpha tower blueprint to highlight Atk sourced from Glyph₁
- refresh styling, docs, and static copy so alpha’s math matches the new flow

## Testing
- not run (UI-only changes)

------
https://chatgpt.com/codex/tasks/task_e_690152e26fa8832aad1123646256da55