### PR TITLE
Refine glyph-driven formulas for early towers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,10 @@ conventions for all AI collaborators working anywhere inside this repository.
    under `MAIN/`. Document licensing info in an accompanying `README` if required.
 5. **Mobile readiness:** Design UI layouts with responsive/touch-friendly controls.
    Verify that new input schemes work for both portrait and landscape if relevant (prioritize portrait).
+6. **Glyph variable language:** When the design specifies a variable such as `Glyph1`, interpret it as the
+   collectible glyph symbol used for upgrades (rendered as the glyph icon with an index like `𝔊₁`). The
+   lowercase form (e.g., `glyph1`) refers to the same glyph symbol with the index styled as a subscript.
+   Treat all glyph variables as upgradeable slots within the tower menus.
 
 ## Workflow Expectations
 - **Branching:** Work on feature branches; keep commits atomic with clear messages.

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -4133,13 +4133,12 @@ body.graphics-mode-low .control-button {
   font-weight: 700;
 }
 
-.tower-upgrade-formula-part-subscript {
-  font-size: 0.68em;
+.tower-upgrade-formula-part-tail {
+  font-size: 0.5em;
   line-height: 1;
-  margin-left: 0.12ch;
-  position: relative;
-  top: 0.45em;
+  margin-left: 0.14ch;
   letter-spacing: 0.08em;
+  transform-origin: left center;
 }
 
 .tower-upgrade-formula-part--dynamic,

--- a/index.html
+++ b/index.html
@@ -341,16 +341,17 @@
                 <h3>α alpha tower</h3>
               </header>
               <div class="formula-block">
-                <p class="formula-line">\( \alpha = Atk \)</p>
+                <p class="formula-line">\( \alpha = Attack \times Speed \)</p>
                 <ul class="formula-definition">
-                  <li>Atk → attack power channelled from Glyph<sub>1</sub></li>
-                  <li>Glyph<sub>1</sub> → upgradeable glyph charge powering α</li>
+                  <li>Attack → projectile force braided from \(\mathcal{G}_{1}\)</li>
+                  <li>Speed → oscillation cadence tuned by \(\mathcal{G}_{2}\)</li>
                 </ul>
-                <p class="formula-line result">\( Atk = 5 \times Glyph_{1} \)</p>
+                <p class="formula-line result">\( Attack = 5 \times \mathcal{G}_{1} \)</p>
+                <p class="formula-line result">\( Speed = 0.5 \times \mathcal{G}_{2} \)</p>
               </div>
               <ul class="upgrade-list">
-                <li>Invest collected glyphs into Glyph<sub>1</sub> to amplify Atk (+damage)</li>
-                <li>Hold steady tempo—Atk inherits all α glyph pacing.</li>
+                <li>Invest collected glyphs into \(\mathcal{G}_{1}\) to amplify Attack.</li>
+                <li>Stabilize \(\mathcal{G}_{2}\) to quicken Speed and sustain tempo.</li>
               </ul>
               <footer class="card-footer">Shoots a focused glyph-bullet at the nearest foe.</footer>
               <button class="tower-equip-button" type="button" data-tower-toggle="alpha">
@@ -363,17 +364,18 @@
                 <h3>β beta tower</h3>
               </header>
               <div class="formula-block">
-                <p class="formula-line">\( \beta = \alpha^{Exp} \)</p>
+                <p class="formula-line">\( \beta = Attack \times Speed \times Range \)</p>
                 <ul class="formula-definition">
-                  <li>α → flux inherited from alpha lattices</li>
-                  <li>Exp → exponent focus from β upgrades</li>
+                  <li>Attack → α's output amplified by \(\mathcal{G}_{1}\)</li>
+                  <li>Speed → cadence accelerated by neighbouring α lattices</li>
+                  <li>Range → coverage stretched through linked α channels</li>
                 </ul>
-                <p class="formula-line result">Refines α into a concentrated piercing beam.</p>
+                <p class="formula-line result">\( Attack = \alpha \times \mathcal{G}_{1} \)</p>
               </div>
               <ul class="upgrade-list">
-                <li>Sharpen Exp to raise the inherited α power</li>
-                <li>Stabilize the beam to hold α's pulse steady</li>
-                <li>Stretch the lattice to guide α farther downlane</li>
+                <li>Sharpen \(\mathcal{G}_{1}\) investments to raise inherited α power.</li>
+                <li>Stabilize linked α lattices to hold the beam's pulse steady.</li>
+                <li>Stretch the lattice web to guide α farther downlane.</li>
               </ul>
               <footer class="card-footer">
                 Emits a piercing beam amplified purely from α's output.
@@ -388,15 +390,19 @@
                 <h3>γ gamma tower</h3>
               </header>
               <div class="formula-block">
-                <p class="formula-line">\( \gamma = \sqrt{\beta} \)</p>
+                <p class="formula-line">\( \gamma = Attack \times Speed \times Range \times Pierce \)</p>
                 <ul class="formula-definition">
-                  <li>β → resonance drawn directly from the beta tower</li>
+                  <li>Attack → β's surge braided with \(\mathcal{G}_{1}\)</li>
+                  <li>Speed → cadence tuned by α lattice links</li>
+                  <li>Range → arc reach extended by β conductors</li>
+                  <li>Pierce → bolt depth anchored to \(\mathcal{G}_{2}\)</li>
                 </ul>
-                <p class="formula-line result">Softens β into homing bolts fueled by its root.</p>
+                <p class="formula-line result">\( Attack = \beta \times \mathcal{G}_{1} \)</p>
+                <p class="formula-line result">\( Pierce = \mathcal{G}_{2} \)</p>
               </div>
               <ul class="upgrade-list">
-                <li>Channel β's beam into branching lightning arcs</li>
-                <li>Stabilize β resonance to keep the bolts on target</li>
+                <li>Channel β's beam into branching lightning arcs.</li>
+                <li>Stabilize β resonance to keep the bolts on target.</li>
               </ul>
               <footer class="card-footer">Distills β into a tempo-shifting conductor with homing bolts.</footer>
               <button class="tower-equip-button" type="button" data-tower-toggle="gamma">


### PR DESCRIPTION
## Summary
- clarify how glyph variables should be interpreted inside the agent guide
- refresh alpha, beta, and gamma tower equations to use the glyph symbol and expose glyph-upgradable variables
- restyle equation fragments so word-based variables render with smaller trailing characters and document the new formulas in the UI

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6902a7a88cf0832a9f39115d3ca3f96a