### PR TITLE
Adjust endless wave scaling and refresh mind gate sprite

### DIFF
--- a/assets/images/tower-mind-gate.svg
+++ b/assets/images/tower-mind-gate.svg
@@ -1,30 +1,31 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <defs>
     <radialGradient id="mindGateAura">
-      <stop offset="0%" stop-color="#fbffb0" stop-opacity="1" />
-      <stop offset="30%" stop-color="#ffb82b" stop-opacity=".8" />
-      <stop offset="60%" stop-color="#ffc145" stop-opacity=".4" />
-      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+      <stop offset="0%" stop-color="#040426" stop-opacity="1" />
+      <stop offset="40%" stop-color="#06063b" stop-opacity="0.75" />
+      <stop offset="100%" stop-color="#00000000" stop-opacity="0" />
     </radialGradient>
+
+    <!-- Glow filter -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
   </defs>
 
-  <circle cx="40" cy="40" r="35" fill="url(#mindGateAura)" opacity="1" />
+  <circle cx="32" cy="32" r="30" fill="url(#mindGateAura)" opacity="1" />
   
   <text
-    x="42"
-    y="49"
+    x="32"
+    y="36"
     font-family="'Cormorant Garamond', 'Times New Roman', serif"
     font-size="26"
     text-anchor="middle"
-    fill="#fffed6"
-    stroke="#06063b"
-    stroke-width="0.7"
+    fill="#fbffb0"
     filter="url(#glow)"
-    >𝔊<tspan
-    font-size="11"
-    stroke-width="0.3"
-    dx="-2"
-    dy="0"
-  >℘</tspan>
-  </text>
+  >℘</text>
 </svg>

--- a/assets/playfield.js
+++ b/assets/playfield.js
@@ -3407,8 +3407,17 @@ export class SimplePlayfield {
     }
   }
 
-  getCycleMultiplier() {
-    return this.isEndlessMode ? 10 ** this.endlessCycle : 1;
+  getCycleScaling() {
+    // Document the endless scaling math so balance tweaks are easy to audit later.
+    if (!this.isEndlessMode) {
+      return { hp: 1, speed: 1, reward: 1 };
+    }
+    const cycle = Math.max(0, this.endlessCycle);
+    const hpMultiplier = 10 ** cycle;
+    // Each endless cycle adds a flat 10% speed bonus so pacing rises linearly instead of exponentially.
+    const speedMultiplier = 1 + 0.1 * cycle;
+    // Match endless mote rewards to HP growth so income keeps pace with the threat increase.
+    return { hp: hpMultiplier, speed: speedMultiplier, reward: hpMultiplier };
   }
 
   computeWaveNumber(index = this.waveIndex) {
@@ -3433,11 +3442,11 @@ export class SimplePlayfield {
       return null;
     }
     const { initialWave = false } = options;
-    const multiplier = this.getCycleMultiplier();
-    const scaledHp = Number.isFinite(config.hp) ? config.hp * multiplier : config.hp;
-    const scaledSpeed = Number.isFinite(config.speed) ? config.speed * multiplier : config.speed;
+    const scaling = this.getCycleScaling();
+    const scaledHp = Number.isFinite(config.hp) ? config.hp * scaling.hp : config.hp;
+    const scaledSpeed = Number.isFinite(config.speed) ? config.speed * scaling.speed : config.speed;
     const scaledReward = Number.isFinite(config.reward)
-      ? config.reward * multiplier
+      ? config.reward * scaling.reward
       : config.reward;
     return {
       config: {
@@ -3448,7 +3457,7 @@ export class SimplePlayfield {
       },
       spawned: 0,
       nextSpawn: initialWave ? this.initialSpawnDelay : 0,
-      multiplier,
+      multiplier: scaling.reward,
     };
   }
 


### PR DESCRIPTION
## Summary
- refresh the mind gate tower SVG with the new ℘ glyph art and aura styling
- update endless cycle scaling to multiply enemy health by 10 per loop and add 10% speed per cycle while keeping rewards aligned

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_6903f2d6bd80832ab3301ac5a38f43c6