### PR TITLE
Ensure zeta metrics respect manual connections

### DIFF
--- a/scripts/features/towers/zetaTower.js
+++ b/scripts/features/towers/zetaTower.js
@@ -44,6 +44,10 @@ export function evaluateZetaMetrics(playfield, tower) {
       x: entry.x,
       y: entry.y,
       range: Number.isFinite(entry.range) ? entry.range : 0,
+      // Preserve manual link targets so dynamic math only counts explicit resource chains.
+      connections: entry.linkTargetId ? [entry.linkTargetId] : [],
+      // Surface upstream suppliers to keep linked-source counts accurate for overlays.
+      sources: entry.linkSources instanceof Set ? Array.from(entry.linkSources) : [],
     });
   });
 
@@ -54,6 +58,10 @@ export function evaluateZetaMetrics(playfield, tower) {
       x: tower.x,
       y: tower.y,
       range: Number.isFinite(tower.range) ? tower.range : 0,
+      // Mirror the tower's outgoing link so downstream counts remain consistent when evaluating ζ.
+      connections: tower.linkTargetId ? [tower.linkTargetId] : [],
+      // Include inbound suppliers when ζ recalculates its battlefield context snapshot.
+      sources: tower.linkSources instanceof Set ? Array.from(tower.linkSources) : [],
     });
   }
 


### PR DESCRIPTION
## Summary
- include manual connection metadata when ζ evaluates the battlefield dynamic context
- ensure tower upgrade overlays count only explicitly linked suppliers

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_6903fceea814832ab5fc91f9e5dd529c