### PR TITLE
Smooth achievement icon flight alignment

### DIFF
--- a/assets/achievementsTab.js
+++ b/assets/achievementsTab.js
@@ -373,6 +373,8 @@ function presentAchievementCinematic(id) {
   overlayEls.floatingIcon.style.width = `${originRect.width}px`;
   overlayEls.floatingIcon.style.height = `${originRect.height}px`;
   overlayEls.floatingIcon.style.transform = 'translate(0px, 0px) scale(1)';
+  // Ensure the traveling icon starts fully opaque before the forward flight fades out.
+  overlayEls.floatingIcon.style.opacity = '1';
 
   iconSource.classList.add('achievement-icon-hidden');
 
@@ -388,6 +390,8 @@ function presentAchievementCinematic(id) {
     const deltaY = targetRect.top - originRect.top;
     const scale = originRect.width ? targetRect.width / originRect.width : 1;
     overlayEls.floatingIcon.style.transform = `translate(${deltaX}px, ${deltaY}px) scale(${scale})`;
+    // Fade the icon towards transparent as it reaches the overlay center.
+    overlayEls.floatingIcon.style.opacity = '0';
   });
 }
 
@@ -419,9 +423,13 @@ function dismissAchievementCinematic() {
   overlayEls.floatingIcon.style.height = `${originRect.height}px`;
   const targetScale = originRect.width ? targetRect.width / originRect.width : 1;
   overlayEls.floatingIcon.style.transform = `translate(${targetRect.left - originRect.left}px, ${targetRect.top - originRect.top}px) scale(${targetScale})`;
+  // Start the return flight transparent so the tile fade-in masks alignment.
+  overlayEls.floatingIcon.style.opacity = '0';
 
   requestAnimationFrame(() => {
     overlayEls.floatingIcon.style.transform = 'translate(0px, 0px) scale(1)';
+    // Restore opacity as the icon settles back into the achievements grid.
+    overlayEls.floatingIcon.style.opacity = '1';
   });
 }
 

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -3318,7 +3318,12 @@ body.graphics-mode-low .control-button {
   font-family: "Space Mono", monospace;
   font-size: 1.5rem;
   z-index: 1300;
-  transition: transform 320ms cubic-bezier(0.23, 1, 0.32, 1);
+  /* Keep the traveling icon visible by default while enabling fade transitions. */
+  opacity: 1;
+  /* Blend movement and fade so the motion can cover minor alignment differences. */
+  transition: transform 320ms cubic-bezier(0.23, 1, 0.32, 1), opacity 320ms ease;
+  /* Anchor transforms to the icon's corner so scaling lands in the overlay center. */
+  transform-origin: top left;
   will-change: transform;
 }
 


### PR DESCRIPTION
## Summary
- anchor the traveling achievement icon so its scaled animation lands in the overlay center
- fade the floating icon during forward and return flights to hide any residual offsets

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_6902805768f8832ab07df11b6b0fffca