### PR TITLE
Add developer solid crystal map elements

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -4944,6 +4944,55 @@ body.show-glyph-equations .tower-upgrade-variable-equations {
   cursor: default;
 }
 
+/* Developer map element controls mirror the level editor styling so new obstacles feel integrated. */
+.overlay-editor__elements {
+  border-top: 1px solid rgba(139, 247, 255, 0.18);
+  padding-top: 12px;
+  display: grid;
+  gap: 10px;
+}
+
+.overlay-editor__elements[hidden] {
+  display: none;
+}
+
+.overlay-editor__elements-title {
+  margin: 0;
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(139, 247, 255, 0.85);
+}
+
+.overlay-editor__elements-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.overlay-editor__button--primary {
+  border-color: rgba(255, 228, 120, 0.55);
+  background: rgba(255, 228, 120, 0.12);
+  color: rgba(255, 228, 120, 0.9);
+}
+
+.overlay-editor__button--primary:hover:not(:disabled) {
+  background: rgba(255, 228, 120, 0.18);
+  border-color: rgba(255, 228, 120, 0.75);
+  color: rgba(255, 244, 212, 0.95);
+}
+
+.overlay-editor__button--active {
+  box-shadow: 0 0 0 1px rgba(255, 228, 120, 0.5);
+}
+
+.overlay-editor__elements-note {
+  margin: 0;
+  font-size: 0.78rem;
+  color: rgba(255, 255, 255, 0.65);
+  line-height: 1.4;
+}
+
 .overlay-editor__output {
   width: 100%;
   min-height: 120px;

--- a/index.html
+++ b/index.html
@@ -1706,6 +1706,23 @@
               Copy Path JSON
             </button>
           </div>
+          <!-- Developer map elements let designers drop experimental obstacles onto the battlefield. -->
+          <div class="overlay-editor__elements" id="developer-map-elements" hidden aria-hidden="true">
+            <p class="overlay-editor__elements-title">Developer Map Elements</p>
+            <div class="overlay-editor__elements-actions">
+              <button
+                class="overlay-editor__button overlay-editor__button--primary"
+                type="button"
+                id="developer-add-crystal"
+              >
+                Place Solid Crystal
+              </button>
+              <button class="overlay-editor__button" type="button" id="developer-clear-crystals">
+                Clear Crystals
+              </button>
+            </div>
+            <p class="overlay-editor__elements-note" id="developer-map-elements-note" hidden></p>
+          </div>
           <textarea
             class="overlay-editor__output"
             id="level-editor-output"


### PR DESCRIPTION
## Summary
- add developer map element controls for placing and clearing solid crystals in the overlay editor
- wire overlay controls into the main runtime so developer clicks route to the playfield and spawn obstacles
- extend the playfield with crystal placement, targeting, fracture effects, shard debris, and projectile handling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6905bb79e0a4832a9510fd483d5ba04c