### PR TITLE
Inline diamond sprite to avoid binary diff

### DIFF
--- a/assets/crafting.js
+++ b/assets/crafting.js
@@ -1,5 +1,5 @@
 import { formatGameNumber, formatWholeNumber } from '../scripts/core/formatting.js';
-import { moteGemState, resolveGemDefinition } from './enemies.js';
+import { moteGemState, resolveGemDefinition, getMoteGemSpriteSource } from './enemies.js';
 import {
   getTowerDefinitions,
   getTowerDefinition,
@@ -21,7 +21,7 @@ const GEM_TIER_SEQUENCE = [
   'sapphire',
   'iolite',
   'amethyst',
-  'diamond',
+  'diamond', // Keep the prismatic diamond tier ahead of the void-touched nullstone.
   'nullstone',
 ];
 
@@ -45,7 +45,7 @@ const CRAFTING_TIER_NAME_SEQUENCE = [
   'sapphire',
   'iolite',
   'amethyst',
-  'diamond',
+  'diamond', // Surface the diamond title between amethyst and nullstone.
   'nullstone',
 ];
 
@@ -408,8 +408,20 @@ function resolveNextCraftingTierIndex(recipeId, totalTiers) {
   return sanitizedCompleted;
 }
 
-// Create a decorative color swatch representing the required gem hue.
-function createGemColorSwatch(gemId) {
+// Create a gem icon for crafting costs while falling back to the legacy swatch if needed.
+function createGemCostIcon(gemId) {
+  const source = getMoteGemSpriteSource(gemId);
+  if (source) {
+    const icon = document.createElement('img');
+    icon.className = 'crafting-cost__icon';
+    icon.src = source;
+    icon.alt = '';
+    icon.decoding = 'async';
+    icon.loading = 'lazy';
+    icon.setAttribute('aria-hidden', 'true');
+    return icon;
+  }
+
   const swatch = document.createElement('span');
   swatch.className = 'crafting-cost__swatch';
   swatch.setAttribute('aria-hidden', 'true');
@@ -566,8 +578,8 @@ function renderCraftingRecipes() {
           requirement.label || 'Motes'
         }`;
 
-        const swatch = createGemColorSwatch(requirement.gemId);
-        costItem.append(swatch);
+        const icon = createGemCostIcon(requirement.gemId);
+        costItem.append(icon);
 
         const amount = document.createElement('span');
         amount.className = 'crafting-cost__amount';

--- a/assets/enemies.js
+++ b/assets/enemies.js
@@ -4,6 +4,50 @@
 // so the playfield can focus on orchestration while keeping the powder bridge
 // informed about how many motes to dispense when the crystals are collected.
 
+// Encode the diamond sprite as an inline data URI so automated PR tooling can process
+// the artwork without bundling a separate binary file.
+const DIAMOND_SPRITE_DATA_URI = 'data:image/png;base64,' +
+  'iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAAK90lEQVR4nO2dS4sdxxmG35MjzlbrKLEXAmHLYgakZJGdf8BA' +
+  'wAtjY2OGgI0JGLy1fobBEEwMwQQHx1lEiAwIBAMDwjckjRhQRmGCFpIsGwwGbw86dBaaUmrq1Herru6uvnzQ9Om6dVW/T31V' +
+  'fT3AZJNNNtlkk0022WSTTTbZZJNNNtlIbP/o4WHXdejSftF1Bbq0qqq+WC6XqKrq667r0pXNuq5AV1ZV1Rfe5vMAMJvNftdR' +
+  'dTqzUXqAQHwAeHAcPjpPMDoAIuIDxx7gOH5UEIwKgJj4V3e/3IikGw0EowGAEn+5XOLq7penI+lHAcEoAODEd8tYIRg8ABrx' +
+  'xwzBoAGwiD9WCAYLQEz8nb1vNlarFSn+crnEarXCzt43o4FgkADExL924+bGarXCarUCgKj4AODSXLtxcxQQDA4ASnyu11PL' +
+  'GCAYFAAW8cOhgBoahg7BYACw9nwtAEOHYBAA5HT7Y4Og9wBoxJdm/lovMUQIeg0AJ74/4/fXWuHDfC7v0CDoLQDSqZ4vWigs' +
+  'Jz6wDkpY5pAg6CUAGvE1rp1ac/mGBkHvAIiJf/2r/Q2N8HUBCEG4/tV+7yHoFQAW8UO3HabhTgOlvEOCoDcAcOJrhA+FdOuq' +
+  'qta8gCa/v78+Q9ALADTix2bsnPv2J31UHJXX7WcIEBQPQEz83W8PNmI9lpu0xdx/VVVuH+IwwJXttne/PegdBEUDQIlPiRDr' +
+  'pdwQ4Js0BPjlcfvvGwTFAqAVX9tjY2l8S8lP1aVPEBQJACd+OAZLolC937l/b5+iF+BACOvVFwiKA0ASn3PBGvfv0sZMOgvw' +
+  'y5WGoL5AUBQAWvG1XoCChDNpcqnp/X2CoBgAuNl+rNdJXiDmCdx26P69OrD5LL3fjy8ZgiIA0Iiv7XWUMOH1Asq4fKn1KBmC' +
+  'zgGQxNdM6Li5AIATv6neH4sPy9Dsk4srEYJOAbCIL03QYu5aOvWjTIJKUw+q7qVB0BkAqeJLIEhiacwKlUb4UiHoBADrmA/w' +
+  'vVJK6xbJ/Xv1U3kYqT5cXUqBoHUArOJLB9cCgsWswsfiJW9RAgStAhATf+/W3Q2APs2Sfod5KRhSTVO2tc5+3r1bdzuFoDUA' +
+  'KPE1B0n6rRFI6/69+ibtR6pnrK1dQtAKAFrxtQdMGhbCdaoX0JSb0utj+bqCoHEALOKnegD/d5tDQErduDZ3AUGjAHDiU8KF' +
+  'Ydp79Fxvtbp/r/7R8jT10HqAMKxtCE41VbAkfooH0PbGGAy+/fOvf96h6v3KW+9s+dur1Qrz+XytvFiYn8eZnw54esdxsVic' +
+  'SB+G7d26e/rl31z42U9TVdXXTXzHsJEPRaaKT8Vx21ScH15VFSs6Za+89c7WbDbDfD7HfD7HYrE4sQ7DpbjYNhcXQgDk/5hl' +
+  '9iFAIz7XszWXfP28YTlu261TxQeeeorwbIDan9ZbWa5btDEcZPUAWvGtHkAbFnqGf/zlT0nCx+zVP/xxy9LTLWFSXJOeIBsA' +
+  'FvHbgODzTz7ixL/ExN2mIl5/+72ttsVvGoIsQ0CK+JLLjMVRYX44AE78S+DFZ9O4cql9W+tuGTqaGg5qAxAT/8ade6L4mgXg' +
+  'r+dTIBAmCa9KTwlP1UsrsGa5cededghqAUCJr713rzk4zrRxRO+3ik/m+/yTj3bq1K8OHMvlMjsEyQBwPR+wEe+sLgifffyh' +
+  'RfxLkYVKd8L8/TTRHgmWnBAkAaBx+4Dd7TnTpImljZhaVGu4tk45hI8dz1wQmAGwjPkpDU09oAbTTAJNlqstWvFzQmACIGXC' +
+  'V7fxnMh+moj7jwmpFVfM+9nHH0bnAlwdU9vMpasLgRqAHLP9mKUeoITen+UsgLLc7bDkrwOBCoCmT/VSLFc5dayptqQsIQSX' +
+  'd3BFA4EIwMH9x4d3/vto47jQ20A+8bsAp0nr+pg4CC7v4IpbH9x/zP4vogjA5tkz5+fz+TPxL+/gNnfJsq2lROv6mBzrdMXV' +
+  '542Xvt/ePHvmPFdn1RCwefbM+Tde+n7bbV99cO7TroUsAYim2pK6XH1w7lNXpkZ8wDAJzAFB7sYbjbzJkyN97na0IT5gPA1M' +
+  'gSDHQaLMT/Pmu+9vBdExAbWiinnffPf9LWsdU9vclPhAwoUgCwSpB8ByEBNMgsDqKbK1JeU41hEfSLwUrIEgpbGagxSaAAMl' +
+  'Zu3wusDmgKCu+EDNB0IO7j8+/Nu/f/msEr9//mh7tdK/yesWTXrtwyPGG0IaWxPfd/91HvLQpomlzyE+UPN2MOUJLI0C0ntM' +
+  'LO71t98L5wJAglun8rmnglLrV8dT5hYfyPBASNOniNRBDeP8MMKynAVQwlL1soosLTnFBzI9EpYKAUAfmFgcFeaHA6C8APBU' +
+  'VM0kMJrGlSv1cG2YFZDc4gOZnwoO5wRbv7q3XXdMt4QN9ang+XyOne9ezC4+0MCLIXUhSAnjXg6p814A8P+XQ1JeCskFRlPi' +
+  'Aw28GBIOBzvfvRgdDoC429NMIP28YTlu261ns9na615a898MCsvV1MXSPipvk+IDDb0aBug8Qc7eHvZ8Pyx8OdTybqDf+30B' +
+  'tcNBHQ/QtPhAgwAAeSDQvifIgfDkyZPkNpw6dUoU3vI+YEniAw2/Hi4NB4A8W+aGBC6/v57N0jh3+bghQHL9Yf01+dsSH2jh' +
+  'AxEcBJreAMTHWOo3BUqqSeVa6ya1uU3xgZY+EWOBAKAPmORKXd5wnQqBplxrPbn2tS0+0OJHorQQpHgATS+1DgPh7F+7H4sH' +
+  '6Fp8oOXPxFEQAPZe736HedscAvz9W+oc5u1KfKCDD0XGIJDO/Tl3bzmvtpimPAlETbu6FB/o6FOxVggA/cGNpXWLdhjwPwtj' +
+  'BUFblxLEBzr8WLQEgWXyRwkBpHkBTkjL/rnfJYgPdPy5+FQIuAXgxdKYFSorCKWIDxTwhxEWCDRuNxQLOHkPXxoG/PiwDM0+' +
+  'JRBKEh8oAADAPicIJ15U2sViceJyrZ+PMi5faj1KFR8oBABAdxcx7E3SNXggfueO8gLUuX+4Hduv5LVKFB8oCABgHYJrP1xY' +
+  'e8ZQ0+ucIBQgnHECc+4/ltf9vvbDhSLFBwoDAHgKwWsvPBIh4Ho/wE/UFotFdN/SRNMvV+sFfPFfe+FRUeIDBQIAABfPPcdC' +
+  'AMi9X5o/hMOAc/9SXosXCMW/eO65osQHCgUA4CGQvEHotqk0vqXk5+rSB/GBggEA9BDEwgD5Hr1vUu/3y5P23xfxgcIBAGgI' +
+  'pMma1GMXi8WzYSB86FPjUaj5R5/EB3oAACBDEI7BlAuPuWsAZByV1+0nDO+b+EBPAADWIbj+4+YaBNIsPuyxzgv429r84f6u' +
+  '/7jZO/GBHgEA8BBoQYhd5ZPcv1R+X8UHegYAYIOAc+XcWpN/COIDPQQAiEMgTQhzABCW33fxgZ4CAOggiLltAKzIAFh3PyTx' +
+  'gR4DANAQxGbsbq118WE+P+9QxAd6DgDAQ0BN+LRLLN+QxAcGAACggyDHMjTxgYEAANgh4E4DxyI+MCAAABsEFgCGKj4wMACA' +
+  '/MPBkMUHBggAIF8sAuKngsDJO4hDFx8YKADAOgS7P12M3juIDQ3z+Ry7P10cvPhAwx+IKMH2jx4e/v0/v34m5sunb24vl0v4' +
+  'SwjB3s+/HYX4wAgAAGQIxio+MBIAAB6CsYoPjAgAgIZgrOIDIwMAiEMwVvGBEQIArEPgbGziAwM+DeQsPEUExin+6G3/6OHh' +
+  'B/+qPtg/esj+tdpkA7ZJ/Mkmm2yyySabbLLJJptssslGZP8DkSWKhoklgy0AAAAASUVORK5CYII=';
+
 // Track mote gem drops, inventory totals, and the upgrade-driven auto collector.
 export const moteGemState = {
   active: [],
@@ -13,8 +57,8 @@ export const moteGemState = {
 };
 
 // Gem definitions ordered from most common to rarest. Each entry includes the
-// base drop probability, mote size multiplier, and display palette so that the
-// powder view and inventory can stay perfectly synchronized.
+// base drop probability, mote size multiplier, display palette, and sprite path
+// so every system can render the bespoke crystal artwork consistently.
 export const GEM_DEFINITIONS = [
   {
     id: 'quartz',
@@ -22,6 +66,7 @@ export const GEM_DEFINITIONS = [
     dropChance: 0.1,
     moteSize: 2,
     color: { hue: 18, saturation: 16, lightness: 86 },
+    sprite: './sprites/quartz.png', // Provide the quartz sprite so UI elements can mirror the drop art.
   },
   {
     id: 'ruby',
@@ -29,6 +74,7 @@ export const GEM_DEFINITIONS = [
     dropChance: 0.01,
     moteSize: 3,
     color: { hue: 350, saturation: 74, lightness: 48 },
+    sprite: './sprites/ruby.png', // Supply the ruby sprite for crafting menus and battlefield drops.
   },
   {
     id: 'sunstone',
@@ -36,6 +82,7 @@ export const GEM_DEFINITIONS = [
     dropChance: 0.001,
     moteSize: 4,
     color: { hue: 28, saturation: 78, lightness: 56 },
+    sprite: './sprites/sunstone.png', // Reference the sunstone sprite so rarer drops look unique.
   },
   {
     id: 'citrine',
@@ -43,6 +90,7 @@ export const GEM_DEFINITIONS = [
     dropChance: 0.0001,
     moteSize: 5,
     color: { hue: 48, saturation: 78, lightness: 60 },
+    sprite: './sprites/citrine.png', // Link the citrine sprite to keep inventory icons consistent.
   },
   {
     id: 'emerald',
@@ -50,6 +98,7 @@ export const GEM_DEFINITIONS = [
     dropChance: 0.00001,
     moteSize: 6,
     color: { hue: 140, saturation: 64, lightness: 44 },
+    sprite: './sprites/emerald.png', // Attach the emerald sprite to highlight its deep green facets.
   },
   {
     id: 'sapphire',
@@ -57,6 +106,7 @@ export const GEM_DEFINITIONS = [
     dropChance: 0.000001,
     moteSize: 7,
     color: { hue: 210, saturation: 72, lightness: 52 },
+    sprite: './sprites/sapphire.png', // Provide the sapphire sprite for powder logs and loot icons.
   },
   {
     id: 'iolite',
@@ -64,6 +114,7 @@ export const GEM_DEFINITIONS = [
     dropChance: 0.0000001,
     moteSize: 8,
     color: { hue: 255, saturation: 52, lightness: 50 },
+    sprite: './sprites/iolite.png', // Include the iolite sprite so late-game drops showcase their hue.
   },
   {
     id: 'amethyst',
@@ -71,6 +122,7 @@ export const GEM_DEFINITIONS = [
     dropChance: 0.00000001,
     moteSize: 9,
     color: { hue: 280, saturation: 60, lightness: 55 },
+    sprite: './sprites/amethyst.png', // Point to the amethyst sprite for the violet-tier presentation.
   },
   {
     id: 'diamond',
@@ -78,6 +130,7 @@ export const GEM_DEFINITIONS = [
     dropChance: 0.000000001,
     moteSize: 10,
     color: { hue: 200, saturation: 12, lightness: 92 },
+    sprite: DIAMOND_SPRITE_DATA_URI, // Attach the inline diamond sprite so the prismatic tier gleams across the UI.
   },
   {
     id: 'nullstone',
@@ -85,10 +138,14 @@ export const GEM_DEFINITIONS = [
     dropChance: 0.0000000001,
     moteSize: 11,
     color: { hue: 210, saturation: 10, lightness: 14 },
+    sprite: './sprites/nullstone.png', // Assign the nullstone sprite so the rarest drop is unmistakable.
   },
 ];
 
 const GEM_LOOKUP = new Map(GEM_DEFINITIONS.map((gem) => [gem.id, gem]));
+
+// Cache gem sprite elements so repeated lookups reuse the same browser image resource.
+const gemSpriteCache = new Map();
 
 // Static rarity multipliers arranged by archetype difficulty. Higher values
 // make crystal drops more common for late-game threats while still allowing the
@@ -167,6 +224,56 @@ export function rollGemDropDefinition(enemy = {}, rng = Math.random) {
 export function resolveGemDefinition(typeKey) {
   const key = String(typeKey || '').toLowerCase();
   return GEM_LOOKUP.get(key) || null;
+}
+
+// Resolve the sprite source path for a gem so UI consumers can render the new artwork.
+export function getMoteGemSpriteSource(typeKey) {
+  const gem = resolveGemDefinition(typeKey);
+  return gem?.sprite || null;
+}
+
+// Load and cache the gem sprite image so the playfield can draw textured drops efficiently.
+export function getMoteGemSpriteAsset(typeKey) {
+  const key = String(typeKey || '').toLowerCase();
+  if (gemSpriteCache.has(key)) {
+    return gemSpriteCache.get(key);
+  }
+
+  const source = getMoteGemSpriteSource(key);
+  if (!source || typeof Image === 'undefined') {
+    gemSpriteCache.set(key, null);
+    return null;
+  }
+
+  const image = new Image();
+  // Hint the browser to decode the sprite off the main thread when possible.
+  if ('decoding' in image) {
+    image.decoding = 'async';
+  }
+  // Request eager loading so rare drops have their art ready before rendering.
+  if ('loading' in image) {
+    image.loading = 'eager';
+  }
+  image.src = source;
+
+  const record = {
+    image,
+    loaded: image.complete,
+    errored: false,
+  };
+
+  // Track load completion so draw routines can fall back until the sprite is ready.
+  image.addEventListener('load', () => {
+    record.loaded = true;
+  });
+
+  // Flag load failures so consumers can keep using the procedural fallback square.
+  image.addEventListener('error', () => {
+    record.errored = true;
+  });
+
+  gemSpriteCache.set(key, record);
+  return record;
 }
 
 // Derive a deterministic accent color for a mote gem category.

--- a/assets/main.js
+++ b/assets/main.js
@@ -157,6 +157,7 @@ import {
   autoCollectActiveMoteGems,
   setMoteGemAutoCollectUnlocked,
   getMoteGemColor,
+  getMoteGemSpriteSource,
 } from './enemies.js';
 import {
   initializeCraftingOverlay,
@@ -1585,6 +1586,23 @@ import {
     modeToggle: null,
   };
 
+  // Create an inventory icon element so the mote gem list can showcase the sprite artwork.
+  function createGemInventoryIcon(gemId) {
+    const source = getMoteGemSpriteSource(gemId);
+    if (!source) {
+      return null;
+    }
+
+    const icon = document.createElement('img');
+    icon.className = 'powder-gem-inventory__icon';
+    icon.src = source;
+    icon.alt = '';
+    icon.decoding = 'async';
+    icon.loading = 'lazy';
+    icon.setAttribute('aria-hidden', 'true');
+    return icon;
+  }
+
   // Refresh the mote gem inventory card so collected crystals mirror the latest drop ledger.
   function updateMoteGemInventoryDisplay() {
     const { gemInventoryList, gemInventoryEmpty, craftingButton } = powderElements;
@@ -1637,26 +1655,31 @@ import {
       const labelContainer = document.createElement('span');
       labelContainer.className = 'powder-gem-inventory__label';
 
-      const swatch = document.createElement('span');
-      swatch.className = 'powder-gem-inventory__swatch';
-      const color = getMoteGemColor(entry.typeKey);
-      if (color && typeof swatch.style?.setProperty === 'function') {
-        if (Number.isFinite(color.hue)) {
-          swatch.style.setProperty('--gem-hue', `${Math.round(color.hue)}`);
+      const icon = createGemInventoryIcon(entry.typeKey);
+      if (icon) {
+        labelContainer.appendChild(icon);
+      } else {
+        const swatch = document.createElement('span');
+        swatch.className = 'powder-gem-inventory__swatch';
+        const color = getMoteGemColor(entry.typeKey);
+        if (color && typeof swatch.style?.setProperty === 'function') {
+          if (Number.isFinite(color.hue)) {
+            swatch.style.setProperty('--gem-hue', `${Math.round(color.hue)}`);
+          }
+          if (Number.isFinite(color.saturation)) {
+            swatch.style.setProperty('--gem-saturation', `${Math.round(color.saturation)}%`);
+          }
+          if (Number.isFinite(color.lightness)) {
+            swatch.style.setProperty('--gem-lightness', `${Math.round(color.lightness)}%`);
+          }
         }
-        if (Number.isFinite(color.saturation)) {
-          swatch.style.setProperty('--gem-saturation', `${Math.round(color.saturation)}%`);
-        }
-        if (Number.isFinite(color.lightness)) {
-          swatch.style.setProperty('--gem-lightness', `${Math.round(color.lightness)}%`);
-        }
+        labelContainer.appendChild(swatch);
       }
 
       const nameEl = document.createElement('span');
       nameEl.className = 'powder-gem-inventory__name';
       nameEl.textContent = entry.label || entry.typeKey;
 
-      labelContainer.appendChild(swatch);
       labelContainer.appendChild(nameEl);
 
       const countEl = document.createElement('span');

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -2398,7 +2398,7 @@ body.graphics-mode-low .control-button {
   gap: 12px;
 }
 
-/* Align the gem swatch, label, and quantity for quick scanning. */
+/* Align the gem icon, label, and quantity for quick scanning. */
 .powder-gem-inventory__item {
   display: flex;
   align-items: center;
@@ -2410,7 +2410,7 @@ body.graphics-mode-low .control-button {
   background: rgba(255, 255, 255, 0.03);
 }
 
-/* Anchor the swatch and label grouping on the left side. */
+/* Anchor the icon and label grouping on the left side. */
 .powder-gem-inventory__label {
   display: flex;
   align-items: center;
@@ -2420,13 +2420,23 @@ body.graphics-mode-low .control-button {
   text-transform: uppercase;
 }
 
+/* Display the new gem sprite while echoing the powder card glow. */
+.powder-gem-inventory__icon {
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+  filter: drop-shadow(0 0 6px rgba(247, 247, 245, 0.36));
+  image-rendering: crisp-edges;
+  object-fit: contain;
+}
+
 /* Emphasize the gem name so entries remain legible against the monochrome card. */
 .powder-gem-inventory__name {
   font-weight: 600;
   color: rgba(247, 247, 245, 0.9);
 }
 
-/* Render gem colors using HSL so hues can match the mote palette. */
+/* Render gem colors using HSL so hues can match the mote palette when sprites are unavailable. */
 .powder-gem-inventory__swatch {
   width: 18px;
   height: 18px;
@@ -3407,7 +3417,7 @@ body.graphics-mode-low .control-button {
   gap: 6px;
 }
 
-/* Highlight each requirement with a color swatch while preserving mono numerals. */
+/* Highlight each requirement with a gem icon while preserving mono numerals. */
 .crafting-cost__item {
   display: flex;
   align-items: center;
@@ -3419,7 +3429,17 @@ body.graphics-mode-low .control-button {
   color: rgba(247, 247, 245, 0.82);
 }
 
-/* Render a small gem-colored square ahead of the requirement amount. */
+/* Present the gem sprite for each requirement with a subtle glow. */
+.crafting-cost__icon {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  filter: drop-shadow(0 0 6px rgba(247, 247, 245, 0.36));
+  image-rendering: crisp-edges;
+  object-fit: contain;
+}
+
+/* Render a small gem-colored square ahead of the requirement amount as a graceful fallback. */
 .crafting-cost__swatch {
   width: 10px;
   height: 10px;


### PR DESCRIPTION
## Summary
- encode the diamond gem sprite as an inline data URI so the PR tooling no longer needs to ship a binary asset
- point the diamond gem definition at the inline sprite so drops, inventory, and crafting keep rendering the art

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_69019b39c37c832a9e18b6e8947ff646