### PR TITLE
Update Mind Gate tier and repair MathJax text formatting

### DIFF
--- a/index.html
+++ b/index.html
@@ -297,24 +297,24 @@
           <div class="panel-grid" id="tower-card-grid">
             <article class="card card--mind-gate" data-tower-id="mind-gate" aria-hidden="false">
               <header class="tower-header">
-                <span class="tower-tier">Origin</span>
+                <span class="tower-tier">Tier 0</span>
                 <h3>
-                  <span class="mind-gate-symbol" aria-hidden="true">⟟</span>
+                  <span class="mind-gate-symbol" aria-hidden="true">℘</span>
                   mind gate
                 </h3>
               </header>
               <div class="formula-block">
                 <p class="formula-line">
-                  \( \aleph_{\text{Mind}} = 10 \times \Psi_{1} + \frac{\Psi_{2}}{1 / \Psi_{1}} \)
+                  \( \wp = \text{Life} \times \text{Regeneration} \)
                 </p>
                 <ul class="formula-definition">
-                  <li>Ψ₁ → life (inspiration reservoir)</li>
-                  <li>Ψ₂ → recovery (glyph-fed renewal)</li>
+                  <li>Life → \( 100^{\aleph_{1} / \aleph_{2}} \)</li>
+                  <li>Regeneration → \( \frac{100 \times \aleph_{2}}{\aleph_{1}} \)</li>
                 </ul>
               </div>
               <ul class="upgrade-list">
-                <li>Fortify Ψ₁ to deepen the Mind Gate's stores of fading inspiration.</li>
-                <li>Amplify Ψ₂ so recovery surges restore the gate between waves.</li>
+                <li>Fortify \(\aleph_{1}\) to amplify Life's exponential reservoir.</li>
+                <li>Stabilize \(\aleph_{2}\) so Regeneration surges refill the gate between waves.</li>
               </ul>
               <footer class="card-footer">
                 The original tower—anchoring the lane's finale. When the Mind Gate collapses, inspiration runs dry.
@@ -341,13 +341,13 @@
                 <h3>α alpha tower</h3>
               </header>
               <div class="formula-block">
-                <p class="formula-line">\( \alpha = Attack \times Speed \)</p>
+                <p class="formula-line">\( \alpha = \text{Attack} \times \text{Speed} \)</p>
                 <ul class="formula-definition">
                   <li>Attack → projectile force braided from \(\aleph_{1}\)</li>
                   <li>Speed → oscillation cadence tuned by \(\aleph_{2}\)</li>
                 </ul>
-                <p class="formula-line result">\( Attack = 5 \times \aleph_{1} \)</p>
-                <p class="formula-line result">\( Speed = 0.5 \times \aleph_{2} \)</p>
+                <p class="formula-line result">\( \text{Attack} = 5 \times \aleph_{1} \)</p>
+                <p class="formula-line result">\( \text{Speed} = 0.5 \times \aleph_{2} \)</p>
               </div>
               <ul class="upgrade-list">
                 <li>Invest collected glyphs into \(\aleph_{1}\) to amplify Attack.</li>
@@ -364,13 +364,13 @@
                 <h3>β beta tower</h3>
               </header>
               <div class="formula-block">
-                <p class="formula-line">\( \beta = Attack \times Speed \times Range \)</p>
+                <p class="formula-line">\( \beta = \text{Attack} \times \text{Speed} \times \text{Range} \)</p>
                 <ul class="formula-definition">
                   <li>Attack → α's output amplified by \(\aleph_{1}\)</li>
                   <li>Speed → cadence accelerated by neighbouring α lattices</li>
                   <li>Range → coverage stretched through linked α channels</li>
                 </ul>
-                <p class="formula-line result">\( Attack = \alpha \times \aleph_{1} \)</p>
+                <p class="formula-line result">\( \text{Attack} = \alpha \times \aleph_{1} \)</p>
               </div>
               <ul class="upgrade-list">
                 <li>Sharpen \(\aleph_{1}\) investments to raise inherited α power.</li>
@@ -390,15 +390,15 @@
                 <h3>γ gamma tower</h3>
               </header>
               <div class="formula-block">
-                <p class="formula-line">\( \gamma = Attack \times Speed \times Range \times Pierce \)</p>
+                <p class="formula-line">\( \gamma = \text{Attack} \times \text{Speed} \times \text{Range} \times \text{Pierce} \)</p>
                 <ul class="formula-definition">
                   <li>Attack → β's surge braided with \(\aleph_{1}\)</li>
                   <li>Speed → cadence tuned by α lattice links</li>
                   <li>Range → arc reach extended by β conductors</li>
                   <li>Pierce → bolt depth anchored to \(\aleph_{2}\)</li>
                 </ul>
-                <p class="formula-line result">\( Attack = \beta \times \aleph_{1} \)</p>
-                <p class="formula-line result">\( Pierce = \aleph_{2} \)</p>
+                <p class="formula-line result">\( \text{Attack} = \beta \times \aleph_{1} \)</p>
+                <p class="formula-line result">\( \text{Pierce} = \aleph_{2} \)</p>
               </div>
               <ul class="upgrade-list">
                 <li>Channel β's beam into branching lightning arcs.</li>


### PR DESCRIPTION
## Summary
- set the Mind Gate card to Tier 0 with a new ℘ glyph and product formula matching its Life and Regeneration definitions
- describe Life and Regeneration in terms of \aleph variables and update the flavor text to match
- wrap tower stat labels in \text{} so MathJax no longer renders attack, speed, range, or pierce with broken lettering

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6902bb033700832a91d5160afd77e1e3