### PR TITLE
Ensure Motefall basin state persists between sessions

### DIFF
--- a/assets/autoSave.js
+++ b/assets/autoSave.js
@@ -37,6 +37,7 @@ const dependencies = {
 
 let statKeys = [];
 let powderSaveHandle = null;
+let powderBasinSaveHandle = null;
 let autoSaveHandle = null;
 
 /**
@@ -264,6 +265,10 @@ function persistTowerUpgrades() {
 
 function performAutoSave() {
   savePowderCurrency();
+  if (powderBasinSaveHandle) {
+    clearTimeout(powderBasinSaveHandle);
+    powderBasinSaveHandle = null;
+  }
   persistPowderBasin();
   persistGameStats();
   persistPreferences();
@@ -312,4 +317,18 @@ function persistPowderBasin() {
     return;
   }
   writeStorageJson(POWDER_BASIN_STORAGE_KEY, snapshot);
+}
+
+/**
+ * Debounces basin writes so rapid simulation updates still persist without
+ * overwhelming localStorage with large payloads.
+ */
+export function schedulePowderBasinSave() {
+  if (powderBasinSaveHandle) {
+    return;
+  }
+  powderBasinSaveHandle = setTimeout(() => {
+    powderBasinSaveHandle = null;
+    persistPowderBasin();
+  }, 1000);
 }


### PR DESCRIPTION
## Summary
- add a debounced powder basin persistence helper to the autosave utilities
- trigger basin saves whenever camera, wall metrics, dune height, or mote queues change so reloads restore the same layout
- persist idle-bank adjustments, developer tweaks, and hydrated snapshots to surface offline rewards after closing the browser

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_690441f83a60832aa8e4544c6c567adb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a debounced basin autosave and triggers saves on key powder interactions (camera, walls, glyphs, height, drops, idle bank/rate, hydration) to persist state across sessions.
> 
> - **Autosave Utilities (`assets/autoSave.js`)**:
>   - Introduces `powderBasinSaveHandle` and `schedulePowderBasinSave()` (1s debounce) to persist `POWDER_BASIN_STORAGE_KEY` without flooding writes.
>   - `performAutoSave()` now clears pending basin debounce before forcing a save.
> - **Powder/Basin Integration (`assets/main.js`)**:
>   - Wires `schedulePowderBasinSave()` across basin-affecting events:
>     - Developer controls: idle mote bank/rate changes.
>     - Snapshot lifecycle: after applying stored basin snapshot, capturing simulation state, and hydrating simulation state.
>     - Simulation signals: view transform changes, wall metrics changes, dune/height updates.
>     - Gameplay actions: wall gap updates from glyphs, queuing mote drops (live/pending), flushing pending drops, adding idle mote bank.
>   - Imports `schedulePowderBasinSave` and ensures basin snapshot replaces stale copies after reconciliation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ed64a33da5b756740287d331513c1cb2886a3ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->