### PR TITLE
Fix elliptic loading animation playback

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -5367,7 +5367,7 @@ body.show-glyph-equations .tower-upgrade-variable-equations {
 
 .startup-overlay__loading--active {
   opacity: 1;
-  animation: pEllipticLoading 3.5167s steps(90) infinite;
+  animation: pEllipticLoading 3.5167s steps(89) infinite;
 }
 
 .startup-overlay__hint {
@@ -5399,10 +5399,10 @@ body.show-glyph-equations .tower-upgrade-variable-equations {
 
 @keyframes pEllipticLoading {
   0% {
-    background-position: 0 0;
+    background-position: 0% 0;
   }
   100% {
-    background-position: -8900% 0; /* Sweep through the remaining 89 frames at the scaled width. */
+    background-position: 100% 0; /* Traverse all 89 frame offsets relative to the scaled sprite width. */
   }
 }
 


### PR DESCRIPTION
## Summary
- correct the elliptic loading sprite animation keyframes so the resized sprite sheet advances through every frame
- update the animation step count to keep the logo reveal and loading glyph in sync

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_690683775728832a8fc3fc91a9bb3593