### PR TITLE
Relocate mote stats to the mote gems tab

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -1663,11 +1663,7 @@ import {
     theroMultiplier: null,
     glyphsTotal: null,
     glyphsUnused: null,
-    glyphBadge: null,
     tabGlyphBadge: null,
-    moteBank: null,
-    moteRate: null,
-    moteBadge: null,
     tabMoteBadge: null,
   };
 
@@ -1676,11 +1672,7 @@ import {
     resourceElements.theroMultiplier = document.getElementById('level-thero-multiplier');
     resourceElements.glyphsTotal = document.getElementById('tower-glyphs-total');
     resourceElements.glyphsUnused = document.getElementById('tower-glyphs-unused');
-    resourceElements.glyphBadge = document.getElementById('tower-glyph-badge');
     resourceElements.tabGlyphBadge = document.getElementById('tab-glyph-badge');
-    resourceElements.moteBank = document.getElementById('tower-mote-bank');
-    resourceElements.moteRate = document.getElementById('tower-mote-rate');
-    resourceElements.moteBadge = document.getElementById('tower-mote-badge');
     resourceElements.tabMoteBadge = document.getElementById('tab-mote-badge');
     updateStatusDisplays();
   }
@@ -1700,12 +1692,6 @@ import {
     if (resourceElements.glyphsUnused) {
       resourceElements.glyphsUnused.textContent = formatWholeNumber(unusedGlyphs);
     }
-    if (resourceElements.glyphBadge) {
-      const unusedGlyphLabel = formatWholeNumber(unusedGlyphs);
-      resourceElements.glyphBadge.textContent = unusedGlyphLabel;
-      resourceElements.glyphBadge.setAttribute('aria-label', `${unusedGlyphLabel} unused glyphs`);
-    }
-
     if (resourceElements.tabGlyphBadge) {
       const tabGlyphLabel = formatWholeNumber(unusedGlyphs);
       resourceElements.tabGlyphBadge.textContent = tabGlyphLabel;
@@ -1722,27 +1708,12 @@ import {
     }
 
     const storedMotes = Math.max(0, powderCurrency + (powderState.idleMoteBank || 0));
-    if (resourceElements.moteBank) {
-      resourceElements.moteBank.textContent = `${formatGameNumber(storedMotes)} Motes`;
-    }
-    if (resourceElements.moteBadge) {
-      const storedLabel = formatGameNumber(storedMotes);
-      resourceElements.moteBadge.textContent = storedLabel;
-      resourceElements.moteBadge.setAttribute('aria-label', `${storedLabel} motes in bank`);
-    }
-
     if (resourceElements.tabMoteBadge) {
       const tabStoredLabel = formatGameNumber(storedMotes);
       resourceElements.tabMoteBadge.textContent = tabStoredLabel;
       resourceElements.tabMoteBadge.setAttribute('aria-label', `${tabStoredLabel} motes in bank`);
       resourceElements.tabMoteBadge.removeAttribute('hidden');
       resourceElements.tabMoteBadge.setAttribute('aria-hidden', 'false');
-    }
-
-    const dispenseRate = Number.isFinite(powderState.idleDrainRate) ? Math.max(0, powderState.idleDrainRate) : 0;
-    if (resourceElements.moteRate) {
-      const moteLabel = dispenseRate === 1 ? 'Mote/sec' : 'Motes/sec';
-      resourceElements.moteRate.textContent = `${formatDecimal(dispenseRate, 2)} ${moteLabel}`;
     }
   }
 
@@ -1818,7 +1789,8 @@ import {
     crystalBonusValue: null,
     stockpile: null,
     idleMultiplier: null,
-    dispenseRate: null,
+    moteBank: null,
+    moteRate: null,
     gemInventoryList: null,
     gemInventoryEmpty: null,
     craftingButton: null,
@@ -6218,10 +6190,18 @@ import {
       )} ${rateLabel}`;
     }
 
-    if (powderElements.dispenseRate) {
+    // Display the relocated idle mote bank readout inside the mote gems tab.
+    if (powderElements.moteBank) {
+      const storedMotes = Math.max(0, powderCurrency + getCurrentIdleMoteBank());
+      const moteLabel = storedMotes === 1 ? 'Mote' : 'Motes';
+      powderElements.moteBank.textContent = `${formatGameNumber(storedMotes)} ${moteLabel}`;
+    }
+
+    // Surface the current fall rate so the mote gems tab mirrors the basin flow.
+    if (powderElements.moteRate) {
       const dispenseRate = getCurrentMoteDispenseRate();
       const moteLabel = dispenseRate === 1 ? 'Mote/sec' : 'Motes/sec';
-      powderElements.dispenseRate.textContent = `${formatDecimal(dispenseRate, 2)} ${moteLabel}`;
+      powderElements.moteRate.textContent = `${formatDecimal(dispenseRate, 2)} ${moteLabel}`;
     }
   }
 
@@ -6257,8 +6237,11 @@ import {
     powderElements.duneBonusValue = document.getElementById('powder-dune-bonus');
     powderElements.crystalBonusValue = document.getElementById('powder-crystal-bonus');
     powderElements.stockpile = document.getElementById('powder-stockpile');
+    // Relocated mote bank indicator now anchors to the mote gems tab summary.
+    powderElements.moteBank = document.getElementById('powder-mote-bank');
+    // Fall rate display follows the bank so both mote flows surface together.
+    powderElements.moteRate = document.getElementById('powder-mote-rate');
     powderElements.idleMultiplier = document.getElementById('powder-idle-multiplier');
-    powderElements.dispenseRate = document.getElementById('powder-dispense-rate');
     powderElements.gemInventoryList = document.getElementById('powder-gem-inventory');
     powderElements.gemInventoryEmpty = document.getElementById('powder-gem-empty');
     powderElements.craftingButton = document.getElementById('open-crafting-menu');

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -4839,15 +4839,15 @@ body.graphics-mode-low .control-button {
   bottom: -2px;
   right: -6px;
   min-width: 26px;
-  padding: 2px 6px;
+  padding: 0 4px;
   font-family: "Space Mono", monospace;
   font-size: 0.58rem;
   border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.26);
-  background: rgba(3, 3, 5, 0.9);
+  border: none;
+  background: transparent;
   color: var(--text);
   text-align: center;
-  box-shadow: 0 0 14px rgba(255, 228, 120, 0.4), 0 0 6px rgba(255, 228, 120, 0.25);
+  text-shadow: 0 0 6px rgba(255, 255, 255, 0.25);
   pointer-events: none;
 }
 
@@ -4958,77 +4958,5 @@ body.graphics-mode-low .control-button {
 
 .tower-glyph-value {
   font-size: clamp(1rem, 2vw, 1.4rem);
-}
-
-.tower-mote-summary {
-  grid-column: 1 / -1;
-  display: grid;
-  gap: 10px;
-  padding: clamp(14px, 3vw, 22px);
-  border-radius: 16px;
-  border: 1px solid var(--panel-border);
-  background: rgba(10, 10, 16, 0.72);
-  box-shadow: var(--shadow);
-}
-
-.tower-mote-line {
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  gap: 12px;
-}
-
-.tower-mote-label {
-  font-family: "Space Mono", monospace;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-size: 0.75rem;
-  color: var(--muted);
-}
-
-.tower-mote-value {
-  font-size: clamp(1rem, 2vw, 1.35rem);
-}
-
-.tower-panel-badges {
-  position: absolute;
-  right: clamp(16px, 3vw, 24px);
-  bottom: clamp(16px, 3vw, 24px);
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  pointer-events: none;
-}
-
-.tower-badge {
-  min-width: 64px;
-  padding: 6px 14px;
-  text-align: center;
-  font-family: "Space Mono", monospace;
-  font-size: 0.9rem;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.28);
-  background: rgba(255, 255, 255, 0.08);
-  color: var(--text);
-  box-shadow: 0 0 18px rgba(255, 228, 120, 0.35), 0 0 8px rgba(255, 228, 120, 0.18);
-}
-
-.tower-badge--glyphs {
-  color: var(--accent-3);
-  text-shadow: 0 0 10px rgba(255, 228, 120, 0.55);
-}
-
-.tower-badge--motes {
-  color: var(--accent);
-  text-shadow: 0 0 12px rgba(139, 247, 255, 0.55);
-}
-
-@media (max-width: 720px) {
-  .tower-panel-badges {
-    position: static;
-    flex-direction: row;
-    justify-content: flex-end;
-    margin-top: 18px;
-  }
 }
 

--- a/index.html
+++ b/index.html
@@ -335,17 +335,6 @@
               </div>
               <footer class="card-footer">Channels stored motes directly into the tower lattice.</footer>
             </article>
-            <!-- Mote bank readout sits beneath the dedicated motes tower entry. -->
-            <div class="tower-mote-summary" id="tower-mote-summary" aria-live="polite">
-              <div class="tower-mote-line">
-                <span class="tower-mote-label">Mote Bank</span>
-                <span class="tower-mote-value" id="tower-mote-bank">0 Motes</span>
-              </div>
-              <div class="tower-mote-line">
-                <span class="tower-mote-label">Fall Rate</span>
-                <span class="tower-mote-value" id="tower-mote-rate">1.00 Motes/sec</span>
-              </div>
-            </div>
             <article class="card" data-tower-id="alpha" aria-hidden="false">
               <header class="tower-header">
                 <span class="tower-tier">Tier I</span>
@@ -991,10 +980,6 @@
             </article>
 
           </div>
-          <div class="tower-panel-badges" id="tower-panel-badges" aria-live="polite">
-            <span class="tower-badge tower-badge--glyphs" id="tower-glyph-badge">0</span>
-            <span class="tower-badge tower-badge--motes" id="tower-mote-badge">0</span>
-          </div>
         </section>
 
         <section
@@ -1075,13 +1060,19 @@
             <article class="card powder-mote-stats">
               <h3>Mote Bank Stats</h3>
               <dl class="powder-metrics">
+                <!-- Idle mote bank readout relocated from the towers tab to centralize mote tracking. -->
+                <div>
+                  <dt>Mote Bank</dt>
+                  <dd id="powder-mote-bank">0 Motes</dd>
+                </div>
+                <!-- Fall rate display migrated alongside the bank so both mote flows live in one tab. -->
+                <div>
+                  <dt>Fall Rate</dt>
+                  <dd id="powder-mote-rate">1.00 Motes/sec</dd>
+                </div>
                 <div>
                   <dt>Idle Multiplier</dt>
                   <dd id="powder-idle-multiplier">0 achievements</dd>
-                </div>
-                <div>
-                    <dt>Dispensing Rate</dt>
-                    <dd id="powder-dispense-rate">1 Mote/sec</dd>
                 </div>
               </dl>
             </article>


### PR DESCRIPTION
## Summary
- move the mote bank and fall rate readouts from the towers tab into the mote gems card so both values live with the mote gems UI
- remove the glowing badge overlay from the towers panel while keeping the tab icon counter
- adjust the tab icon badge styling so only the numerals glow against a transparent background

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_69026ba2b154832aa7b832b625e6ce31