### PR TITLE
Simplify tower card display

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -142,6 +142,7 @@ import {
   bindTowerCardUpgradeInteractions,
   updateTowerCardVisibility,
   injectTowerCardPreviews,
+  simplifyTowerCards,
   annotateTowerCardsWithCost,
   initializeTowerSelection,
   initializeTowerEquipmentInterface,
@@ -7852,6 +7853,7 @@ import {
     markLastActive();
 
     injectTowerCardPreviews();
+    simplifyTowerCards();
     annotateTowerCardsWithCost();
     initializeTowerEquipmentInterface();
     updateTowerCardVisibility();

--- a/assets/towersTab.js
+++ b/assets/towersTab.js
@@ -4286,6 +4286,30 @@ export function injectTowerCardPreviews() {
   });
 }
 
+export function simplifyTowerCards() {
+  const cards = document.querySelectorAll('[data-tower-id]');
+  cards.forEach((card) => {
+    if (!(card instanceof HTMLElement)) {
+      return;
+    }
+
+    const formulaBlock = card.querySelector('.formula-block');
+    if (formulaBlock instanceof HTMLElement) {
+      const primaryEquation = formulaBlock.querySelector('.formula-line');
+      const allowedNodes = new Set(primaryEquation ? [primaryEquation] : []);
+      Array.from(formulaBlock.children).forEach((child) => {
+        if (!allowedNodes.has(child)) {
+          child.remove();
+        }
+      });
+    }
+
+    card.querySelectorAll('.formula-definition, .formula-line.result, .upgrade-list').forEach((element) => {
+      element.remove();
+    });
+  });
+}
+
 export function annotateTowerCardsWithCost() {
   const cards = document.querySelectorAll('[data-tower-id]');
   cards.forEach((card) => {


### PR DESCRIPTION
Remove extraneous details from tower cards to simplify their display.

---
<a href="https://cursor.com/background-agent?bcId=bc-9d531cdb-ea0a-478a-befa-76d635d57792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9d531cdb-ea0a-478a-befa-76d635d57792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

