### PR TITLE
Ensure startup overlay animation runs on mobile

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -169,9 +169,10 @@ body.graphics-mode-low::before {
   display: none;
 }
 
-body.graphics-mode-low *,
-body.graphics-mode-low *::before,
-body.graphics-mode-low *::after {
+/* Preserve specific animations by opting elements into data-allow-animation. */
+body.graphics-mode-low *:not([data-allow-animation]),
+body.graphics-mode-low *:not([data-allow-animation])::before,
+body.graphics-mode-low *:not([data-allow-animation])::after {
   box-shadow: none !important;
   text-shadow: none !important;
   filter: none !important;

--- a/index.html
+++ b/index.html
@@ -35,17 +35,21 @@
   <body>
     <div class="startup-overlay" id="startup-overlay" role="status" aria-live="polite">
       <div class="startup-overlay__content" role="presentation">
+        <!-- Allow the logo animation to run even when low graphics mode disables other animations. -->
         <img
           class="startup-overlay__logo"
           src="./assets/sprites/gravy_thyme_logo.png"
           alt="Thero Idle sigil"
           data-startup-logo
+          data-allow-animation
         />
+        <!-- Keep the loading glyph animated on mobile by opting it into animations explicitly. -->
         <div
           class="startup-overlay__loading"
           data-startup-loading
           role="img"
           aria-label="Loading glyph animation"
+          data-allow-animation
         ></div>
         <p class="startup-overlay__hint">Calibrating glyph lattice…</p>
       </div>


### PR DESCRIPTION
## Summary
- allow startup overlay elements to opt into animations even when low graphics mode disables other effects
- mark the logo and loading glyph so the loading sequence continues on mobile devices

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6906b36b1ee0832a956b784331cae0e7