### PR TITLE
Stack level selection sets and surface per-stage starting Thero

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -218,12 +218,6 @@ body.graphics-mode-low .control-button {
   gap: 12px;
 }
 
-.level-thero-row--equation {
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-  padding: 8px 0;
-}
-
 .level-thero-label {
   font-family: "Space Mono", monospace;
   text-transform: uppercase;
@@ -236,24 +230,9 @@ body.graphics-mode-low .control-button {
   font-size: clamp(1.1rem, 2.4vw, 1.5rem);
 }
 
-.level-thero-equation {
-  display: flex;
-  align-items: baseline;
-  gap: 6px;
-  font-size: clamp(1rem, 2vw, 1.35rem);
-}
-
-.level-thero-symbol {
-  color: var(--muted);
-}
-
 @media (max-width: 640px) {
   .level-thero-banner {
     gap: 10px;
-  }
-
-  .level-thero-equation {
-    flex-wrap: wrap;
   }
 }
 
@@ -1062,10 +1041,9 @@ body.graphics-mode-low .control-button {
 
 .level-grid {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: 24px;
-  justify-content: center;
-  align-items: flex-start;
+  align-items: stretch;
   width: 100%;
 }
 
@@ -1078,8 +1056,9 @@ body.graphics-mode-low .control-button {
   gap: 18px;
   padding: 6px 0;
   flex: 0 0 auto;
-  width: var(--level-node-size);
-  transition: width 360ms ease, transform 320ms ease;
+  width: 100%;
+  max-width: 100%;
+  transition: transform 320ms ease;
 }
 
 .level-set.expanded {

--- a/index.html
+++ b/index.html
@@ -193,20 +193,6 @@
                 <span class="level-thero-label">Thero Multiplier</span>
                 <span class="level-thero-value" id="level-thero-multiplier">×0.00</span>
               </div>
-              <div class="level-thero-row level-thero-row--equation">
-                <span class="level-thero-label">Starting Thero</span>
-                <span class="level-thero-equation" id="level-thero-equation">
-                  <span id="level-thero-base">0 þ</span>
-                  <span aria-hidden="true" class="level-thero-symbol">×</span>
-                  <span id="level-thero-equation-multiplier">0.00</span>
-                  <span aria-hidden="true" class="level-thero-symbol">=</span>
-                  <span id="level-thero-total">0 þ</span>
-                </span>
-              </div>
-              <div class="level-thero-row level-thero-row--reserve">
-                <span class="level-thero-label">Current Reserve</span>
-                <span class="level-thero-value" id="level-thero-score">0 þ</span>
-              </div>
             </div>
             <header class="subsection-title">Conjecture Set</header>
             <p class="level-intro">
@@ -1711,6 +1697,10 @@
           <div>
             <dt>Run Length</dt>
             <dd id="overlay-duration">—</dd>
+          </div>
+          <div>
+            <dt>Starting Thero</dt>
+            <dd id="overlay-start-thero">—</dd>
           </div>
           <div>
             <dt>Rewards</dt>


### PR DESCRIPTION
## Summary
- stack level selection sets vertically so expanding one no longer shifts its neighbors
- simplify the stage banner by removing reserve/start rows and add a starting Thero metric to the level preview overlay
- compute per-stage starting Thero totals and announce them in the overlay and level summaries

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_690250bd95dc832abcdc03c6c4cef340