### PR TITLE
Add Aleph₁-driven delta cohort formulas

### DIFF
--- a/assets/towersTab.js
+++ b/assets/towersTab.js
@@ -817,18 +817,129 @@ const TOWER_EQUATION_BLUEPRINTS = {
         format: (value) => formatDecimal(value, 2),
       },
       {
-        key: 'tot',
-        symbol: 'Tot',
-        name: 'Total Cohort',
-        description: 'Maximum spectral soldiers δ can field simultaneously.',
-        upgradable: false,
-        getBase: ({ definition }) => {
-          if (Number.isFinite(definition?.tot)) {
-            return Math.max(1, Math.round(definition.tot));
-          }
-          return 5;
+        key: 'aleph1',
+        symbol: 'ℵ₁',
+        equationSymbol: 'ℵ₁',
+        name: 'Aleph₁ Phalanx',
+        description:
+          'Allocates ℵ₁ glyphs to Δ soldiers, amplifying vitality, muster, and training cadence.',
+        baseValue: 1,
+        step: 1,
+        upgradable: true,
+        maxLevel: 4,
+        cost: (level) => {
+          const normalizedLevel = Number.isFinite(level) ? Math.max(0, Math.floor(level)) : 0;
+          return 5 * 2 ** normalizedLevel;
         },
-        format: (value) => `${formatWholeNumber(value)} soldiers`,
+        format: (value) => {
+          const rank = Number.isFinite(value) ? Math.max(1, Math.round(value)) : 1;
+          return `${formatWholeNumber(rank)} ℵ₁`;
+        },
+        getSubEquations({ value }) {
+          const alephRank = Number.isFinite(value) ? Math.max(1, Math.round(value)) : 1;
+          const gammaDefinition = getTowerDefinition('gamma');
+          const gammaEquation = calculateTowerEquationResult('gamma');
+          const fallbackGamma = Number.isFinite(gammaDefinition?.damage)
+            ? Math.max(1, gammaDefinition.damage)
+            : 1;
+          const gammaValue = Number.isFinite(gammaEquation) && gammaEquation > 0
+            ? gammaEquation
+            : fallbackGamma;
+          const rawHealth = gammaValue ** alephRank;
+          const health = Number.isFinite(rawHealth) ? Math.max(1, rawHealth) : Number.MAX_SAFE_INTEGER;
+          const rawTrainingSeconds = 5 ** alephRank;
+          const trainingSeconds = Number.isFinite(rawTrainingSeconds)
+            ? Math.max(1, rawTrainingSeconds)
+            : Number.MAX_SAFE_INTEGER;
+          const totalSoldiers = 3 + alephRank;
+          const formattedHealth = Number.isFinite(health)
+            ? formatGameNumber(health)
+            : formatGameNumber(Number.MAX_SAFE_INTEGER);
+          const formattedGamma = Number.isFinite(gammaValue)
+            ? formatGameNumber(gammaValue)
+            : formatGameNumber(fallbackGamma);
+          const formattedSpeed = Number.isFinite(trainingSeconds)
+            ? formatGameNumber(trainingSeconds)
+            : formatGameNumber(Number.MAX_SAFE_INTEGER);
+          const formattedAleph = formatWholeNumber(alephRank);
+          const formattedTotal = formatWholeNumber(totalSoldiers);
+          return [
+            { expression: String.raw`\( \text{Hlth} = \gamma^{\aleph_{1}} \)` },
+            {
+              values: String.raw`\( ${formattedHealth} = ${formattedGamma}^{${formattedAleph}} \)`,
+              variant: 'values',
+            },
+            { expression: String.raw`\( \text{Spd} = 5^{\aleph_{1}} \)` },
+            {
+              values: String.raw`\( ${formattedSpeed}\,\text{s} = 5^{${formattedAleph}} \)`,
+              variant: 'values',
+            },
+            { expression: String.raw`\( \text{Tot} = 3 + \aleph_{1} \)` },
+            {
+              values: String.raw`\( ${formattedTotal} = 3 + ${formattedAleph} \)`,
+              variant: 'values',
+            },
+            {
+              expression: String.raw`\( \aleph_{1} = ${formattedAleph} \)`,
+              variant: 'values',
+            },
+          ];
+        },
+      },
+      {
+        key: 'regen',
+        symbol: 'Reg',
+        equationSymbol: 'Reg',
+        name: 'Regeneration',
+        description: 'Health restored by each Δ soldier every second.',
+        upgradable: false,
+        computeValue({ blueprint, towerId }) {
+          const effectiveBlueprint = blueprint || getTowerEquationBlueprint(towerId);
+          const alephValue = computeTowerVariableValue(towerId, 'aleph1', effectiveBlueprint);
+          const alephRank = Number.isFinite(alephValue) ? Math.max(1, Math.round(alephValue)) : 1;
+          const gammaDefinition = getTowerDefinition('gamma');
+          const gammaEquation = calculateTowerEquationResult('gamma');
+          const fallbackGamma = Number.isFinite(gammaDefinition?.damage)
+            ? Math.max(1, gammaDefinition.damage)
+            : 1;
+          const gammaValue = Number.isFinite(gammaEquation) && gammaEquation > 0
+            ? gammaEquation
+            : fallbackGamma;
+          const rawHealth = gammaValue ** alephRank;
+          const health = Number.isFinite(rawHealth) ? Math.max(1, rawHealth) : Number.MAX_SAFE_INTEGER;
+          const regen = health / 20;
+          return Number.isFinite(regen) ? regen : Number.MAX_SAFE_INTEGER;
+        },
+        format: (value) => `${formatGameNumber(Math.max(0, value))} hp/s`,
+        getSubEquations({ blueprint, towerId }) {
+          const effectiveBlueprint = blueprint || getTowerEquationBlueprint(towerId);
+          const alephValue = computeTowerVariableValue(towerId, 'aleph1', effectiveBlueprint);
+          const alephRank = Number.isFinite(alephValue) ? Math.max(1, Math.round(alephValue)) : 1;
+          const gammaDefinition = getTowerDefinition('gamma');
+          const gammaEquation = calculateTowerEquationResult('gamma');
+          const fallbackGamma = Number.isFinite(gammaDefinition?.damage)
+            ? Math.max(1, gammaDefinition.damage)
+            : 1;
+          const gammaValue = Number.isFinite(gammaEquation) && gammaEquation > 0
+            ? gammaEquation
+            : fallbackGamma;
+          const rawHealth = gammaValue ** alephRank;
+          const health = Number.isFinite(rawHealth) ? Math.max(1, rawHealth) : Number.MAX_SAFE_INTEGER;
+          const regen = health / 20;
+          const formattedRegen = Number.isFinite(regen)
+            ? formatGameNumber(regen)
+            : formatGameNumber(Number.MAX_SAFE_INTEGER);
+          const formattedHealth = Number.isFinite(health)
+            ? formatGameNumber(health)
+            : formatGameNumber(Number.MAX_SAFE_INTEGER);
+          return [
+            { expression: String.raw`\( \text{Reg} = \text{Hlth} / 20 \)` },
+            {
+              values: String.raw`\( ${formattedRegen} = ${formattedHealth} / 20 \)`,
+              variant: 'values',
+            },
+          ];
+        },
       },
     ],
     computeResult(values) {


### PR DESCRIPTION
## Summary
- add an Aleph₁ upgrade track for the Δ tower with explicit health, speed, and total soldier formulas plus a regeneration card
- recalculate Δ soldier stats from the Aleph₁ value, including spawn timing and regeneration, and draw a health bar with the remaining life value above each soldier

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6904e50b5a34832aa6db2aaeceaea31f

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds ℵ₁ upgrade and Regeneration to Δ, recalculating soldier health, spawn timing, and totals from γ and ℵ₁, and rendering numeric health bars above soldiers.
> 
> - **Δ equations (`assets/towersTab.js`)**:
>   - **New upgrade** `aleph1` (ℵ₁): adds cost/format and sub-equations for Health `γ^ℵ₁`, Speed `5^ℵ₁` (training seconds), and Total `3 + ℵ₁`.
>   - **New derived variable** `regen` (Regeneration): computes `Health / 20` with value formatting and sub-equation lines.
> - **Δ tower logic (`scripts/features/towers/deltaTower.js`)**:
>   - Recompute cohort from γ and ℵ₁: `maxHealth = γ^ℵ₁`, `trainingSeconds = 5^ℵ₁`, `spawnRate = 1/trainingSeconds`, `regenPerSecond = maxHealth/20`, `maxSoldiers = 3 + ℵ₁`; update state propagation and soldier instances accordingly.
>   - Adjust spawning: derive cooldown from `spawnRate` or `trainingSeconds`; set `tower.rate/baseRate`.
>   - Update regeneration model: per-second flat `regenPerSecond` instead of percent-of-max.
>   - Rendering: draw a health bar above each soldier with formatted remaining health; minor trail visuals maintained.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13fdb0d8eac49c82144e02e009d02899ed11b574. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->