### PR TITLE
Fix powder tab layout initialization glitch

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -6096,10 +6096,19 @@ import {
 
     // Synchronize tab interactions with overlay state, audio cues, and banner refreshes.
     configureTabManager({
-      getOverlayActiveState: () => Boolean(overlay && overlay.classList.contains('active')), 
+      getOverlayActiveState: () => Boolean(overlay && overlay.classList.contains('active')),
       isFieldNotesOverlayVisible,
-      onTabChange: () => {
+      onTabChange: (tabId) => {
         refreshTabMusic();
+        if (tabId === 'powder') {
+          // Realign the powder basin after the tab becomes visible so layout metrics refresh.
+          requestAnimationFrame(() => {
+            if (powderSimulation && typeof powderSimulation.handleResize === 'function') {
+              powderSimulation.handleResize();
+              handlePowderViewTransformChange(powderSimulation.getViewTransform());
+            }
+          });
+        }
       },
       onTowerTabActivated: () => {
         updateActiveLevelBanner();


### PR DESCRIPTION
## Summary
- trigger a powder simulation resize after the mote tab becomes visible so the basin picks up its true dimensions
- ensure the viewport transform is refreshed alongside the resize to keep decorative walls aligned

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_690198787380832a8fc1312b8c27fa14