### PR TITLE
Apply palette gradients to projectile visuals

### DIFF
--- a/scripts/features/towers/betaTower.js
+++ b/scripts/features/towers/betaTower.js
@@ -6,12 +6,25 @@ import {
   updateTowerBursts,
   drawTowerBursts,
 } from './alphaTower.js';
+import { samplePaletteGradient } from '../../../assets/colorSchemeUtils.js';
 
 // Β tower tones lean into amber math light so shared particles still read uniquely.
 const BETA_PARTICLE_COLORS = [
   { r: 255, g: 214, b: 112 },
   { r: 118, g: 189, b: 255 },
 ];
+
+// Β offsets bias toward the warmer half of the gradient to keep cascades distinct from α.
+const BETA_COLOR_OFFSETS = [0.32, 0.88];
+
+// Sample the global gradient for β motes so palette swaps recolor mirrored bursts instantly.
+function resolveBetaParticleColors() {
+  const colors = BETA_COLOR_OFFSETS.map((offset) => samplePaletteGradient(offset)).filter((color) => color);
+  if (colors.length >= 2) {
+    return colors;
+  }
+  return BETA_PARTICLE_COLORS.map((entry) => ({ ...entry }));
+}
 
 // Configuration mirrors historical β behavior so projectile pacing remains unchanged.
 const BETA_PARTICLE_CONFIG = {
@@ -20,6 +33,7 @@ const BETA_PARTICLE_CONFIG = {
   burstListKey: 'betaBursts',
   idPrefix: 'beta',
   colors: BETA_PARTICLE_COLORS,
+  colorResolver: resolveBetaParticleColors,
   behavior: 'swirlBounce',
   particleCountRange: { min: 5, max: 10 },
   dashDelayRange: 0.06,

--- a/scripts/features/towers/gammaTower.js
+++ b/scripts/features/towers/gammaTower.js
@@ -6,12 +6,25 @@ import {
   updateTowerBursts,
   drawTowerBursts,
 } from './alphaTower.js';
+import { samplePaletteGradient } from '../../../assets/colorSchemeUtils.js';
 
 // Γ tower particles glow with verdant energy to telegraph piercing precision.
 const GAMMA_PARTICLE_COLORS = [
   { r: 176, g: 255, b: 193 },
   { r: 120, g: 219, b: 255 },
 ];
+
+// Γ offsets favor cooler values so piercing lasers inherit the outer gradient tail.
+const GAMMA_COLOR_OFFSETS = [0.08, 0.66];
+
+// Resolve gradient colors for γ beams to keep piercing shots aligned with the active palette.
+function resolveGammaParticleColors() {
+  const colors = GAMMA_COLOR_OFFSETS.map((offset) => samplePaletteGradient(offset)).filter((color) => color);
+  if (colors.length >= 2) {
+    return colors;
+  }
+  return GAMMA_PARTICLE_COLORS.map((entry) => ({ ...entry }));
+}
 
 // Configuration retains legacy γ laser parameters so gameplay cadence is preserved.
 const GAMMA_PARTICLE_CONFIG = {
@@ -20,6 +33,7 @@ const GAMMA_PARTICLE_CONFIG = {
   burstListKey: 'gammaBursts',
   idPrefix: 'gamma',
   colors: GAMMA_PARTICLE_COLORS,
+  colorResolver: resolveGammaParticleColors,
   behavior: 'pierceLaser',
   particleCountRange: { min: 5, max: 10 },
   dashDelayRange: 0.02,


### PR DESCRIPTION
## Summary
- add gradient definitions to each palette and expose helpers for sampling projectile colors
- recolor Alpha/Beta/Gamma bursts plus Delta soldiers, Zeta pendulums, and Eta rings/lasers from the active gradient
- update playfield projectile rendering so generic bullets and Eta lasers use palette-driven gradients

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_6903a468d230832aa3a90728a20e88c1