### PR TITLE
Expand mobile mote spire basin width

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -2862,6 +2862,13 @@ body.graphics-mode-low .control-button {
   min-height: clamp(220px, 42.5vh, 380px);
 }
 
+@media (max-width: 640px) {
+  /* Allow the Spire basin to use the full mobile width so walls no longer overlap. */
+  .powder-simulation {
+    width: min(100%, 360px);
+  }
+}
+
 .powder-simulation h3 {
   text-align: center;
 }


### PR DESCRIPTION
## Summary
- allow the Spire basin layout to expand to the full mobile width so the walls separate correctly
- document the responsive rule to keep the mote spire readable on touch devices

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6905c8699804832ab904373ca627aff2