### PR TITLE
Revamp alpha/beta/gamma equations and dynamic display

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -4091,12 +4091,6 @@ body.graphics-mode-low .control-button {
   border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
-.tower-upgrade-equation--gold {
-  background: linear-gradient(135deg, rgba(48, 32, 0, 0.9), rgba(88, 64, 12, 0.65));
-  border-color: rgba(255, 215, 0, 0.45);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
-}
-
 .tower-upgrade-equation-label {
   margin: 0 0 6px;
   font-size: 0.95rem;
@@ -4117,6 +4111,14 @@ body.graphics-mode-low .control-button {
   line-height: 1.35;
 }
 
+.tower-upgrade-formula--values {
+  margin-top: 6px;
+  font-size: 1rem;
+  color: rgba(177, 212, 255, 0.9);
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+
 .tower-upgrade-formula-part {
   display: inline-flex;
   align-items: center;
@@ -4129,6 +4131,22 @@ body.graphics-mode-low .control-button {
   color: rgba(255, 255, 255, 1);
   text-shadow: 0 0 18px rgba(255, 255, 255, 0.65);
   font-weight: 700;
+}
+
+.tower-upgrade-formula-part-subscript {
+  font-size: 0.68em;
+  line-height: 1;
+  margin-left: 0.12ch;
+  position: relative;
+  top: 0.45em;
+  letter-spacing: 0.08em;
+}
+
+.tower-upgrade-formula-part--dynamic,
+.tower-upgrade-variable-equation-line .dynamic-variable,
+.tower-upgrade-variable-equation-line--values .dynamic-variable {
+  color: rgb(143, 210, 255);
+  text-shadow: 0 0 12px rgba(143, 210, 255, 0.6);
 }
 
 .tower-upgrade-formula-part--variable.is-departed {
@@ -4205,6 +4223,11 @@ body.graphics-mode-low .control-button {
   font-size: 0.92rem;
   letter-spacing: 0.04em;
   text-align: left;
+}
+
+.tower-upgrade-variable-equation-line--values {
+  color: rgba(177, 212, 255, 0.9);
+  font-size: 0.9rem;
 }
 
 /* Ensure MathJax breakdown lines stay readable against the dark lattice card. */

--- a/index.html
+++ b/index.html
@@ -1487,13 +1487,7 @@
           <section class="tower-upgrade-equation" aria-labelledby="tower-upgrade-base-label">
             <h3 class="tower-upgrade-equation-label" id="tower-upgrade-base-label">Base Equation</h3>
             <p class="tower-upgrade-formula" id="tower-upgrade-base"></p>
-          </section>
-          <section
-            class="tower-upgrade-equation tower-upgrade-equation--gold"
-            aria-labelledby="tower-upgrade-golden-label"
-          >
-            <h3 class="tower-upgrade-equation-label" id="tower-upgrade-golden-label">Golden Equation</h3>
-            <p class="tower-upgrade-formula" id="tower-upgrade-golden"></p>
+            <p class="tower-upgrade-formula tower-upgrade-formula--values" id="tower-upgrade-base-values"></p>
           </section>
         </div>
         <div class="tower-upgrade-variables" id="tower-upgrade-variables" role="list"></div>


### PR DESCRIPTION
## Summary
- replace the alpha, beta, and gamma tower blueprints with the new Attack/Speed/Range/Pierce formulas and render numeric evaluation rows beneath each equation
- feed the tower overlay with live connection counts when opened from the playfield and draw lines between connected towers to visualize the network
- remove the golden equation section while updating the layout and styles so the formulas use subscript labels and a dedicated values line

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69029a8de0fc832a8364be1b2909b26e