### PR TITLE
Enable Mind Gate upgrades and Aleph glyph rewards

### DIFF
--- a/assets/data/gameplayConfig.json
+++ b/assets/data/gameplayConfig.json
@@ -7,6 +7,7 @@
       "alpha"
     ],
     "initialUnlockedTowers": [
+      "mind-gate",
       "alpha"
     ]
   },

--- a/assets/data/towers/index.js
+++ b/assets/data/towers/index.js
@@ -1,6 +1,7 @@
 /**
  * Tower definition registry composed of individually sourced tower modules.
  */
+import MIND_GATE_TOWER from './mind-gate.js';
 import ALPHA_TOWER from './alpha.js';
 import BETA_TOWER from './beta.js';
 import GAMMA_TOWER from './gamma.js';
@@ -33,6 +34,7 @@ import ALEPH_FOUR_TOWER from './aleph-four.js';
 import ALEPH_FIVE_TOWER from './aleph-five.js';
 
 export {
+  MIND_GATE_TOWER as mind_gateTower,
   ALPHA_TOWER as alphaTower,
   BETA_TOWER as betaTower,
   GAMMA_TOWER as gammaTower,
@@ -66,6 +68,8 @@ export {
 };
 
 export const towers = [
+  // Surface the Mind Gate first so upgrade systems can treat it as the foundation lattice.
+  MIND_GATE_TOWER,
   ALPHA_TOWER,
   BETA_TOWER,
   GAMMA_TOWER,

--- a/assets/data/towers/mind-gate.js
+++ b/assets/data/towers/mind-gate.js
@@ -1,0 +1,18 @@
+/**
+ * Mind Gate tower definition modeling the base lattice at the lane terminus.
+ */
+export const MIND_GATE_TOWER = Object.freeze({
+  id: 'mind-gate',
+  symbol: '⟟',
+  name: 'Mind Gate',
+  tierLabel: 'Origin',
+  baseCost: 0,
+  damage: 0,
+  rate: 0,
+  range: 0,
+  diameterMeters: 2.4,
+  description:
+    'Anchors the defense core—when the Mind Gate folds, inspiration and glyph conduits collapse.',
+});
+
+export default MIND_GATE_TOWER;

--- a/assets/main.js
+++ b/assets/main.js
@@ -113,6 +113,7 @@ import {
   setAudioManager as setTowersAudioManager,
   setPlayfield as setTowersPlayfield,
   setGlyphCurrency,
+  addGlyphCurrency,
   getGlyphCurrency,
   setTheroSymbol,
   setTowerLoadoutLimit,
@@ -1751,6 +1752,7 @@ import {
     charges: 0,
     simulatedDuneGain: 0,
     wallGlyphsLit: 0,
+    glyphsAwarded: 0, // Highest Aleph index already translated into glyph currency.
     idleMoteBank: 100,
     idleDrainRate: 1,
     pendingMoteDrops: [],
@@ -6109,6 +6111,17 @@ import {
 
     if (glyphMetrics) {
       const { glyphsLit, highestRaw, progressFraction } = glyphMetrics;
+      // Award glyph currency the moment a new Aleph threshold is illuminated.
+      const previousAwarded = Number.isFinite(powderState.glyphsAwarded)
+        ? Math.max(0, powderState.glyphsAwarded)
+        : 0;
+      if (glyphsLit > previousAwarded) {
+        const newlyEarned = glyphsLit - previousAwarded;
+        addGlyphCurrency(newlyEarned);
+        powderState.glyphsAwarded = glyphsLit;
+      } else if (!Number.isFinite(powderState.glyphsAwarded) || powderState.glyphsAwarded < glyphsLit) {
+        powderState.glyphsAwarded = Math.max(previousAwarded, glyphsLit);
+      }
       updatePowderWallGapFromGlyphs(glyphsLit);
       if (powderElements.leftWall) {
         powderElements.leftWall.classList.toggle('wall-awake', highestRaw > 0);

--- a/index.html
+++ b/index.html
@@ -295,7 +295,7 @@
             <p class="tower-tree-map-note">Only discovered towers appear in this constellation.</p>
           </div>
           <div class="panel-grid" id="tower-card-grid">
-            <article class="card card--mind-gate" aria-hidden="false">
+            <article class="card card--mind-gate" data-tower-id="mind-gate" aria-hidden="false">
               <header class="tower-header">
                 <span class="tower-tier">Origin</span>
                 <h3>
@@ -305,16 +305,16 @@
               </header>
               <div class="formula-block">
                 <p class="formula-line">
-                  \( \mathcal{G}_{\text{Mind}} = 10 \times X_{\text{life}} + \frac{Y_{\text{recovery}}}{1 / X_{\text{life}}} \)
+                  \( \mathcal{G}_{\text{Mind}} = 10 \times \Psi_{1} + \frac{\Psi_{2}}{1 / \Psi_{1}} \)
                 </p>
                 <ul class="formula-definition">
-                  <li>X → life (inspiration reservoir)</li>
-                  <li>Y → recovery (glyph-fed renewal)</li>
+                  <li>Ψ₁ → life (inspiration reservoir)</li>
+                  <li>Ψ₂ → recovery (glyph-fed renewal)</li>
                 </ul>
               </div>
               <ul class="upgrade-list">
-                <li>Fortify X to deepen the Mind Gate's stores of fading inspiration.</li>
-                <li>Amplify Y so recovery surges restore the gate between waves.</li>
+                <li>Fortify Ψ₁ to deepen the Mind Gate's stores of fading inspiration.</li>
+                <li>Amplify Ψ₂ so recovery surges restore the gate between waves.</li>
               </ul>
               <footer class="card-footer">
                 The original tower—anchoring the lane's finale. When the Mind Gate collapses, inspiration runs dry.


### PR DESCRIPTION
## Summary
- add a Mind Gate tower definition and equation blueprint so its Ψ₁ life and Ψ₂ recovery conduits can accept glyph upgrades
- refresh the Mind Gate card copy and tier labeling to match the glyph notation and expose the upgrade overlay
- award glyph currency exclusively when the gem motes tower lights a new Aleph threshold, tracking previous grants to avoid duplicates

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_69026e573d7c832abc877d953efb1e9a