### PR TITLE
Remove motes tower resource card and normalize equation text

### DIFF
--- a/assets/towersTab.js
+++ b/assets/towersTab.js
@@ -491,7 +491,7 @@ const TOWER_EQUATION_BLUEPRINTS = {
           const attackValue = Number.isFinite(value) ? value : 0;
           return [
             {
-              expression: '\( A_{\text{ttack}} = 5 \times \aleph_{1} \)',
+              expression: '\( \text{Attack} = 5 \times \aleph_{1} \)',
               values: `\( ${formatWholeNumber(attackValue)} = 5 \times ${formatWholeNumber(glyphRank)} \)`,
             },
           ];
@@ -512,7 +512,7 @@ const TOWER_EQUATION_BLUEPRINTS = {
           const speedValue = Number.isFinite(value) ? value : glyphRank * 0.5;
           return [
             {
-              expression: '\( S_{\text{peed}} = 0.5 \times \aleph_{2} \)',
+              expression: '\( \text{Speed} = 0.5 \times \aleph_{2} \)',
               values: `\( ${formatDecimal(speedValue, 2)} = 0.5 \times ${formatDecimal(glyphRank, 2)} \)`,
             },
           ];
@@ -556,7 +556,7 @@ const TOWER_EQUATION_BLUEPRINTS = {
           const attackValue = alphaValue * glyphRank;
           return [
             {
-              expression: '\( A_{\text{ttack}} = \alpha \times \aleph_{1} \)',
+              expression: '\( \text{Attack} = \alpha \times \aleph_{1} \)',
               values: `\( ${formatDecimal(attackValue, 2)} = ${formatDecimal(alphaValue, 2)} \times ${formatWholeNumber(glyphRank)} \)`,
             },
           ];
@@ -580,7 +580,7 @@ const TOWER_EQUATION_BLUEPRINTS = {
           const speedValue = 0.5 + 1.5 * alphaConnections;
           return [
             {
-              expression: '\\( S_{\\text{peed}} = 0.5 + 1.5 \\left( {\\color{#8fd2ff}{\\alpha_{\\beta}}} \\right) \\)',
+              expression: '\\( \\text{Speed} = 0.5 + 1.5 \\left( {\\color{#8fd2ff}{\\alpha_{\\beta}}} \\right) \\)',
               values: `\\( ${formatDecimal(speedValue, 2)} = 0.5 + 1.5 \\left( ${formatWholeNumber(alphaConnections)} \\right) \\)`,
             },
           ];
@@ -602,7 +602,7 @@ const TOWER_EQUATION_BLUEPRINTS = {
           const alphaConnections = getDynamicConnectionCount('alpha');
           return [
             {
-              expression: '\\( R_{\\text{ange}} = 1 \\times \\left( {\\color{#8fd2ff}{\\alpha_{\\beta}}} \\right) \\)',
+              expression: '\\( \\text{Range} = 1 \\times \\left( {\\color{#8fd2ff}{\\alpha_{\\beta}}} \\right) \\)',
               values: `\\( ${formatDecimal(alphaConnections, 2)} = 1 \\times \\left( ${formatWholeNumber(alphaConnections)} \\right) \\)`,
             },
           ];
@@ -648,7 +648,7 @@ const TOWER_EQUATION_BLUEPRINTS = {
           const attackValue = betaValue * glyphRank;
           return [
             {
-              expression: '\( A_{\text{ttack}} = \beta \times \aleph_{1} \)',
+              expression: '\( \text{Attack} = \beta \times \aleph_{1} \)',
               values: `\( ${formatDecimal(attackValue, 2)} = ${formatDecimal(betaValue, 2)} \times ${formatWholeNumber(glyphRank)} \)`,
             },
           ];
@@ -672,7 +672,7 @@ const TOWER_EQUATION_BLUEPRINTS = {
           const speedValue = 0.5 + 0.25 * alphaConnections;
           return [
             {
-              expression: '\\( S_{\\text{peed}} = 0.5 + 0.25 \\left( {\\color{#8fd2ff}{\\alpha_{\\gamma}}} \\right) \\)',
+              expression: '\\( \\text{Speed} = 0.5 + 0.25 \\left( {\\color{#8fd2ff}{\\alpha_{\\gamma}}} \\right) \\)',
               values: `\\( ${formatDecimal(speedValue, 2)} = 0.5 + 0.25 \\left( ${formatWholeNumber(alphaConnections)} \\right) \\)`,
             },
           ];
@@ -696,7 +696,7 @@ const TOWER_EQUATION_BLUEPRINTS = {
           const rangeValue = 1 + 2 * betaConnections;
           return [
             {
-              expression: '\\( R_{\\text{ange}} = 1 + 2 \\left( {\\color{#8fd2ff}{\\beta_{\\gamma}}} \\right) \\)',
+              expression: '\\( \\text{Range} = 1 + 2 \\left( {\\color{#8fd2ff}{\\beta_{\\gamma}}} \\right) \\)',
               values: `\\( ${formatDecimal(rangeValue, 2)} = 1 + 2 \\left( ${formatWholeNumber(betaConnections)} \\right) \\)`,
             },
           ];
@@ -717,7 +717,7 @@ const TOWER_EQUATION_BLUEPRINTS = {
           const pierceValue = Number.isFinite(value) ? value : glyphRank;
           return [
             {
-              expression: '\( P_{\text{ierce}} = \aleph_{2} \)',
+              expression: '\( \text{Pierce} = \aleph_{2} \)',
               values: `\( ${formatWholeNumber(pierceValue)} = ${formatWholeNumber(glyphRank)} \)`,
             },
           ];

--- a/index.html
+++ b/index.html
@@ -320,21 +320,6 @@
                 The original tower—anchoring the lane's finale. When the Mind Gate collapses, inspiration runs dry.
               </footer>
             </article>
-            <article class="card card--motes">
-              <header class="tower-header">
-                <span class="tower-tier">Resource</span>
-                <h3>motes tower</h3>
-              </header>
-              <div class="formula-block">
-                <p class="formula-line">\( \mathcal{M} = B_{\text{idle}} + R_{\text{fall}} \)</p>
-                <ul class="formula-definition">
-                  <li>B<sub>idle</sub> → idle mote bank harvested between waves</li>
-                  <li>R<sub>fall</sub> → live fall rate siphoned from the motefall basin</li>
-                </ul>
-                <p class="formula-line result">Tracks idle motes fueling powder-forged upgrades.</p>
-              </div>
-              <footer class="card-footer">Channels stored motes directly into the tower lattice.</footer>
-            </article>
             <article class="card" data-tower-id="alpha" aria-hidden="false">
               <header class="tower-header">
                 <span class="tower-tier">Tier I</span>


### PR DESCRIPTION
## Summary
- remove the redundant Motes Tower card from the towers tab layout
- update tower sub-equation MathJax expressions so variable names render at a consistent size

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6902c044d74c832aa78e3971b895743f