### PR TITLE
Fix MathJax retries and attach Eta Aleph upgrades to parent controls

### DIFF
--- a/assets/towersTab.js
+++ b/assets/towersTab.js
@@ -1045,6 +1045,7 @@ const TOWER_EQUATION_BLUEPRINTS = {
         baseValue: 1,
         step: 1,
         upgradable: true,
+        attachedToVariable: 'spdRing',
         format: (value) => formatWholeNumber(Math.max(1, value)),
         getSubEquations({ level, value }) {
           const rank = Math.max(0, Number.isFinite(level) ? level : 0);
@@ -1069,6 +1070,7 @@ const TOWER_EQUATION_BLUEPRINTS = {
         baseValue: 1,
         step: 1,
         upgradable: true,
+        attachedToVariable: 'spdRing',
         format: (value) => formatWholeNumber(Math.max(1, value)),
         getSubEquations({ level, value }) {
           const rank = Math.max(0, Number.isFinite(level) ? level : 0);
@@ -1093,6 +1095,7 @@ const TOWER_EQUATION_BLUEPRINTS = {
         baseValue: 1,
         step: 1,
         upgradable: true,
+        attachedToVariable: 'spdRing',
         format: (value) => formatWholeNumber(Math.max(1, value)),
         getSubEquations({ level, value }) {
           const rank = Math.max(0, Number.isFinite(level) ? level : 0);
@@ -1117,6 +1120,7 @@ const TOWER_EQUATION_BLUEPRINTS = {
         baseValue: 1,
         step: 1,
         upgradable: true,
+        attachedToVariable: 'spdRing',
         format: (value) => formatWholeNumber(Math.max(1, value)),
         getSubEquations({ level, value }) {
           const rank = Math.max(0, Number.isFinite(level) ? level : 0);
@@ -1181,6 +1185,7 @@ const TOWER_EQUATION_BLUEPRINTS = {
         step: 1,
         upgradable: true,
         maxLevel: 4,
+        attachedToVariable: 'rng',
         format: (value) => formatWholeNumber(Math.max(1, value)),
         getSubEquations({ level, value }) {
           const rank = Math.max(0, Number.isFinite(level) ? level : 0);

--- a/scripts/core/mathText.js
+++ b/scripts/core/mathText.js
@@ -27,6 +27,12 @@ export function renderMathElement(element) {
 
   const mathJax = window.MathJax;
   if (!mathJax) {
+    const attempt = (mathElementRenderAttempts.get(element) || 0) + 1;
+    if (attempt > MAX_MATH_RENDER_ATTEMPTS) {
+      return;
+    }
+    mathElementRenderAttempts.set(element, attempt);
+    setTimeout(() => renderMathElement(element), MATH_RENDER_RETRY_DELAY_MS);
     return;
   }
 


### PR DESCRIPTION
## Summary
- retry MathJax typesetting until the library is ready so tower formulas render correctly
- anchor Eta tower Aleph₂–₅ upgrades to the speed ring section and Aleph₆ to the range section

## Testing
- Not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_6903781c690c832aa48f9fc0bf2cd0c0