### PR TITLE
Implement meter-aware tower drag and streamline loadout UI

### DIFF
--- a/assets/data/gameplayConfig.json
+++ b/assets/data/gameplayConfig.json
@@ -20,6 +20,7 @@
       "damage": 28,
       "rate": 1.25,
       "range": 0.24,
+      "diameterMeters": 1,
       "icon": "assets/images/tower-alpha.svg",
       "nextTierId": "beta"
     },

--- a/assets/gameUnits.js
+++ b/assets/gameUnits.js
@@ -1,0 +1,28 @@
+// Shared conversion helpers for working with standardized game units.
+export const ALPHA_BASE_RADIUS_FACTOR = 0.042; // Ratio of playfield size that matches the alpha radius.
+export const ALPHA_BASE_DIAMETER_FACTOR = ALPHA_BASE_RADIUS_FACTOR * 2; // Diameter ratio derived from the alpha baseline.
+export const DEFAULT_TOWER_DIAMETER_METERS = 1; // Fallback diameter so towers without explicit data still measure 1 meter.
+
+// Translate meters into a normalized fraction of the playfield's minimum dimension.
+export function metersToCanvasFraction(meters) {
+  if (!Number.isFinite(meters) || meters <= 0) {
+    return 0;
+  }
+  return meters * ALPHA_BASE_DIAMETER_FACTOR;
+}
+
+// Translate a normalized fraction of the playfield into meters.
+export function canvasFractionToMeters(fraction) {
+  if (!Number.isFinite(fraction) || fraction <= 0) {
+    return 0;
+  }
+  return fraction / ALPHA_BASE_DIAMETER_FACTOR;
+}
+
+// Convert meters into absolute pixels using the playfield's minimum dimension.
+export function metersToPixels(meters, minDimension) {
+  if (!Number.isFinite(minDimension) || minDimension <= 0) {
+    return 0;
+  }
+  return metersToCanvasFraction(meters) * minDimension;
+}

--- a/assets/main.js
+++ b/assets/main.js
@@ -1066,8 +1066,15 @@ import {
     }
 
     resetPlayfieldMenuLevelSelect();
-    closePlayfieldMenu();
-    leaveActiveLevel();
+    const finalizeExit = () => {
+      leaveActiveLevel();
+      closePlayfieldMenu({ restoreFocus: true }); // Ensure the quick menu collapses after returning to level selection.
+    };
+    if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame(finalizeExit);
+    } else {
+      finalizeExit();
+    }
   }
 
   function handleCommenceWaveFromMenu() {

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -801,12 +801,6 @@ body.graphics-mode-low .control-button {
   box-shadow: 0 16px 32px rgba(255, 228, 120, 0.28);
 }
 
-.tower-loadout-symbol {
-  font-family: "Cormorant Garamond", serif;
-  font-size: 1.2rem;
-  letter-spacing: 0.06em;
-}
-
 .tower-loadout-art {
   width: 44px;
   height: 44px;
@@ -818,15 +812,8 @@ body.graphics-mode-low .control-button {
   mix-blend-mode: screen;
 }
 
-.tower-loadout-label {
-  margin: 0;
-  font-size: 0.6rem;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.72);
-}
-
 .tower-loadout-cost {
+  /* Stack the cost beneath the icon with enough contrast to remain legible in the compact layout. */
   margin: 0;
   font-size: 0.6rem;
   letter-spacing: 0.06em;


### PR DESCRIPTION
## Summary
- add shared unit conversion helpers so tower definitions expose meter-calibrated sizes and ranges (alpha diameter = 1 m)
- offset touch placement previews by one meter, and ensure the level selection confirmation returns to the map
- condense the tower loadout inventory to show only each icon with its cost for a smaller footprint

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69016ccab3cc832a8b4ef01ef99efd7f