### PR TITLE
Fix audio playback lifecycle issues

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -7098,11 +7098,19 @@ import {
     // Commit the latest autosave snapshot when the page transitions away.
     commitAutoSave();
     markLastActive();
+    if (audioManager && typeof audioManager.stopMusic === 'function') {
+      // Halt any lingering music so tracks do not continue after the session closes.
+      audioManager.stopMusic();
+    }
   });
   window.addEventListener('beforeunload', () => {
     // Ensure progress persists even if the browser closes abruptly.
     commitAutoSave();
     markLastActive();
+    if (audioManager && typeof audioManager.stopMusic === 'function') {
+      // Ensure the soundtrack fully stops before the tab exits.
+      audioManager.stopMusic();
+    }
   });
 
   document.addEventListener('keydown', (event) => {


### PR DESCRIPTION
## Summary
- ensure music fade cancellations fully stop the previous track to prevent overlapping songs
- remember music entry keys for suspended playback to resume the correct song
- stop background music when the page hides or unloads so it does not continue playing after exit

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6903701b2248832aa5c2f3f1d1a325b4