### PR TITLE
Improve tower variable equation contrast

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -3844,8 +3844,16 @@ body.graphics-mode-low .control-button {
   text-align: left;
 }
 
+/* Ensure MathJax breakdown lines stay readable against the dark lattice card. */
 .tower-upgrade-variable-equations mjx-container {
+  display: flex;
   justify-content: flex-start;
+  color: rgba(255, 255, 255, 0.9);
+  text-shadow: 0 0 8px rgba(255, 255, 255, 0.28);
+}
+
+.tower-upgrade-variable-equations mjx-container mjx-math {
+  color: inherit;
 }
 
 .tower-upgrade-variable.is-visible {


### PR DESCRIPTION
## Summary
- brighten MathJax-rendered breakdown lines in the tower variable cards
- ensure the equation text inherits the intended lattice overlay colors

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_69015707cb74832ab1f08c17c36886ae