### PR TITLE
Add tower info overlay access from battlefield radial menu

### DIFF
--- a/assets/playfield.js
+++ b/assets/playfield.js
@@ -13,6 +13,7 @@ import {
   cancelTowerDrag,
   getTowerEquationBlueprint,
   getTowerLoadoutState,
+  openTowerUpgradeOverlay,
 } from './towersTab.js';
 import {
   moteGemState,
@@ -2052,6 +2053,13 @@ export class SimplePlayfield {
       icon: '$þ',
       label: 'Sell lattice',
     });
+    // Surface the tower dossier overlay entry point directly inside the radial menu.
+    options.push({
+      id: 'info',
+      type: 'info',
+      icon: 'ℹ',
+      label: 'Tower information',
+    });
     const priority = tower.targetPriority || 'first';
     options.push({
       id: 'priority-first',
@@ -2163,6 +2171,18 @@ export class SimplePlayfield {
     }
     if (option.type === 'action' && option.id === 'sell') {
       this.sellTower(tower);
+      return;
+    }
+    if (option.type === 'info') {
+      // Route the command to the tower overlay so players can review formulas mid-combat.
+      if (tower?.type) {
+        openTowerUpgradeOverlay(tower.type);
+      }
+      if (this.messageEl) {
+        const label = tower.definition?.name || `${tower.symbol || 'Tower'}`;
+        this.messageEl.textContent = `${label} dossier projected over the field.`;
+      }
+      this.closeTowerMenu();
       return;
     }
     if (option.type === 'priority' && option.value) {


### PR DESCRIPTION
## Summary
- add an info command to the battlefield tower radial menu
- open the tower dossier overlay from the new command so players can review stats in combat

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69028ce9c33c832a97e1104b87e1988a