### PR TITLE
Adopt aleph glyph notation and clarify Mind Gate behavior

### DIFF
--- a/assets/data/towers/mind-gate.js
+++ b/assets/data/towers/mind-gate.js
@@ -6,6 +6,7 @@ export const MIND_GATE_TOWER = Object.freeze({
   symbol: '⟟',
   name: 'Mind Gate',
   tierLabel: 'Origin',
+  placeable: false,
   baseCost: 0,
   damage: 0,
   rate: 0,

--- a/assets/towersTab.js
+++ b/assets/towersTab.js
@@ -426,8 +426,8 @@ function getDynamicConnectionCount(towerType) {
 const TOWER_EQUATION_BLUEPRINTS = {
   // Model the Mind Gate's two glyph conduits so it can accept upgrades directly.
   'mind-gate': {
-    mathSymbol: '\\mathcal{G}_{\\text{Mind}}',
-    baseEquation: '\\( \\mathcal{G}_{\\text{Mind}} = 10 \\times \\Psi_{1} + \\frac{\\Psi_{2}}{1 / \\Psi_{1}} \\)',
+    mathSymbol: '\\aleph_{\\text{Mind}}',
+    baseEquation: '\\( \\aleph_{\\text{Mind}} = 10 \\times \\Psi_{1} + \\frac{\\Psi_{2}}{1 / \\Psi_{1}} \\)',
     variables: [
       {
         key: 'life',
@@ -442,7 +442,7 @@ const TOWER_EQUATION_BLUEPRINTS = {
         getSubEquations({ level, value }) {
           const invested = Math.max(0, Number.isFinite(level) ? level : 0);
           const rank = Math.max(1, Number.isFinite(value) ? value : 1);
-          return [`\\( \\Psi_{1} = 1 + ${formatWholeNumber(invested)} = ${formatWholeNumber(rank)} \\)`];
+          return [`\\( ${formatWholeNumber(rank)} = 1 + ${formatWholeNumber(invested)} \\)`];
         },
       },
       {
@@ -458,7 +458,7 @@ const TOWER_EQUATION_BLUEPRINTS = {
         getSubEquations({ level, value }) {
           const invested = Math.max(0, Number.isFinite(level) ? level : 0);
           const rank = Math.max(1, Number.isFinite(value) ? value : 2);
-          return [`\\( \\Psi_{2} = 2 + ${formatWholeNumber(invested)} = ${formatWholeNumber(rank)} \\)`];
+          return [`\\( ${formatWholeNumber(rank)} = 2 + ${formatWholeNumber(invested)} \\)`];
         },
       },
     ],
@@ -491,8 +491,8 @@ const TOWER_EQUATION_BLUEPRINTS = {
           const attackValue = Number.isFinite(value) ? value : 0;
           return [
             {
-              expression: '\( A_{\text{ttack}} = 5 \times \mathcal{G}_{1} \)',
-              values: `\( = 5 \times ${formatWholeNumber(glyphRank)} = ${formatWholeNumber(attackValue)} \)`,
+              expression: '\( A_{\text{ttack}} = 5 \times \aleph_{1} \)',
+              values: `\( ${formatWholeNumber(attackValue)} = 5 \times ${formatWholeNumber(glyphRank)} \)`,
             },
           ];
         },
@@ -512,8 +512,8 @@ const TOWER_EQUATION_BLUEPRINTS = {
           const speedValue = Number.isFinite(value) ? value : glyphRank * 0.5;
           return [
             {
-              expression: '\( S_{\text{peed}} = 0.5 \times \mathcal{G}_{2} \)',
-              values: `\( = 0.5 \times ${formatDecimal(glyphRank, 2)} = ${formatDecimal(speedValue, 2)} \)`,
+              expression: '\( S_{\text{peed}} = 0.5 \times \aleph_{2} \)',
+              values: `\( ${formatDecimal(speedValue, 2)} = 0.5 \times ${formatDecimal(glyphRank, 2)} \)`,
             },
           ];
         },
@@ -527,7 +527,7 @@ const TOWER_EQUATION_BLUEPRINTS = {
     formatBaseEquationValues({ values, result, formatComponent }) {
       const attack = Number.isFinite(values.atk) ? values.atk : 0;
       const speed = Number.isFinite(values.speed) ? values.speed : 0;
-      return `= ${formatComponent(attack)} × ${formatComponent(speed)} = ${formatComponent(result)}`;
+      return `${formatComponent(result)} = ${formatComponent(attack)} × ${formatComponent(speed)}`;
     },
   },
   beta: {
@@ -556,8 +556,8 @@ const TOWER_EQUATION_BLUEPRINTS = {
           const attackValue = alphaValue * glyphRank;
           return [
             {
-              expression: '\( A_{\text{ttack}} = \alpha \times \mathcal{G}_{1} \)',
-              values: `\( = ${formatDecimal(alphaValue, 2)} \times ${formatWholeNumber(glyphRank)} = ${formatDecimal(attackValue, 2)} \)`,
+              expression: '\( A_{\text{ttack}} = \alpha \times \aleph_{1} \)',
+              values: `\( ${formatDecimal(attackValue, 2)} = ${formatDecimal(alphaValue, 2)} \times ${formatWholeNumber(glyphRank)} \)`,
             },
           ];
         },
@@ -580,8 +580,8 @@ const TOWER_EQUATION_BLUEPRINTS = {
           const speedValue = 0.5 + 1.5 * alphaConnections;
           return [
             {
-              expression: '\\( S_{\\text{peed}} = 0.5 + 1.5 \\left( {\\color{#8fd2ff}{\\#\\alpha}} \\right) \\)',
-              values: `\\( = 0.5 + 1.5 \\left( ${formatWholeNumber(alphaConnections)} \\right) = ${formatDecimal(speedValue, 2)} \\)`,
+              expression: '\\( S_{\\text{peed}} = 0.5 + 1.5 \\left( {\\color{#8fd2ff}{\\alpha_{\\beta}}} \\right) \\)',
+              values: `\\( ${formatDecimal(speedValue, 2)} = 0.5 + 1.5 \\left( ${formatWholeNumber(alphaConnections)} \\right) \\)`,
             },
           ];
         },
@@ -602,8 +602,8 @@ const TOWER_EQUATION_BLUEPRINTS = {
           const alphaConnections = getDynamicConnectionCount('alpha');
           return [
             {
-              expression: '\\( R_{\\text{ange}} = 1 \\left( {\\color{#8fd2ff}{\\#\\alpha}} \\right) \\)',
-              values: `\\( = 1 \\left( ${formatWholeNumber(alphaConnections)} \\right) = ${formatDecimal(alphaConnections, 2)} \\)`,
+              expression: '\\( R_{\\text{ange}} = 1 \\times \\left( {\\color{#8fd2ff}{\\alpha_{\\beta}}} \\right) \\)',
+              values: `\\( ${formatDecimal(alphaConnections, 2)} = 1 \\times \\left( ${formatWholeNumber(alphaConnections)} \\right) \\)`,
             },
           ];
         },
@@ -619,7 +619,7 @@ const TOWER_EQUATION_BLUEPRINTS = {
       const attack = Number.isFinite(values.attack) ? values.attack : 0;
       const speed = Number.isFinite(values.speed) ? values.speed : 0;
       const range = Number.isFinite(values.range) ? values.range : 0;
-      return `= ${formatComponent(attack)} × ${formatComponent(speed)} × ${formatComponent(range)} = ${formatComponent(result)}`;
+      return `${formatComponent(result)} = ${formatComponent(attack)} × ${formatComponent(speed)} × ${formatComponent(range)}`;
     },
   },
   gamma: {
@@ -648,8 +648,8 @@ const TOWER_EQUATION_BLUEPRINTS = {
           const attackValue = betaValue * glyphRank;
           return [
             {
-              expression: '\( A_{\text{ttack}} = \beta \times \mathcal{G}_{1} \)',
-              values: `\( = ${formatDecimal(betaValue, 2)} \times ${formatWholeNumber(glyphRank)} = ${formatDecimal(attackValue, 2)} \)`,
+              expression: '\( A_{\text{ttack}} = \beta \times \aleph_{1} \)',
+              values: `\( ${formatDecimal(attackValue, 2)} = ${formatDecimal(betaValue, 2)} \times ${formatWholeNumber(glyphRank)} \)`,
             },
           ];
         },
@@ -672,8 +672,8 @@ const TOWER_EQUATION_BLUEPRINTS = {
           const speedValue = 0.5 + 0.25 * alphaConnections;
           return [
             {
-              expression: '\\( S_{\\text{peed}} = 0.5 + 0.25 \\left( {\\color{#8fd2ff}{\\#\\alpha}} \\right) \\)',
-              values: `\\( = 0.5 + 0.25 \\left( ${formatWholeNumber(alphaConnections)} \\right) = ${formatDecimal(speedValue, 2)} \\)`,
+              expression: '\\( S_{\\text{peed}} = 0.5 + 0.25 \\left( {\\color{#8fd2ff}{\\alpha_{\\gamma}}} \\right) \\)',
+              values: `\\( ${formatDecimal(speedValue, 2)} = 0.5 + 0.25 \\left( ${formatWholeNumber(alphaConnections)} \\right) \\)`,
             },
           ];
         },
@@ -696,8 +696,8 @@ const TOWER_EQUATION_BLUEPRINTS = {
           const rangeValue = 1 + 2 * betaConnections;
           return [
             {
-              expression: '\\( R_{\\text{ange}} = 1 + 2 \\left( {\\color{#8fd2ff}{\\#\\beta}} \\right) \\)',
-              values: `\\( = 1 + 2 \\left( ${formatWholeNumber(betaConnections)} \\right) = ${formatDecimal(rangeValue, 2)} \\)`,
+              expression: '\\( R_{\\text{ange}} = 1 + 2 \\left( {\\color{#8fd2ff}{\\beta_{\\gamma}}} \\right) \\)',
+              values: `\\( ${formatDecimal(rangeValue, 2)} = 1 + 2 \\left( ${formatWholeNumber(betaConnections)} \\right) \\)`,
             },
           ];
         },
@@ -717,8 +717,8 @@ const TOWER_EQUATION_BLUEPRINTS = {
           const pierceValue = Number.isFinite(value) ? value : glyphRank;
           return [
             {
-              expression: '\( P_{\text{ierce}} = \mathcal{G}_{2} \)',
-              values: `\( = ${formatWholeNumber(glyphRank)} = ${formatWholeNumber(pierceValue)} \)`,
+              expression: '\( P_{\text{ierce}} = \aleph_{2} \)',
+              values: `\( ${formatWholeNumber(pierceValue)} = ${formatWholeNumber(glyphRank)} \)`,
             },
           ];
         },
@@ -736,7 +736,7 @@ const TOWER_EQUATION_BLUEPRINTS = {
       const speed = Number.isFinite(values.speed) ? values.speed : 0;
       const range = Number.isFinite(values.range) ? values.range : 0;
       const pierce = Number.isFinite(values.pierce) ? values.pierce : 0;
-      return `= ${formatComponent(attack)} × ${formatComponent(speed)} × ${formatComponent(range)} × ${formatComponent(pierce)} = ${formatComponent(result)}`;
+      return `${formatComponent(result)} = ${formatComponent(attack)} × ${formatComponent(speed)} × ${formatComponent(range)} × ${formatComponent(pierce)}`;
     },
   },
   delta: {
@@ -838,6 +838,14 @@ export function isTowerUnlocked(towerId) {
   return towerTabState.unlockState.unlocked.has(towerId);
 }
 
+export function isTowerPlaceable(towerId) {
+  const definition = getTowerDefinition(towerId);
+  if (!definition) {
+    return false;
+  }
+  return definition.placeable !== false;
+}
+
 export function unlockTower(towerId, { silent = false } = {}) {
   if (!towerId || !towerTabState.towerDefinitionMap.has(towerId)) {
     return false;
@@ -907,7 +915,8 @@ function resetTowerVariableAnimationState() {
   towerTabState.towerVariableAnimation.shouldPlayEntry = false;
 }
 
-const DYNAMIC_EQUATION_PATTERN = /(#α|#β)/g;
+const DYNAMIC_EQUATION_PATTERN = /([α-ω]_[α-ω])/gu;
+const DYNAMIC_VARIABLE_TOKEN = /^[α-ω]_[α-ω]$/u;
 
 function appendEquationText(target, text) {
   if (!target) {
@@ -918,7 +927,7 @@ function appendEquationText(target, text) {
     if (!segment) {
       return;
     }
-    if (segment === '#α' || segment === '#β') {
+    if (DYNAMIC_VARIABLE_TOKEN.test(segment)) {
       const dynamic = document.createElement('span');
       dynamic.classList.add('tower-upgrade-formula-part--dynamic', 'dynamic-variable');
       dynamic.textContent = segment;
@@ -1186,7 +1195,8 @@ export function pruneLockedTowersFromLoadout() {
   const selected = towerTabState.loadoutState.selected;
   let changed = false;
   for (let index = selected.length - 1; index >= 0; index -= 1) {
-    if (!isTowerUnlocked(selected[index])) {
+    const towerId = selected[index];
+    if (!isTowerUnlocked(towerId) || !isTowerPlaceable(towerId)) {
       selected.splice(index, 1);
       changed = true;
     }
@@ -1253,7 +1263,7 @@ function renderTowerLoadout() {
 
   selected.forEach((towerId) => {
     const definition = getTowerDefinition(towerId);
-    if (!definition) {
+    if (!definition || definition.placeable === false) {
       return;
     }
 
@@ -1744,7 +1754,20 @@ export function updateTowerSelectionButtons() {
     const selected = towerTabState.loadoutState.selected.includes(towerId);
     const label = definition ? definition.symbol : towerId;
     const unlocked = isTowerUnlocked(towerId);
-    button.dataset.locked = unlocked ? 'false' : 'true';
+    const placeable = isTowerPlaceable(towerId);
+    button.dataset.locked = unlocked && placeable ? 'false' : 'true';
+    if (!placeable) {
+      button.disabled = true;
+      button.setAttribute('aria-pressed', 'false');
+      if (definition) {
+        button.textContent = `${definition.symbol || 'Static'} anchored`;
+        button.title = `${definition.name || 'This lattice'} cannot be placed on the battlefield.`;
+      } else {
+        button.textContent = 'Unavailable';
+        button.title = 'This lattice cannot be placed on the battlefield.';
+      }
+      return;
+    }
     if (!unlocked) {
       button.disabled = true;
       button.setAttribute('aria-pressed', 'false');
@@ -1774,6 +1797,9 @@ export function updateTowerSelectionButtons() {
 
 export function toggleTowerSelection(towerId) {
   if (!towerTabState.towerDefinitionMap.has(towerId)) {
+    return;
+  }
+  if (!isTowerPlaceable(towerId)) {
     return;
   }
   if (towerTabState.playfield && towerTabState.playfield.isInteractiveLevelActive()) {
@@ -3063,8 +3089,9 @@ export function initializeTowerEquipmentInterface() {
 
 export function syncLoadoutToPlayfield() {
   pruneLockedTowersFromLoadout();
+  const placeableSelection = towerTabState.loadoutState.selected.filter((towerId) => isTowerPlaceable(towerId));
   if (towerTabState.playfield) {
-    towerTabState.playfield.setAvailableTowers(towerTabState.loadoutState.selected);
+    towerTabState.playfield.setAvailableTowers(placeableSelection);
   }
   renderTowerLoadout();
   updateTowerSelectionButtons();

--- a/docs/PROGRESSION.md
+++ b/docs/PROGRESSION.md
@@ -72,6 +72,9 @@ Future sets escalate enemy modifiers and map complexity but follow the same five
 ## Tower Evolution
 The tower roster now explicitly runs through the entire Greek alphabet from **α** to **ω**, with each lowercase glyph defining a unique tactical role and an evocative mathematical formula. Core rules for collecting, merging, and prestiging towers now follow these tenets:
 
+- **Connection notation:** Dynamic connection counts use the source tower's lowercase letter with a subscript denoting the lattice that consumes it (e.g., `α_γ` tallies α lattices linked to γ).
+- **Equation evaluation layout:** Numeric evaluations beneath formulas place the computed result on the left (e.g., `2.50 = 5.00 × 0.50`).
+
 - **Five-of-a-kind prestige:** Once the player can simultaneously afford and field **five matching lowercase towers**, they may perform a *tower prestige* to fuse them into the corresponding uppercase glyph. The prestige keeps the lowercase formula but adds one powerful, easy-to-track mutation described below.
 - **Uppercase uniqueness:** Only **one uppercase tower of each letter** may exist on the field at a time. While an uppercase tower is deployed, the player may not place additional lowercase towers of that letter.
 - **Population accounting:** For all mechanics that scale with tower counts (including formulas that reference `n`, adjacency checks, or synergies), a single uppercase tower counts as **five lowercase towers of its letter**.

--- a/index.html
+++ b/index.html
@@ -305,7 +305,7 @@
               </header>
               <div class="formula-block">
                 <p class="formula-line">
-                  \( \mathcal{G}_{\text{Mind}} = 10 \times \Psi_{1} + \frac{\Psi_{2}}{1 / \Psi_{1}} \)
+                  \( \aleph_{\text{Mind}} = 10 \times \Psi_{1} + \frac{\Psi_{2}}{1 / \Psi_{1}} \)
                 </p>
                 <ul class="formula-definition">
                   <li>Ψ₁ → life (inspiration reservoir)</li>
@@ -343,15 +343,15 @@
               <div class="formula-block">
                 <p class="formula-line">\( \alpha = Attack \times Speed \)</p>
                 <ul class="formula-definition">
-                  <li>Attack → projectile force braided from \(\mathcal{G}_{1}\)</li>
-                  <li>Speed → oscillation cadence tuned by \(\mathcal{G}_{2}\)</li>
+                  <li>Attack → projectile force braided from \(\aleph_{1}\)</li>
+                  <li>Speed → oscillation cadence tuned by \(\aleph_{2}\)</li>
                 </ul>
-                <p class="formula-line result">\( Attack = 5 \times \mathcal{G}_{1} \)</p>
-                <p class="formula-line result">\( Speed = 0.5 \times \mathcal{G}_{2} \)</p>
+                <p class="formula-line result">\( Attack = 5 \times \aleph_{1} \)</p>
+                <p class="formula-line result">\( Speed = 0.5 \times \aleph_{2} \)</p>
               </div>
               <ul class="upgrade-list">
-                <li>Invest collected glyphs into \(\mathcal{G}_{1}\) to amplify Attack.</li>
-                <li>Stabilize \(\mathcal{G}_{2}\) to quicken Speed and sustain tempo.</li>
+                <li>Invest collected glyphs into \(\aleph_{1}\) to amplify Attack.</li>
+                <li>Stabilize \(\aleph_{2}\) to quicken Speed and sustain tempo.</li>
               </ul>
               <footer class="card-footer">Shoots a focused glyph-bullet at the nearest foe.</footer>
               <button class="tower-equip-button" type="button" data-tower-toggle="alpha">
@@ -366,14 +366,14 @@
               <div class="formula-block">
                 <p class="formula-line">\( \beta = Attack \times Speed \times Range \)</p>
                 <ul class="formula-definition">
-                  <li>Attack → α's output amplified by \(\mathcal{G}_{1}\)</li>
+                  <li>Attack → α's output amplified by \(\aleph_{1}\)</li>
                   <li>Speed → cadence accelerated by neighbouring α lattices</li>
                   <li>Range → coverage stretched through linked α channels</li>
                 </ul>
-                <p class="formula-line result">\( Attack = \alpha \times \mathcal{G}_{1} \)</p>
+                <p class="formula-line result">\( Attack = \alpha \times \aleph_{1} \)</p>
               </div>
               <ul class="upgrade-list">
-                <li>Sharpen \(\mathcal{G}_{1}\) investments to raise inherited α power.</li>
+                <li>Sharpen \(\aleph_{1}\) investments to raise inherited α power.</li>
                 <li>Stabilize linked α lattices to hold the beam's pulse steady.</li>
                 <li>Stretch the lattice web to guide α farther downlane.</li>
               </ul>
@@ -392,13 +392,13 @@
               <div class="formula-block">
                 <p class="formula-line">\( \gamma = Attack \times Speed \times Range \times Pierce \)</p>
                 <ul class="formula-definition">
-                  <li>Attack → β's surge braided with \(\mathcal{G}_{1}\)</li>
+                  <li>Attack → β's surge braided with \(\aleph_{1}\)</li>
                   <li>Speed → cadence tuned by α lattice links</li>
                   <li>Range → arc reach extended by β conductors</li>
-                  <li>Pierce → bolt depth anchored to \(\mathcal{G}_{2}\)</li>
+                  <li>Pierce → bolt depth anchored to \(\aleph_{2}\)</li>
                 </ul>
-                <p class="formula-line result">\( Attack = \beta \times \mathcal{G}_{1} \)</p>
-                <p class="formula-line result">\( Pierce = \mathcal{G}_{2} \)</p>
+                <p class="formula-line result">\( Attack = \beta \times \aleph_{1} \)</p>
+                <p class="formula-line result">\( Pierce = \aleph_{2} \)</p>
               </div>
               <ul class="upgrade-list">
                 <li>Channel β's beam into branching lightning arcs.</li>

--- a/scripts/core/mathText.js
+++ b/scripts/core/mathText.js
@@ -194,6 +194,7 @@ export function convertMathExpressionToPlainText(expression) {
 const GREEK_SYMBOL_LOOKUP = new Map([
   ['\\alpha', 'α'],
   ['\\beta', 'β'],
+  ['\\aleph', 'ℵ'],
   ['\\gamma', 'γ'],
   ['\\delta', 'δ'],
   ['\\epsilon', 'ε'],


### PR DESCRIPTION
## Summary
- replace glyph upgrade equations to use aleph notation and left-aligned evaluation results
- convert dynamic connection variables to subscripted Greek forms and document the formatting rule
- mark the Mind Gate as non-placeable and filter it out of loadouts while updating UI copy

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6902b30a9030832aa6cb7bd2665191fb