### PR TITLE
Add glowing resource badges to tab icons

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -1667,9 +1667,11 @@ import {
     glyphsTotal: null,
     glyphsUnused: null,
     glyphBadge: null,
+    tabGlyphBadge: null,
     moteBank: null,
     moteRate: null,
     moteBadge: null,
+    tabMoteBadge: null,
   };
 
   // Cache the relocated resource nodes so status updates only swap text content.
@@ -1683,9 +1685,11 @@ import {
     resourceElements.glyphsTotal = document.getElementById('tower-glyphs-total');
     resourceElements.glyphsUnused = document.getElementById('tower-glyphs-unused');
     resourceElements.glyphBadge = document.getElementById('tower-glyph-badge');
+    resourceElements.tabGlyphBadge = document.getElementById('tab-glyph-badge');
     resourceElements.moteBank = document.getElementById('tower-mote-bank');
     resourceElements.moteRate = document.getElementById('tower-mote-rate');
     resourceElements.moteBadge = document.getElementById('tower-mote-badge');
+    resourceElements.tabMoteBadge = document.getElementById('tab-mote-badge');
     updateStatusDisplays();
   }
 
@@ -1734,6 +1738,21 @@ import {
       resourceElements.glyphBadge.setAttribute('aria-label', `${unusedGlyphLabel} unused glyphs`);
     }
 
+    if (resourceElements.tabGlyphBadge) {
+      const tabGlyphLabel = formatWholeNumber(unusedGlyphs);
+      resourceElements.tabGlyphBadge.textContent = tabGlyphLabel;
+      resourceElements.tabGlyphBadge.setAttribute('aria-label', `${tabGlyphLabel} unused glyphs`);
+      const hasUnusedGlyphs = unusedGlyphs > 0;
+      // Mirror the glow badge visibility on the towers tab so idle glyphs stand out immediately.
+      if (hasUnusedGlyphs) {
+        resourceElements.tabGlyphBadge.removeAttribute('hidden');
+        resourceElements.tabGlyphBadge.setAttribute('aria-hidden', 'false');
+      } else {
+        resourceElements.tabGlyphBadge.setAttribute('hidden', '');
+        resourceElements.tabGlyphBadge.setAttribute('aria-hidden', 'true');
+      }
+    }
+
     const storedMotes = Math.max(0, powderCurrency + (powderState.idleMoteBank || 0));
     if (resourceElements.moteBank) {
       resourceElements.moteBank.textContent = `${formatGameNumber(storedMotes)} Motes`;
@@ -1742,6 +1761,14 @@ import {
       const storedLabel = formatGameNumber(storedMotes);
       resourceElements.moteBadge.textContent = storedLabel;
       resourceElements.moteBadge.setAttribute('aria-label', `${storedLabel} motes in bank`);
+    }
+
+    if (resourceElements.tabMoteBadge) {
+      const tabStoredLabel = formatGameNumber(storedMotes);
+      resourceElements.tabMoteBadge.textContent = tabStoredLabel;
+      resourceElements.tabMoteBadge.setAttribute('aria-label', `${tabStoredLabel} motes in bank`);
+      resourceElements.tabMoteBadge.removeAttribute('hidden');
+      resourceElements.tabMoteBadge.setAttribute('aria-hidden', 'false');
     }
 
     const dispenseRate = Number.isFinite(powderState.idleDrainRate) ? Math.max(0, powderState.idleDrainRate) : 0;

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -4851,6 +4851,37 @@ body.graphics-mode-low .control-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  position: relative;
+}
+
+/* Compact glowing badge overlay to surface resource counts atop tab icons. */
+.tab-icon-badge {
+  position: absolute;
+  bottom: -2px;
+  right: -6px;
+  min-width: 26px;
+  padding: 2px 6px;
+  font-family: "Space Mono", monospace;
+  font-size: 0.58rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.26);
+  background: rgba(3, 3, 5, 0.9);
+  color: var(--text);
+  text-align: center;
+  box-shadow: 0 0 14px rgba(255, 228, 120, 0.4), 0 0 6px rgba(255, 228, 120, 0.25);
+  pointer-events: none;
+}
+
+/* Accent the glyph badge with the same amber glow used in the tower panel. */
+.tab-icon-badge--glyphs {
+  color: var(--accent-3);
+  text-shadow: 0 0 6px rgba(255, 228, 120, 0.65);
+}
+
+/* Highlight the mote badge with the teal glow from the mote panel indicator. */
+.tab-icon-badge--motes {
+  color: var(--accent);
+  text-shadow: 0 0 8px rgba(139, 247, 255, 0.65);
 }
 
 .tab-icon img {

--- a/index.html
+++ b/index.html
@@ -1364,7 +1364,11 @@
           aria-selected="false"
           aria-pressed="false"
         >
-          <span class="tab-icon">Δ</span>
+          <span class="tab-icon">
+            Δ
+            <!-- Indicator for unused glyph currency within the towers tab icon. -->
+            <span class="tab-icon-badge tab-icon-badge--glyphs" id="tab-glyph-badge" hidden>0</span>
+          </span>
           <span class="tab-label">Towers</span>
         </button>
         <button
@@ -1378,7 +1382,11 @@
           aria-selected="false"
           aria-pressed="false"
         >
-          <span class="tab-icon">⧖</span>
+          <span class="tab-icon">
+            ⧖
+            <!-- Persistent mote bank indicator within the powder tab icon. -->
+            <span class="tab-icon-badge tab-icon-badge--motes" id="tab-mote-badge">0.00</span>
+          </span>
           <span class="tab-label">Mote Gems</span>
         </button>
         <button


### PR DESCRIPTION
## Summary
- overlay the unused glyph count on the Towers tab icon so idle glyphs stand out immediately
- surface the stored mote total on the Mote Gems tab icon for constant visibility
- style the new icon badges with glowing accents that match existing resource indicators

## Testing
- Manual: Loaded the local build in a browser to verify tab badges render and update


------
https://chatgpt.com/codex/tasks/task_e_69024d93b170832aa8f006d72180b803