### PR TITLE
Clarify tower script organization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ conventions for all AI collaborators working anywhere inside this repository.
 1. **Documentation:** Whenever introducing a new formula or mechanic, leave inline
    comments or docstrings describing the equation and its impact. Use Markdown tables in
    README-like docs when summarizing upgrade trees.
-2. **Scripts:**  Use descriptive, theme-aligned names (e.g., `SigmaTower`, `PhiEnemy`). TO FILL OUT
+2. **Scripts:**  Use descriptive, theme-aligned names (e.g., `SigmaTower`, `PhiEnemy`). Tower-specific logic should be delegated into dedicated `.js` modules (e.g., `scripts/towers/<TowerName>.js`) rather than expanding `playfield.js` beyond core orchestration responsibilities.
 3. **Code style:** Include a descriptive comment for each added piece of code.
 4. **Assets:** Place new art, fonts, or audio inside appropriately named subfolders
    under `MAIN/`. Document licensing info in an accompanying `README` if required.


### PR DESCRIPTION
## Summary
- update scripting guidelines to emphasize creating dedicated tower modules instead of enlarging playfield.js

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69030ffbddc8832aa6e8a3c658796738