### PR TITLE
Add playfield outcome overlay and endless checkpoints

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -1381,6 +1381,172 @@ import {
     autoAnchorButton: null,
     slots: [],
   };
+  const playfieldOutcomeElements = {
+    overlay: null,
+    title: null,
+    subtitle: null,
+    primary: null,
+    secondary: null,
+  };
+  const playfieldOutcomeState = {
+    onPrimary: null,
+    onSecondary: null,
+    bound: false,
+  };
+
+  // Invoke the currently registered primary outcome action, if present.
+  function triggerPlayfieldOutcomePrimary() {
+    if (typeof playfieldOutcomeState.onPrimary === 'function') {
+      playfieldOutcomeState.onPrimary();
+    }
+  }
+
+  // Invoke the stored secondary outcome action when the retry button is pressed.
+  function triggerPlayfieldOutcomeSecondary() {
+    if (typeof playfieldOutcomeState.onSecondary === 'function') {
+      playfieldOutcomeState.onSecondary();
+    }
+  }
+
+  // Reset the outcome overlay to its hidden state and optionally restore focus.
+  function hidePlayfieldOutcome({ restoreFocus = false } = {}) {
+    const { overlay } = playfieldOutcomeElements;
+    if (!overlay) {
+      return;
+    }
+    overlay.classList.remove('active', 'playfield-outcome--victory', 'playfield-outcome--defeat');
+    overlay.setAttribute('aria-hidden', 'true');
+    overlay.setAttribute('hidden', '');
+    playfieldOutcomeState.onPrimary = null;
+    playfieldOutcomeState.onSecondary = null;
+    const { primary, secondary } = playfieldOutcomeElements;
+    if (primary) {
+      primary.disabled = false;
+    }
+    if (secondary) {
+      secondary.disabled = false;
+      secondary.setAttribute('hidden', '');
+    }
+    if (restoreFocus && playfieldElements.startButton && typeof playfieldElements.startButton.focus === 'function') {
+      try {
+        playfieldElements.startButton.focus({ preventScroll: true });
+      } catch (error) {
+        playfieldElements.startButton.focus();
+      }
+    }
+  }
+
+  // Surface the desired victory or defeat text and wire up overlay button callbacks.
+  function showPlayfieldOutcome({
+    outcome = 'defeat',
+    title = '',
+    subtitle = '',
+    primaryLabel = 'Back to Level Selection',
+    onPrimary = null,
+    secondaryLabel = null,
+    onSecondary = null,
+  } = {}) {
+    const { overlay, title: titleEl, subtitle: subtitleEl, primary, secondary } = playfieldOutcomeElements;
+    if (!overlay || !titleEl || !primary) {
+      return;
+    }
+
+    hidePlayfieldOutcome();
+
+    overlay.classList.remove('playfield-outcome--victory', 'playfield-outcome--defeat');
+    if (outcome === 'victory') {
+      overlay.classList.add('playfield-outcome--victory');
+    } else {
+      overlay.classList.add('playfield-outcome--defeat');
+    }
+
+    titleEl.textContent = title;
+    if (subtitleEl) {
+      subtitleEl.textContent = subtitle || '';
+      subtitleEl.toggleAttribute('hidden', !subtitle);
+    }
+
+    primary.textContent = primaryLabel;
+    playfieldOutcomeState.onPrimary = typeof onPrimary === 'function' ? onPrimary : null;
+
+    if (secondary) {
+      if (secondaryLabel) {
+        secondary.textContent = secondaryLabel;
+        secondary.removeAttribute('hidden');
+        playfieldOutcomeState.onSecondary = typeof onSecondary === 'function' ? onSecondary : null;
+      } else {
+        secondary.setAttribute('hidden', '');
+        playfieldOutcomeState.onSecondary = null;
+      }
+    }
+
+    overlay.removeAttribute('hidden');
+    overlay.setAttribute('aria-hidden', 'false');
+
+    requestAnimationFrame(() => {
+      overlay.classList.add('active');
+    });
+
+    if (typeof overlay.focus === 'function') {
+      try {
+        overlay.focus({ preventScroll: true });
+      } catch (error) {
+        overlay.focus();
+      }
+    }
+  }
+
+  // Attach listeners to the overlay the first time it is initialized.
+  function bindPlayfieldOutcomeEvents() {
+    if (playfieldOutcomeState.bound) {
+      return;
+    }
+    const { overlay, primary, secondary } = playfieldOutcomeElements;
+    if (!overlay || !primary) {
+      return;
+    }
+
+    primary.addEventListener('click', () => triggerPlayfieldOutcomePrimary());
+    if (secondary) {
+      secondary.addEventListener('click', () => triggerPlayfieldOutcomeSecondary());
+    }
+    overlay.addEventListener('click', (event) => {
+      if (event.target === overlay) {
+        triggerPlayfieldOutcomePrimary();
+      }
+    });
+    overlay.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        triggerPlayfieldOutcomePrimary();
+      }
+    });
+
+    playfieldOutcomeState.bound = true;
+  }
+
+  // Leave combat and transition back to the level selection grid when the overlay is dismissed.
+  function exitToLevelSelectionFromOutcome() {
+    hidePlayfieldOutcome();
+    leaveActiveLevel();
+    updateLayoutVisibility();
+  }
+
+  // Attempt to reload the most recent endless checkpoint when the retry button is pressed.
+  function handleOutcomeRetryRequest() {
+    if (!playfield || typeof playfield.retryFromEndlessCheckpoint !== 'function') {
+      return;
+    }
+    const success = playfield.retryFromEndlessCheckpoint();
+    if (success) {
+      hidePlayfieldOutcome();
+      return;
+    }
+    const { secondary } = playfieldOutcomeElements;
+    if (secondary) {
+      secondary.disabled = true;
+    }
+  }
 
   const alephSubscriptDigits = {
     0: '₀',
@@ -2630,6 +2796,7 @@ import {
     if (!levelId) {
       return;
     }
+    hidePlayfieldOutcome();
     const existing = levelState.get(levelId) || {
       entered: false,
       running: false,
@@ -2688,6 +2855,19 @@ import {
 
     updateActiveLevelBanner();
     updateLevelCards();
+
+    if (activeLevelId === levelId && activeLevelIsInteractive && playfield) {
+      // Surface the victory overlay so the player can exit the battlefield gracefully.
+      const level = levelLookup.get(levelId);
+      const subtitle = level && level.title ? `${level.title} sealed.` : 'All waves contained.';
+      showPlayfieldOutcome({
+        outcome: 'victory',
+        title: 'Victory!',
+        subtitle,
+        primaryLabel: 'Back to Level Selection',
+        onPrimary: exitToLevelSelectionFromOutcome,
+      });
+    }
   }
 
   function handlePlayfieldDefeat(levelId, stats = {}) {
@@ -2712,6 +2892,38 @@ import {
     resourceState.running = false;
     updateActiveLevelBanner();
     updateLevelCards();
+
+    if (activeLevelId === levelId && activeLevelIsInteractive && playfield) {
+      // Display defeat messaging and optional endless retry controls directly on the playfield.
+      const isEndless = Boolean(playfield.isEndlessMode);
+      const fallbackWave = Number.isFinite(playfield.maxWaveReached)
+        ? playfield.maxWaveReached
+        : null;
+      const achievedWave = Number.isFinite(stats.maxWave) ? stats.maxWave : fallbackWave;
+      const waveLabel = achievedWave ? formatWholeNumber(achievedWave) : null;
+      const subtitle = isEndless && waveLabel
+        ? `Wave ${waveLabel} achieved.`
+        : 'The defense collapsed—recalibrate and retry.';
+      let secondaryLabel = null;
+      let secondaryAction = null;
+      if (isEndless && typeof playfield.getEndlessCheckpointInfo === 'function') {
+        const checkpoint = playfield.getEndlessCheckpointInfo();
+        if (checkpoint?.available && Number.isFinite(checkpoint.waveNumber)) {
+          const retryWave = formatWholeNumber(checkpoint.waveNumber);
+          secondaryLabel = `Retry from wave ${retryWave}`;
+          secondaryAction = handleOutcomeRetryRequest;
+        }
+      }
+      showPlayfieldOutcome({
+        outcome: 'defeat',
+        title: 'Defeat…',
+        subtitle,
+        primaryLabel: 'Back to Level Selection',
+        onPrimary: exitToLevelSelectionFromOutcome,
+        secondaryLabel,
+        onSecondary: secondaryAction,
+      });
+    }
   }
 
   
@@ -4306,6 +4518,7 @@ import {
 
   function leaveActiveLevel() {
     if (!activeLevelId) return;
+    hidePlayfieldOutcome();
     const state = levelState.get(activeLevelId);
     if (state) {
       levelState.set(activeLevelId, { ...state, running: false });
@@ -6263,6 +6476,13 @@ import {
     playfieldElements.autoAnchorButton = document.getElementById('playfield-auto');
     playfieldElements.autoWaveCheckbox = document.getElementById('playfield-auto-wave');
     playfieldElements.slots = Array.from(document.querySelectorAll('.tower-slot'));
+    playfieldOutcomeElements.overlay = document.getElementById('playfield-outcome');
+    playfieldOutcomeElements.title = document.getElementById('playfield-outcome-title');
+    playfieldOutcomeElements.subtitle = document.getElementById('playfield-outcome-subtitle');
+    playfieldOutcomeElements.primary = document.getElementById('playfield-outcome-primary');
+    playfieldOutcomeElements.secondary = document.getElementById('playfield-outcome-secondary');
+    bindPlayfieldOutcomeEvents();
+    hidePlayfieldOutcome();
 
     setLoadoutElements({
       container: document.getElementById('tower-loadout'),

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -471,6 +471,122 @@ body.graphics-mode-low .control-button {
   touch-action: none;
 }
 
+/* Fade-in overlay that announces victory or defeat outcomes without leaving the battlefield context. */
+.playfield-outcome {
+  position: absolute;
+  inset: 0;
+  z-index: 5;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: linear-gradient(180deg, rgba(7, 9, 14, 0.78), rgba(7, 9, 14, 0.92));
+  backdrop-filter: blur(8px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--transition, 0.35s ease), transform var(--transition, 0.35s ease);
+}
+
+.playfield-outcome.active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.playfield-outcome__panel {
+  max-width: min(520px, 85vw);
+  text-align: center;
+  display: grid;
+  gap: 18px;
+}
+
+.playfield-outcome__title {
+  font-family: 'Cormorant Garamond', serif;
+  font-size: clamp(2.4rem, 6vw, 3.6rem);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.92);
+  opacity: 0;
+  transform: translateY(12px);
+  transition: opacity 0.45s ease, transform 0.45s ease;
+}
+
+.playfield-outcome.active .playfield-outcome__title {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.playfield-outcome__subtitle {
+  font-size: clamp(1rem, 2.6vw, 1.3rem);
+  color: rgba(255, 255, 255, 0.75);
+  margin: 0;
+  opacity: 0;
+  transform: translateY(16px);
+  transition: opacity 0.45s ease 0.08s, transform 0.45s ease 0.08s;
+}
+
+.playfield-outcome.active .playfield-outcome__subtitle {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.playfield-outcome__actions {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  flex-wrap: wrap;
+  opacity: 0;
+  transform: translateY(18px);
+  transition: opacity 0.45s ease 0.16s, transform 0.45s ease 0.16s;
+}
+
+.playfield-outcome.active .playfield-outcome__actions {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.playfield-outcome__button {
+  min-width: 180px;
+  padding: 12px 18px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  background: rgba(12, 15, 24, 0.8);
+  color: rgba(255, 255, 255, 0.92);
+  font-size: 1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background var(--transition, 0.3s ease), transform var(--transition, 0.3s ease);
+}
+
+.playfield-outcome__button:hover,
+.playfield-outcome__button:focus-visible {
+  background: rgba(32, 37, 54, 0.92);
+  transform: translateY(-1px);
+}
+
+.playfield-outcome__button:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.4);
+  outline-offset: 3px;
+}
+
+.playfield-outcome__button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.playfield-outcome__button--secondary {
+  border-color: rgba(255, 215, 141, 0.32);
+}
+
+.playfield-outcome--victory .playfield-outcome__title {
+  color: #f5d674;
+  text-shadow: 0 0 18px rgba(245, 214, 116, 0.35);
+}
+
+.playfield-outcome--defeat .playfield-outcome__title {
+  color: #ff6b7c;
+  text-shadow: 0 0 12px rgba(255, 80, 102, 0.28);
+}
+
 .playfield-menu-button {
   /* Compact hamburger control that anchors in the playfield's top-right corner. */
   position: absolute;

--- a/index.html
+++ b/index.html
@@ -156,6 +156,36 @@
                   </label>
                 </div>
                 <canvas id="playfield-canvas" width="560" height="360"></canvas>
+                <!-- Outcome overlay dims the battlefield and surfaces victory or defeat messaging. -->
+                <div
+                  class="playfield-outcome"
+                  id="playfield-outcome"
+                  role="dialog"
+                  aria-modal="true"
+                  aria-hidden="true"
+                  tabindex="-1"
+                  hidden
+                >
+                  <div class="playfield-outcome__panel">
+                    <p class="playfield-outcome__title" id="playfield-outcome-title"></p>
+                    <p class="playfield-outcome__subtitle" id="playfield-outcome-subtitle"></p>
+                    <div class="playfield-outcome__actions">
+                      <button
+                        class="playfield-outcome__button"
+                        type="button"
+                        id="playfield-outcome-primary"
+                      >
+                        Back to Level Selection
+                      </button>
+                      <button
+                        class="playfield-outcome__button playfield-outcome__button--secondary"
+                        type="button"
+                        id="playfield-outcome-secondary"
+                        hidden
+                      ></button>
+                    </div>
+                  </div>
+                </div>
                 <dl class="playfield-stats" aria-live="polite">
                   <div class="playfield-stats__item">
                     <dt>Wave</dt>


### PR DESCRIPTION
## Summary
- add a playfield outcome overlay that dims the battlefield and shows victory/defeat messaging
- autosave endless mode checkpoints at the start of each wave cycle and expose a one-time retry hook
- surface endless defeat wave results with an optional checkpoint retry button and return-to-selection action

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6901c7574118832a8a9ff5bfaebbf98d