### PR TITLE
Update Mind Gate visuals and Aleph glyph indicators

### DIFF
--- a/assets/data/towers/mind-gate.js
+++ b/assets/data/towers/mind-gate.js
@@ -3,8 +3,9 @@
  */
 export const MIND_GATE_TOWER = Object.freeze({
   id: 'mind-gate',
-  symbol: '⟟',
+  symbol: 'ℵ₀',
   name: 'Mind Gate',
+  tier: 0,
   tierLabel: 'Origin',
   placeable: false,
   baseCost: 0,
@@ -12,6 +13,7 @@ export const MIND_GATE_TOWER = Object.freeze({
   rate: 0,
   range: 0,
   diameterMeters: 2.4,
+  icon: 'assets/images/tower-aleph-null.svg',
   description:
     'Anchors the defense core—when the Mind Gate folds, inspiration and glyph conduits collapse.',
 });

--- a/assets/main.js
+++ b/assets/main.js
@@ -1688,7 +1688,7 @@ import {
     const totalGlyphs = Math.max(0, Math.floor(gameStats.enemiesDefeated || 0));
     const unusedGlyphs = Math.max(0, Math.floor(getGlyphCurrency()));
     if (resourceElements.glyphsTotal) {
-      resourceElements.glyphsTotal.textContent = formatWholeNumber(totalGlyphs);
+      resourceElements.glyphsTotal.textContent = `${formatWholeNumber(totalGlyphs)} ℵ`;
     }
     if (resourceElements.glyphsUnused) {
       resourceElements.glyphsUnused.textContent = formatWholeNumber(unusedGlyphs);

--- a/assets/playfield.js
+++ b/assets/playfield.js
@@ -58,6 +58,13 @@ const defaultDependencies = {
   isLowGraphicsMode: () => false,
 };
 
+// Preload the Mind Gate sprite so the path finale mirrors the Towers tab art.
+const MIND_GATE_SPRITE_URL = 'assets/images/tower-aleph-null.svg';
+const mindGateSprite = new Image();
+mindGateSprite.src = MIND_GATE_SPRITE_URL;
+mindGateSprite.decoding = 'async';
+mindGateSprite.loading = 'eager';
+
 let playfieldDependencies = { ...defaultDependencies };
 
 export function configurePlayfieldSystem(options = {}) {
@@ -5135,45 +5142,63 @@ export class SimplePlayfield {
     ctx.save();
     ctx.translate(position.x, position.y);
 
-    const glow = ctx.createRadialGradient(0, 0, radius * 0.2, 0, 0, radius);
+    const glow = ctx.createRadialGradient(0, 0, radius * 0.22, 0, 0, radius);
     glow.addColorStop(0, 'rgba(255, 248, 220, 0.9)');
-    glow.addColorStop(0.6, 'rgba(255, 196, 150, 0.35)');
-    glow.addColorStop(1, 'rgba(255, 158, 88, 0.15)');
+    glow.addColorStop(0.55, 'rgba(255, 196, 150, 0.35)');
+    glow.addColorStop(1, 'rgba(139, 247, 255, 0.18)');
     ctx.fillStyle = glow;
     ctx.beginPath();
     ctx.arc(0, 0, radius, 0, Math.PI * 2);
     ctx.fill();
 
-    this.applyCanvasShadow(ctx, 'rgba(255, 196, 150, 0.55)', radius * 0.9);
-    ctx.strokeStyle = 'rgba(255, 158, 88, 0.88)';
-    ctx.lineWidth = Math.max(2, radius * 0.16);
+    this.applyCanvasShadow(ctx, 'rgba(255, 228, 120, 0.55)', radius);
+    ctx.strokeStyle = 'rgba(255, 228, 120, 0.85)';
+    ctx.lineWidth = Math.max(2, radius * 0.12);
     ctx.beginPath();
-    ctx.arc(0, 0, radius * 0.82, 0, Math.PI * 2);
+    ctx.arc(0, 0, radius * 0.88, 0, Math.PI * 2);
     ctx.stroke();
 
-    this.applyCanvasShadow(ctx, 'rgba(139, 247, 255, 0.55)', radius * 0.7);
-    ctx.strokeStyle = 'rgba(139, 247, 255, 0.85)';
-    ctx.lineWidth = Math.max(1.4, radius * 0.12);
-    ctx.beginPath();
-    ctx.moveTo(0, radius * 0.64);
-    ctx.lineTo(0, -radius * 0.6);
-    ctx.stroke();
+    const spriteReady = mindGateSprite?.complete && mindGateSprite.naturalWidth > 0;
+    if (spriteReady) {
+      // Draw the Aleph-null sprite scaled to the battlefield finale.
+      const spriteSize = Math.max(radius * 2.1, 46);
+      ctx.save();
+      ctx.globalAlpha = 0.96;
+      ctx.drawImage(mindGateSprite, -spriteSize / 2, -spriteSize / 2, spriteSize, spriteSize);
+      ctx.restore();
 
-    ctx.beginPath();
-    ctx.arc(0, 0, radius * 0.28, 0, Math.PI * 2);
-    ctx.stroke();
+      this.applyCanvasShadow(ctx, 'rgba(139, 247, 255, 0.45)', radius * 0.9);
+      ctx.strokeStyle = 'rgba(139, 247, 255, 0.6)';
+      ctx.lineWidth = Math.max(1.2, radius * 0.1);
+      ctx.beginPath();
+      ctx.arc(0, 0, radius * 0.6, 0, Math.PI * 2);
+      ctx.stroke();
+    } else {
+      // Fall back to the legacy geometric rendering until the sprite finishes loading.
+      this.applyCanvasShadow(ctx, 'rgba(139, 247, 255, 0.55)', radius * 0.7);
+      ctx.strokeStyle = 'rgba(139, 247, 255, 0.85)';
+      ctx.lineWidth = Math.max(1.4, radius * 0.12);
+      ctx.beginPath();
+      ctx.moveTo(0, radius * 0.64);
+      ctx.lineTo(0, -radius * 0.6);
+      ctx.stroke();
 
-    ctx.strokeStyle = 'rgba(255, 228, 120, 0.92)';
-    this.applyCanvasShadow(ctx, 'rgba(255, 228, 120, 0.55)', radius * 0.8);
-    ctx.lineWidth = Math.max(1.6, radius * 0.14);
-    ctx.beginPath();
-    const gateWidth = radius * 0.58;
-    const gateBase = radius * 0.62;
-    ctx.moveTo(-gateWidth, gateBase);
-    ctx.lineTo(-gateWidth, -radius * 0.18);
-    ctx.quadraticCurveTo(0, -radius * 0.95, gateWidth, -radius * 0.18);
-    ctx.lineTo(gateWidth, gateBase);
-    ctx.stroke();
+      ctx.beginPath();
+      ctx.arc(0, 0, radius * 0.28, 0, Math.PI * 2);
+      ctx.stroke();
+
+      ctx.strokeStyle = 'rgba(255, 228, 120, 0.92)';
+      this.applyCanvasShadow(ctx, 'rgba(255, 228, 120, 0.55)', radius * 0.8);
+      ctx.lineWidth = Math.max(1.6, radius * 0.14);
+      ctx.beginPath();
+      const gateWidth = radius * 0.58;
+      const gateBase = radius * 0.62;
+      ctx.moveTo(-gateWidth, gateBase);
+      ctx.lineTo(-gateWidth, -radius * 0.18);
+      ctx.quadraticCurveTo(0, -radius * 0.95, gateWidth, -radius * 0.18);
+      ctx.lineTo(gateWidth, gateBase);
+      ctx.stroke();
+    }
 
     const gateIntegrity = Math.max(0, Math.floor(this.lives || 0));
     const maxIntegrity = Math.max(

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -2176,6 +2176,21 @@ body.graphics-mode-low .control-button {
   text-shadow: 0 0 14px rgba(255, 228, 120, 0.65);
 }
 
+/* Display the Mind Gate's sprite directly within the constellation node. */
+.tower-tree-node-symbol--icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.tower-tree-node-icon {
+  width: 32px;
+  height: 32px;
+  display: block;
+  object-fit: contain;
+  filter: drop-shadow(0 0 12px rgba(255, 228, 120, 0.55));
+}
+
 .tower-tree-node-name {
   font-size: 0.6rem;
   letter-spacing: 0.08em;
@@ -2280,17 +2295,23 @@ body.graphics-mode-low .control-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 1.65em;
-  height: 1.65em;
+  width: 2.1em;
+  height: 2.1em;
   margin-right: 0.4em;
   border-radius: 999px;
-  font-family: "Cormorant Garamond", serif;
-  font-size: 1.5rem;
-  line-height: 1;
   background: linear-gradient(140deg, rgba(255, 228, 120, 0.26), rgba(139, 247, 255, 0.18));
   color: rgba(255, 228, 120, 0.92);
   box-shadow: 0 0 18px rgba(255, 228, 120, 0.55), 0 0 32px rgba(139, 247, 255, 0.3);
   text-shadow: 0 0 20px rgba(255, 228, 120, 0.65);
+}
+
+/* Render the Mind Gate sprite with a contained glow inside the tower header. */
+.mind-gate-symbol img {
+  display: block;
+  width: 78%;
+  height: 78%;
+  object-fit: contain;
+  filter: drop-shadow(0 0 10px rgba(255, 228, 120, 0.55));
 }
 
 @media (prefers-reduced-motion: no-preference) {
@@ -4821,7 +4842,7 @@ body.graphics-mode-low .control-button {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 6px;
+  gap: 4px;
   padding: 10px 12px;
   border-radius: 12px;
   cursor: pointer;
@@ -4858,37 +4879,42 @@ body.graphics-mode-low .control-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  position: relative;
 }
 
-/* Compact glowing badge overlay to surface resource counts atop tab icons. */
+/* Glowing tab supplements now sit beneath the tab label for immediate readability. */
 .tab-icon-badge {
-  position: absolute;
-  bottom: -2px;
-  right: -6px;
-  min-width: 26px;
-  padding: 0 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 36px;
+  padding: 2px 8px;
+  margin-top: 2px;
   font-family: "Space Mono", monospace;
-  font-size: 0.58rem;
+  font-size: 0.62rem;
   border-radius: 999px;
-  border: none;
-  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: linear-gradient(160deg, rgba(16, 18, 26, 0.82), rgba(22, 12, 32, 0.78));
   color: var(--text);
   text-align: center;
   text-shadow: 0 0 6px rgba(255, 255, 255, 0.25);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.28);
   pointer-events: none;
 }
 
 /* Accent the glyph badge with the same amber glow used in the tower panel. */
 .tab-icon-badge--glyphs {
   color: var(--accent-3);
-  text-shadow: 0 0 6px rgba(255, 228, 120, 0.65);
+  border-color: rgba(255, 228, 120, 0.4);
+  text-shadow: 0 0 10px rgba(255, 228, 120, 0.65);
+  box-shadow: 0 0 18px rgba(255, 228, 120, 0.35), 0 12px 20px rgba(0, 0, 0, 0.28);
 }
 
 /* Highlight the mote badge with the teal glow from the mote panel indicator. */
 .tab-icon-badge--motes {
   color: var(--accent);
-  text-shadow: 0 0 8px rgba(139, 247, 255, 0.65);
+  border-color: rgba(139, 247, 255, 0.4);
+  text-shadow: 0 0 12px rgba(139, 247, 255, 0.65);
+  box-shadow: 0 0 20px rgba(139, 247, 255, 0.35), 0 12px 20px rgba(0, 0, 0, 0.28);
 }
 
 .tab-icon img {

--- a/assets/towerTreeMap.js
+++ b/assets/towerTreeMap.js
@@ -416,7 +416,19 @@ function createTreeNode(definition, position, indexInTier) {
 
   const symbolEl = document.createElement('span');
   symbolEl.className = 'tower-tree-node-symbol';
-  symbolEl.textContent = definition.symbol || definition.id;
+  if (definition && definition.id === 'mind-gate' && definition.icon) {
+    // Use the Mind Gate's card sprite so the constellation node mirrors the tower card art.
+    symbolEl.classList.add('tower-tree-node-symbol--icon');
+    const iconEl = document.createElement('img');
+    iconEl.className = 'tower-tree-node-icon';
+    iconEl.src = definition.icon;
+    iconEl.alt = definition.name || 'Mind Gate';
+    iconEl.loading = 'lazy';
+    iconEl.decoding = 'async';
+    symbolEl.append(iconEl);
+  } else {
+    symbolEl.textContent = definition.symbol || definition.id;
+  }
 
   const nameEl = document.createElement('span');
   nameEl.className = 'tower-tree-node-name';
@@ -1113,6 +1125,17 @@ function computeNodeLayout(towers) {
       }
     });
   });
+
+  const hasMindGate = towers.some((tower) => tower.id === 'mind-gate');
+  const hasAlpha = towers.some((tower) => tower.id === 'alpha');
+  if (hasMindGate && hasAlpha) {
+    // Explicitly anchor the Mind Gate to Alpha so the tree highlights the foundational link.
+    const key = ['mind-gate', 'alpha'].sort().join('::');
+    if (!edgeSet.has(key) && positions.has('mind-gate') && positions.has('alpha')) {
+      edgeSet.add(key);
+      edges.push(['mind-gate', 'alpha']);
+    }
+  }
 
   if (towerTreeState.nodeLayer) {
     // Resize the physics canvas so the viewport can pan across the entire layout.

--- a/assets/towersTab.js
+++ b/assets/towersTab.js
@@ -427,17 +427,17 @@ const TOWER_EQUATION_BLUEPRINTS = {
   // Model the Mind Gate's two glyph conduits so it can accept upgrades directly.
   'mind-gate': {
     mathSymbol: String.raw`\aleph_{\text{Mind}}`,
-    baseEquation: String.raw`\( \aleph_{\text{Mind}} = 10 \times \Psi_{1} + \frac{\Psi_{2}}{1 / \Psi_{1}} \)`,
+    baseEquation: String.raw`\( \aleph_{\text{Mind}} = 10 \times \aleph_{1} + \frac{\aleph_{2}}{1 / \aleph_{1}} \)`,
     variables: [
       {
         key: 'life',
-        symbol: 'Ψ₁',
-        name: 'Ψ₁ Life Reservoir',
-        description: 'Glyph lifeforce braided into the Mind Gate core.',
+        symbol: 'ℵ₁',
+        name: 'ℵ₁ Life Reservoir',
+        description: 'Aleph lifeforce braided into the Mind Gate core.',
         baseValue: 1,
         step: 1,
         upgradable: true,
-        format: (value) => `${formatWholeNumber(value)} Ψ₁`,
+        format: (value) => `${formatWholeNumber(value)} ℵ₁`,
         cost: (level) => Math.max(1, 1 + level),
         getSubEquations({ level, value }) {
           const invested = Math.max(0, Number.isFinite(level) ? level : 0);
@@ -447,13 +447,13 @@ const TOWER_EQUATION_BLUEPRINTS = {
       },
       {
         key: 'recovery',
-        symbol: 'Ψ₂',
-        name: 'Ψ₂ Recovery Surge',
-        description: 'Restorative glyph cadence that rethreads the gate between waves.',
+        symbol: 'ℵ₂',
+        name: 'ℵ₂ Recovery Surge',
+        description: 'Restorative Aleph cadence that rethreads the gate between waves.',
         baseValue: 2,
         step: 1,
         upgradable: true,
-        format: (value) => `${formatWholeNumber(value)} Ψ₂`,
+        format: (value) => `${formatWholeNumber(value)} ℵ₂`,
         cost: (level) => Math.max(1, 2 + level),
         getSubEquations({ level, value }) {
           const invested = Math.max(0, Number.isFinite(level) ? level : 0);
@@ -2485,7 +2485,7 @@ function renderTowerUpgradeVariables(towerId, blueprint, values = {}) {
 
       const glyphCount = document.createElement('span');
       glyphCount.className = 'tower-upgrade-variable-glyph-count';
-      glyphCount.textContent = `${level} Ψ`;
+      glyphCount.textContent = `${level} ℵ`;
       glyphControl.append(glyphCount);
 
       const increment = document.createElement('button');

--- a/index.html
+++ b/index.html
@@ -299,14 +299,14 @@
               <header class="tower-header">
                 <span class="tower-tier">Tier 0</span>
                 <h3>
-                  <span class="mind-gate-symbol" aria-hidden="true">℘</span>
-                  mind gate
+                  <span class="mind-gate-symbol" aria-hidden="true">
+                    <img src="assets/images/tower-aleph-null.svg" alt="" />
+                  </span>
+                  Mind Gate
                 </h3>
               </header>
               <div class="formula-block">
-                <p class="formula-line">
-                  \( \wp = \text{Life} \times \text{Regeneration} \)
-                </p>
+                <p class="formula-line">\( \aleph_{\text{Mind}} = \text{Life} \times \text{Regeneration} \)</p>
                 <ul class="formula-definition">
                   <li>Life → \( 100^{\aleph_{1} / \aleph_{2}} \)</li>
                   <li>Regeneration → \( \frac{100 \times \aleph_{2}}{\aleph_{1}} \)</li>
@@ -1332,12 +1332,10 @@
           aria-selected="false"
           aria-pressed="false"
         >
-          <span class="tab-icon">
-            Δ
-            <!-- Indicator for unused glyph currency within the towers tab icon. -->
-            <span class="tab-icon-badge tab-icon-badge--glyphs" id="tab-glyph-badge" hidden>0</span>
-          </span>
+          <span class="tab-icon">Δ</span>
           <span class="tab-label">Towers</span>
+          <!-- Indicator for unused glyph currency relocated beneath the tab title. -->
+          <span class="tab-icon-badge tab-icon-badge--glyphs" id="tab-glyph-badge" hidden>0</span>
         </button>
         <button
           class="tab-button"
@@ -1350,12 +1348,10 @@
           aria-selected="false"
           aria-pressed="false"
         >
-          <span class="tab-icon">
-            ⧖
-            <!-- Persistent mote bank indicator within the powder tab icon. -->
-            <span class="tab-icon-badge tab-icon-badge--motes" id="tab-mote-badge">0.00</span>
-          </span>
+          <span class="tab-icon">⧖</span>
           <span class="tab-label">Mote Gems</span>
+          <!-- Persistent mote bank indicator relocated beneath the tab title. -->
+          <span class="tab-icon-badge tab-icon-badge--motes" id="tab-mote-badge">0.00</span>
         </button>
         <button
           class="tab-button"


### PR DESCRIPTION
## Summary
- replace the Mind Gate upgrade glyph displays with Aleph notation and decorate the Total Glyphs counter
- relocate the unused glyph and mote badge readouts beneath their tab titles and show the Mind Gate card sprite in UI panels
- render the Mind Gate sprite at the path finale and link the Tier 0 Mind Gate node to Alpha on the tower tree

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_6902ca86191c832a8acca3e835e37468