### PR TITLE
Refactor resource displays into stage and tower panels

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -1658,56 +1658,96 @@ import {
   }
 
   const resourceElements = {
-    score: null,
-    scoreMultiplier: null,
+    theroReserve: null,
+    theroMultiplier: null,
+    theroBase: null,
+    theroEquationMultiplier: null,
+    theroEquationTotal: null,
+    theroEquationContainer: null,
     glyphsTotal: null,
     glyphsUnused: null,
-    moteStorage: null,
-    dispenseRate: null,
+    glyphBadge: null,
+    moteBank: null,
+    moteRate: null,
+    moteBadge: null,
   };
 
-  // Cache the status bar DOM nodes so resource updates only perform lightweight text swaps.
+  // Cache the relocated resource nodes so status updates only swap text content.
   function bindStatusElements() {
-    resourceElements.score = document.getElementById('status-score');
-    resourceElements.scoreMultiplier = document.getElementById('status-score-multiplier');
-    resourceElements.glyphsTotal = document.getElementById('status-glyphs-total');
-    resourceElements.glyphsUnused = document.getElementById('status-glyphs-unused');
-    resourceElements.moteStorage = document.getElementById('status-mote-storage');
-    resourceElements.dispenseRate = document.getElementById('status-dispense-rate');
+    resourceElements.theroReserve = document.getElementById('level-thero-score');
+    resourceElements.theroMultiplier = document.getElementById('level-thero-multiplier');
+    resourceElements.theroBase = document.getElementById('level-thero-base');
+    resourceElements.theroEquationMultiplier = document.getElementById('level-thero-equation-multiplier');
+    resourceElements.theroEquationTotal = document.getElementById('level-thero-total');
+    resourceElements.theroEquationContainer = document.getElementById('level-thero-equation');
+    resourceElements.glyphsTotal = document.getElementById('tower-glyphs-total');
+    resourceElements.glyphsUnused = document.getElementById('tower-glyphs-unused');
+    resourceElements.glyphBadge = document.getElementById('tower-glyph-badge');
+    resourceElements.moteBank = document.getElementById('tower-mote-bank');
+    resourceElements.moteRate = document.getElementById('tower-mote-rate');
+    resourceElements.moteBadge = document.getElementById('tower-mote-badge');
     updateStatusDisplays();
   }
 
