### PR TITLE
Fix tower upgrade overlay entry animation

### DIFF
--- a/assets/towersTab.js
+++ b/assets/towersTab.js
@@ -2303,6 +2303,7 @@ export function openTowerUpgradeOverlay(towerId, options = {}) {
   renderTowerUpgradeOverlay(towerId, {
     blueprint: options.blueprint,
     baseEquationText: options.baseEquationText,
+    animateEntry: true,
   });
   overlay.focus({ preventScroll: true });
   maybePlayTowerVariableEntry();


### PR DESCRIPTION
## Summary
- trigger the tower upgrade overlay to request its entry animation when opened so variable cards and glyph equations appear

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_6901c35c2724832a8ac78aa007b4a81b