### PR TITLE
Fix Mind Gate symbol rendering and palette sync

### DIFF
--- a/assets/images/tower-mind-gate.svg
+++ b/assets/images/tower-mind-gate.svg
@@ -6,6 +6,16 @@
       <stop offset="60%" stop-color="#ffc145" stop-opacity=".4" />
       <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
     </radialGradient>
+
+    <!-- Soft glow filter keeps the rune visible on mobile Safari implementations. -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2.2" result="blur" />
+      <feMerge>
+        <feMergeNode in="blur" />
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
   </defs>
 
   <circle cx="40" cy="40" r="35" fill="url(#mindGateAura)" opacity="1" />

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -2349,10 +2349,18 @@ body.graphics-mode-low .control-button {
   font-family: 'Cormorant Garamond', serif;
   font-size: 1.5rem;
   line-height: 1;
-  background: linear-gradient(140deg, rgba(255, 228, 120, 0.26), rgba(139, 247, 255, 0.18));
-  color: rgba(255, 228, 120, 0.92);
-  box-shadow: 0 0 18px rgba(255, 228, 120, 0.55), 0 0 32px rgba(139, 247, 255, 0.3);
-  text-shadow: 0 0 20px rgba(255, 228, 120, 0.65);
+  /* Tie the badge fill to the live mote gradient with a CSS variable fallback. */
+  background: var(
+    --mind-gate-gradient,
+    linear-gradient(140deg, rgba(255, 228, 120, 0.26), rgba(139, 247, 255, 0.18))
+  );
+  /* Mirror the exponent's highlight tint while retaining a warm default. */
+  color: var(--mind-gate-highlight, rgba(255, 228, 120, 0.92));
+  box-shadow:
+    0 0 18px var(--mind-gate-glow-primary, rgba(255, 228, 120, 0.55)),
+    0 0 32px var(--mind-gate-glow-secondary, rgba(139, 247, 255, 0.3));
+  /* Carry the glow color into the text shadow so the rune pulses consistently. */
+  text-shadow: 0 0 20px var(--mind-gate-text-glow, rgba(255, 228, 120, 0.65));
 }
 
 /* Render the Mind Gate sprite with a contained glow inside the tower header. */
@@ -2361,7 +2369,8 @@ body.graphics-mode-low .control-button {
   width: 78%;
   height: 78%;
   object-fit: contain;
-  filter: drop-shadow(0 0 10px rgba(255, 228, 120, 0.55));
+  /* Drive the sprite glow from the same highlight used by the exponent gradient. */
+  filter: drop-shadow(0 0 10px var(--mind-gate-icon-glow, rgba(255, 228, 120, 0.55)));
 }
 
 @media (prefers-reduced-motion: no-preference) {


### PR DESCRIPTION
## Summary
- add a glow filter to the Mind Gate SVG so the rune renders on mobile Safari
- drive the Towers tab Mind Gate badge styling from the active mote palette via CSS variables
- refresh the new palette variables whenever the mote palette changes or loads from storage

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6904d76d6d90832a8f2f989c9618a243

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an SVG glow to ensure the Mind Gate renders on mobile Safari and drives the Towers tab emblem from the live mote palette, updating on init, loads, mode switches, and palette changes.
> 
> - **Visuals**:
>   - **SVG**: Add `glow` filter in `assets/images/tower-mind-gate.svg` and apply to rune to ensure visibility on mobile Safari.
> - **Frontend**:
>   - **Palette → DOM bridge**: Introduce `applyMindGatePaletteToDom(palette)` in `assets/main.js` to compute CSS vars (`--mind-gate-*`) from mote palette.
>   - Invoke on app init, palette loads/restores, simulation snapshot/export, mode switches (`sand`/`fluid`), and global palette changes to keep UI in sync.
> - **Styles**:
>   - Update `.mind-gate-symbol` and image glow in `assets/styles.css` to use new CSS vars for gradient, highlight, and shadows with sensible fallbacks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1bf68ad5a3e0dfadf525661de685eb9977d1bca9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->