-  // Render the header status bar using the latest score, glyph, and mote reserves.
+  // Render the relocated resource panels using the latest score, glyph, and mote reserves.
   function updateStatusDisplays() {
     const scoreValue = Number.isFinite(resourceState.score) ? Math.max(0, resourceState.score) : 0;
-    if (resourceElements.score) {
-      resourceElements.score.textContent = `${formatGameNumber(scoreValue)} ${THERO_SYMBOL}`;
+    if (resourceElements.theroReserve) {
+      resourceElements.theroReserve.textContent = `${formatGameNumber(scoreValue)} ${THERO_SYMBOL}`;
     }
 
     const theroMultiplier = getStartingTheroMultiplier();
-    if (resourceElements.scoreMultiplier) {
-      resourceElements.scoreMultiplier.textContent = `×${formatDecimal(theroMultiplier, 2)}`;
+    if (resourceElements.theroMultiplier) {
+      resourceElements.theroMultiplier.textContent = `×${formatDecimal(theroMultiplier, 2)}`;
+    }
+    if (resourceElements.theroBase) {
+      resourceElements.theroBase.textContent = `${formatGameNumber(BASE_START_THERO)} ${THERO_SYMBOL}`;
+    }
+    if (resourceElements.theroEquationMultiplier) {
+      resourceElements.theroEquationMultiplier.textContent = `${formatDecimal(theroMultiplier, 2)}`;
+    }
+    const startingThero = Math.max(0, BASE_START_THERO * theroMultiplier);
+    if (resourceElements.theroEquationTotal) {
+      resourceElements.theroEquationTotal.textContent = `${formatGameNumber(startingThero)} ${THERO_SYMBOL}`;
+    }
+    if (resourceElements.theroEquationContainer) {
+      resourceElements.theroEquationContainer.setAttribute(
+        'aria-label',
+        `Starting Thero equals ${formatGameNumber(BASE_START_THERO)} ${THERO_SYMBOL} times ${formatDecimal(
+          theroMultiplier,
+          2,
+        )} equals ${formatGameNumber(startingThero)} ${THERO_SYMBOL}`,
+      );
     }
 
     const totalGlyphs = Math.max(0, Math.floor(gameStats.enemiesDefeated || 0));
     const unusedGlyphs = Math.max(0, Math.floor(getGlyphCurrency()));
     if (resourceElements.glyphsTotal) {
-      const glyphLabel = totalGlyphs === 1 ? 'Glyph' : 'Glyphs';
-      resourceElements.glyphsTotal.textContent = `${formatWholeNumber(totalGlyphs)} ${glyphLabel}`;
+      resourceElements.glyphsTotal.textContent = formatWholeNumber(totalGlyphs);
     }
     if (resourceElements.glyphsUnused) {
-      resourceElements.glyphsUnused.textContent = `(${formatWholeNumber(unusedGlyphs)} unused)`;
+      resourceElements.glyphsUnused.textContent = formatWholeNumber(unusedGlyphs);
+    }
+    if (resourceElements.glyphBadge) {
+      const unusedGlyphLabel = formatWholeNumber(unusedGlyphs);
+      resourceElements.glyphBadge.textContent = unusedGlyphLabel;
+      resourceElements.glyphBadge.setAttribute('aria-label', `${unusedGlyphLabel} unused glyphs`);
     }
 
     const storedMotes = Math.max(0, powderCurrency + (powderState.idleMoteBank || 0));
-    if (resourceElements.moteStorage) {
-      resourceElements.moteStorage.textContent = `${formatGameNumber(storedMotes)} Motes`;
+    if (resourceElements.moteBank) {
+      resourceElements.moteBank.textContent = `${formatGameNumber(storedMotes)} Motes`;
+    }
+    if (resourceElements.moteBadge) {
+      const storedLabel = formatGameNumber(storedMotes);
+      resourceElements.moteBadge.textContent = storedLabel;
+      resourceElements.moteBadge.setAttribute('aria-label', `${storedLabel} motes in bank`);
     }
 
     const dispenseRate = Number.isFinite(powderState.idleDrainRate) ? Math.max(0, powderState.idleDrainRate) : 0;
-    if (resourceElements.dispenseRate) {
+    if (resourceElements.moteRate) {
       const moteLabel = dispenseRate === 1 ? 'Mote/sec' : 'Motes/sec';
-      resourceElements.dispenseRate.textContent = `${formatDecimal(dispenseRate, 2)} ${moteLabel}`;
+      resourceElements.moteRate.textContent = `${formatDecimal(dispenseRate, 2)} ${moteLabel}`;
     }
   }
 

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -194,9 +194,67 @@ body.graphics-mode-low .control-button {
   width: min(960px, 100%);
   min-height: 100vh;
   display: grid;
-  grid-template-rows: auto minmax(0, 1fr) auto;
+  grid-template-rows: minmax(0, 1fr) auto;
   padding: 24px clamp(16px, 4vw, 36px) 16px;
   gap: 16px;
+}
+
+/* Display the relocated thero equation banner within the level selection tab. */
+.level-thero-banner {
+  background: var(--panel);
+  border: 1px solid var(--panel-border);
+  border-radius: 18px;
+  padding: clamp(16px, 3vw, 24px);
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 12px;
+  margin-bottom: clamp(18px, 4vw, 28px);
+}
+
+.level-thero-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.level-thero-row--equation {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 8px 0;
+}
+
+.level-thero-label {
+  font-family: "Space Mono", monospace;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.level-thero-value {
+  font-size: clamp(1.1rem, 2.4vw, 1.5rem);
+}
+
+.level-thero-equation {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  font-size: clamp(1rem, 2vw, 1.35rem);
+}
+
+.level-thero-symbol {
+  color: var(--muted);
+}
+
+@media (max-width: 640px) {
+  .level-thero-banner {
+    gap: 10px;
+  }
+
+  .level-thero-equation {
+    flex-wrap: wrap;
+  }
 }
 
 .status-bar {
@@ -4854,5 +4912,113 @@ body.graphics-mode-low .control-button {
 .tower-cost-value {
   font-weight: 600;
   color: var(--path-orange);
+}
+
+#panel-towers {
+  position: relative;
+}
+
+/* Highlight glyph and mote summaries within the Towers tab. */
+.tower-glyph-summary {
+  display: flex;
+  gap: 18px;
+  flex-wrap: wrap;
+  margin-bottom: 20px;
+  padding: 14px clamp(14px, 3vw, 24px);
+  border: 1px solid var(--panel-border);
+  border-radius: 16px;
+  background: rgba(10, 10, 16, 0.72);
+  box-shadow: var(--shadow);
+}
+
+.tower-glyph-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 140px;
+}
+
+.tower-glyph-label {
+  font-family: "Space Mono", monospace;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.tower-glyph-value {
+  font-size: clamp(1rem, 2vw, 1.4rem);
+}
+
+.tower-mote-summary {
+  grid-column: 1 / -1;
+  display: grid;
+  gap: 10px;
+  padding: clamp(14px, 3vw, 22px);
+  border-radius: 16px;
+  border: 1px solid var(--panel-border);
+  background: rgba(10, 10, 16, 0.72);
+  box-shadow: var(--shadow);
+}
+
+.tower-mote-line {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.tower-mote-label {
+  font-family: "Space Mono", monospace;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.tower-mote-value {
+  font-size: clamp(1rem, 2vw, 1.35rem);
+}
+
+.tower-panel-badges {
+  position: absolute;
+  right: clamp(16px, 3vw, 24px);
+  bottom: clamp(16px, 3vw, 24px);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  pointer-events: none;
+}
+
+.tower-badge {
+  min-width: 64px;
+  padding: 6px 14px;
+  text-align: center;
+  font-family: "Space Mono", monospace;
+  font-size: 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text);
+  box-shadow: 0 0 18px rgba(255, 228, 120, 0.35), 0 0 8px rgba(255, 228, 120, 0.18);
+}
+
+.tower-badge--glyphs {
+  color: var(--accent-3);
+  text-shadow: 0 0 10px rgba(255, 228, 120, 0.55);
+}
+
+.tower-badge--motes {
+  color: var(--accent);
+  text-shadow: 0 0 12px rgba(139, 247, 255, 0.55);
+}
+
+@media (max-width: 720px) {
+  .tower-panel-badges {
+    position: static;
+    flex-direction: row;
+    justify-content: flex-end;
+    margin-top: 18px;
+  }
 }
 

--- a/index.html
+++ b/index.html
@@ -57,30 +57,6 @@
       </div>
     </div>
     <div class="app-shell">
-      <header class="status-bar">
-        <div class="status-group">
-          <span class="status-label">þ Thero</span>
-          <span class="status-value status-value--stacked">
-            <span id="status-score">0 þ</span>
-            <span class="status-multiplier" id="status-score-multiplier">×0</span>
-          </span>
-        </div>
-        <div class="status-group">
-          <span class="status-label">Ψ Glyphs</span>
-          <span class="status-value status-value--stacked">
-            <span id="status-glyphs-total">0 Glyphs</span>
-            <span class="status-subvalue status-subvalue--gold" id="status-glyphs-unused">(0 unused)</span>
-          </span>
-        </div>
-        <div class="status-group">
-          <span class="status-label">Motes Stored</span>
-          <span class="status-value status-value--stacked">
-            <span id="status-mote-storage">0 Motes</span>
-            <span class="status-subvalue status-subvalue--gold" id="status-dispense-rate">1 Mote/sec</span>
-          </span>
-        </div>
-      </header>
-
       <main class="main-stage">
         <section
           class="panel active"
@@ -211,6 +187,27 @@
             </div>
           </section>
           <section class="level-section" id="level-selection">
+            <!-- Surface the live thero multiplier and starting equation at the top of the level list. -->
+            <div class="level-thero-banner" id="level-thero-banner" aria-live="polite">
+              <div class="level-thero-row">
+                <span class="level-thero-label">Thero Multiplier</span>
+                <span class="level-thero-value" id="level-thero-multiplier">×0.00</span>
+              </div>
+              <div class="level-thero-row level-thero-row--equation">
+                <span class="level-thero-label">Starting Thero</span>
+                <span class="level-thero-equation" id="level-thero-equation">
+                  <span id="level-thero-base">0 þ</span>
+                  <span aria-hidden="true" class="level-thero-symbol">×</span>
+                  <span id="level-thero-equation-multiplier">0.00</span>
+                  <span aria-hidden="true" class="level-thero-symbol">=</span>
+                  <span id="level-thero-total">0 þ</span>
+                </span>
+              </div>
+              <div class="level-thero-row level-thero-row--reserve">
+                <span class="level-thero-label">Current Reserve</span>
+                <span class="level-thero-value" id="level-thero-score">0 þ</span>
+              </div>
+            </div>
             <header class="subsection-title">Conjecture Set</header>
             <p class="level-intro">
               The opening proofs trace immortal-defense style figure-eights,
@@ -230,6 +227,17 @@
           aria-labelledby="tab-towers"
           hidden
         >
+          <!-- Present tower resource summaries near the top of the Towers tab. -->
+          <div class="tower-glyph-summary" id="tower-glyph-summary" aria-live="polite">
+            <div class="tower-glyph-item">
+              <span class="tower-glyph-label">Total Glyphs</span>
+              <span class="tower-glyph-value" id="tower-glyphs-total">0</span>
+            </div>
+            <div class="tower-glyph-item">
+              <span class="tower-glyph-label">Unused Glyphs</span>
+              <span class="tower-glyph-value" id="tower-glyphs-unused">0</span>
+            </div>
+          </div>
           <div class="tower-panel-controls" id="tower-panel-controls">
             <button
               class="tower-panel-button tower-tree-map-button"
@@ -326,6 +334,32 @@
                 The original tower—anchoring the lane's finale. When the Mind Gate collapses, inspiration runs dry.
               </footer>
             </article>
+            <article class="card card--motes">
+              <header class="tower-header">
+                <span class="tower-tier">Resource</span>
+                <h3>motes tower</h3>
+              </header>
+              <div class="formula-block">
+                <p class="formula-line">\( \mathcal{M} = B_{\text{idle}} + R_{\text{fall}} \)</p>
+                <ul class="formula-definition">
+                  <li>B<sub>idle</sub> → idle mote bank harvested between waves</li>
+                  <li>R<sub>fall</sub> → live fall rate siphoned from the motefall basin</li>
+                </ul>
+                <p class="formula-line result">Tracks idle motes fueling powder-forged upgrades.</p>
+              </div>
+              <footer class="card-footer">Channels stored motes directly into the tower lattice.</footer>
+            </article>
+            <!-- Mote bank readout sits beneath the dedicated motes tower entry. -->
+            <div class="tower-mote-summary" id="tower-mote-summary" aria-live="polite">
+              <div class="tower-mote-line">
+                <span class="tower-mote-label">Mote Bank</span>
+                <span class="tower-mote-value" id="tower-mote-bank">0 Motes</span>
+              </div>
+              <div class="tower-mote-line">
+                <span class="tower-mote-label">Fall Rate</span>
+                <span class="tower-mote-value" id="tower-mote-rate">1.00 Motes/sec</span>
+              </div>
+            </div>
             <article class="card" data-tower-id="alpha" aria-hidden="false">
               <header class="tower-header">
                 <span class="tower-tier">Tier I</span>
@@ -970,6 +1004,10 @@
               </button>
             </article>
 
+          </div>
+          <div class="tower-panel-badges" id="tower-panel-badges" aria-live="polite">
+            <span class="tower-badge tower-badge--glyphs" id="tower-glyph-badge">0</span>
+            <span class="tower-badge tower-badge--motes" id="tower-mote-badge">0</span>
           </div>
         </section>
 


### PR DESCRIPTION
## Summary
- remove the global status bar and move the thero multiplier into a level selection banner
- surface glyph totals and mote stats inside the towers tab with a dedicated motes card and badges
- update styling and resource bindings to drive the new HUD locations

## Testing
- Not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_690249362c90832abdd7a60649b72da4