### PR TITLE
Ensure equipment slots have full octagonal border

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1682,6 +1682,7 @@ body.graphics-mode-low .control-button {
 }
 
 .tower-equipment-button {
+  --equipment-slot-border: rgba(255, 228, 120, 0.45);
   position: relative;
   width: 96px;
   height: 96px;
@@ -1689,14 +1690,18 @@ body.graphics-mode-low .control-button {
   gap: 6px;
   justify-items: center;
   align-content: center;
-  border: 1px solid rgba(255, 228, 120, 0.45);
-  background: linear-gradient(140deg, rgba(8, 10, 16, 0.92), rgba(20, 26, 40, 0.92));
+  box-sizing: border-box;
+  border: 2px solid transparent;
+  background:
+    linear-gradient(140deg, rgba(8, 10, 16, 0.92), rgba(20, 26, 40, 0.92)) padding-box,
+    linear-gradient(var(--equipment-slot-border), var(--equipment-slot-border)) border-box;
+  background-clip: padding-box, border-box;
   color: var(--text);
   clip-path: polygon(30% 0, 70% 0, 100% 30%, 100% 70%, 70% 100%, 30% 100%, 0 70%, 0 30%);
   cursor: pointer;
   /* Surround the octagon with a gentle amber glow to emphasize its energized state. */
   box-shadow: 0 0 24px rgba(255, 228, 120, 0.28), 0 0 0 2px rgba(255, 228, 120, 0.22) inset;
-  transition: border-color var(--transition), box-shadow var(--transition), color var(--transition);
+  transition: box-shadow var(--transition), color var(--transition), background var(--transition);
 }
 
 .tower-equipment-button:focus-visible {
@@ -1705,14 +1710,14 @@ body.graphics-mode-low .control-button {
 }
 
 .tower-equipment-slot[data-filled='true'] .tower-equipment-button {
-  border-color: rgba(255, 228, 120, 0.72);
+  --equipment-slot-border: rgba(255, 228, 120, 0.72);
   color: rgba(255, 228, 120, 0.92);
   /* Intensify the glow for infused relics so active gear feels radiant. */
   box-shadow: 0 0 28px rgba(255, 228, 120, 0.38), 0 12px 26px rgba(255, 228, 120, 0.24);
 }
 
 .tower-equipment-slot[data-menu-open='true'] .tower-equipment-button {
-  border-color: rgba(139, 247, 255, 0.6);
+  --equipment-slot-border: rgba(139, 247, 255, 0.6);
   /* Blend the cyan selection halo with the baseline amber aura for better focus cues. */
   box-shadow: 0 0 30px rgba(255, 228, 120, 0.32), 0 12px 28px rgba(139, 247, 255, 0.28);
 }


### PR DESCRIPTION
## Summary
- render the equipment slot border with layered backgrounds so the outline follows the octagonal clip path
- expose the border color through a CSS variable so filled and open states still glow appropriately

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_6902e7cc150c832ab6619b5a0ccca906