### PR TITLE
Enforce startup overlay minimum display and restore idle reward overlay

### DIFF
--- a/assets/offlinePersistence.js
+++ b/assets/offlinePersistence.js
@@ -384,9 +384,6 @@ export function checkOfflineRewards() {
   const storedRate = Number(savedState.powderRate);
   const fallbackRate = dependencies.getCurrentFluxRate();
   const effectiveRate = Number.isFinite(storedRate) ? Math.max(0, storedRate) : Math.max(0, fallbackRate);
-  if (effectiveRate <= 0) {
-    return;
-  }
 
   const powderEarned = minutesAway * effectiveRate;
   dependencies.applyPowderGain(powderEarned, { source: 'offline', minutes: minutesAway, rate: effectiveRate });


### PR DESCRIPTION
## Summary
- guarantee the startup overlay remains visible for at least four seconds before fading
- allow the idle reward overlay to surface even when the stored flux rate is zero so the idle mote prompt appears on entry

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_6905cb012c20832aaa117a557184c059