### PR TITLE
Render gem sprites across drops and menus

### DIFF
--- a/assets/crafting.js
+++ b/assets/crafting.js
@@ -1,5 +1,5 @@
 import { formatGameNumber, formatWholeNumber } from '../scripts/core/formatting.js';
-import { moteGemState, resolveGemDefinition } from './enemies.js';
+import { moteGemState, resolveGemDefinition, getGemSpriteAssetPath } from './enemies.js';
 import {
   getTowerDefinitions,
   getTowerDefinition,
@@ -408,11 +408,24 @@ function resolveNextCraftingTierIndex(recipeId, totalTiers) {
   return sanitizedCompleted;
 }
 
-// Create a decorative color swatch representing the required gem hue.
+// Create a decorative swatch or sprite representing the required gem.
 function createGemColorSwatch(gemId) {
   const swatch = document.createElement('span');
   swatch.className = 'crafting-cost__swatch';
   swatch.setAttribute('aria-hidden', 'true');
+  const spritePath = getGemSpriteAssetPath(gemId);
+  if (spritePath) {
+    // Embed the gem sprite so crafting requirements match the collectible art style.
+    swatch.classList.add('crafting-cost__swatch--sprite');
+    const spriteImg = document.createElement('img');
+    spriteImg.className = 'crafting-cost__sprite';
+    spriteImg.decoding = 'async';
+    spriteImg.loading = 'lazy';
+    spriteImg.alt = '';
+    spriteImg.src = spritePath;
+    swatch.appendChild(spriteImg);
+    return swatch;
+  }
   const gem = resolveGemDefinition(gemId);
   if (gem?.color) {
     const { hue, saturation, lightness } = gem.color;

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -70,6 +70,16 @@ body {
   justify-content: center;
 }
 
+/* Activate the gem cursor on desktop pointers without affecting touch targets. */
+body.mouse-cursor-gem {
+  cursor: url('./sprites/mouse_cursor.png') 4 2, auto;
+}
+
+/* Mirror the gem cursor on common interactive elements while respecting disabled states. */
+body.mouse-cursor-gem :is(button, a, [role='button']):not([disabled]):not([aria-disabled='true']) {
+  cursor: url('./sprites/mouse_cursor.png') 4 2, pointer;
+}
+
 button {
   position: relative;
   overflow: hidden;
@@ -2428,12 +2438,29 @@ body.graphics-mode-low .control-button {
 
 /* Render gem colors using HSL so hues can match the mote palette. */
 .powder-gem-inventory__swatch {
-  width: 18px;
-  height: 18px;
+  width: 22px;
+  height: 22px;
   border-radius: 50%;
   border: 1px solid rgba(255, 255, 255, 0.18);
   background: hsl(var(--gem-hue, 210), var(--gem-saturation, 60%), var(--gem-lightness, 50%));
   box-shadow: 0 0 6px rgba(255, 255, 255, 0.18);
+}
+
+/* Present gem sprites inside the inventory swatch without breaking the circular framing. */
+.powder-gem-inventory__swatch--sprite {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px;
+  background: rgba(14, 18, 28, 0.68);
+}
+
+/* Ensure gem icons stay crisp while fitting within the swatch circle. */
+.powder-gem-inventory__sprite {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  image-rendering: crisp-edges;
 }
 
 /* Highlight the gem quantity with the same mono font used in powder logs. */
@@ -3426,6 +3453,26 @@ body.graphics-mode-low .control-button {
   border-radius: 3px;
   background: var(--crafting-cost-swatch-color, rgba(247, 247, 245, 0.82));
   box-shadow: 0 0 0 1px rgba(14, 18, 28, 0.6), 0 0 6px rgba(247, 247, 245, 0.32);
+}
+
+/* Display gem sprites within crafting cost swatches while maintaining legibility. */
+.crafting-cost__swatch--sprite {
+  width: 20px;
+  height: 20px;
+  border-radius: 6px;
+  background: rgba(14, 18, 28, 0.68);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 0 0 1px rgba(14, 18, 28, 0.6), 0 0 6px rgba(247, 247, 245, 0.32);
+}
+
+/* Keep crafting sprites sharp without stretching beyond the swatch bounds. */
+.crafting-cost__sprite {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  image-rendering: crisp-edges;
 }
 
 /* Isolate the numeric amount so the owned count can remain secondary. */


### PR DESCRIPTION
## Summary
- render mote gem drops with their dedicated sprite art and fall back to legacy shapes while sprites load
- surface gem sprites in the inventory and crafting recipes alongside refreshed styling helpers
- detect desktop pointer devices to enable the new mouse cursor sprite without affecting touch users

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_6901a9f60a14832abd40b18fabc314f5