### PR TITLE
Fix punctuation for startup hint and toggle labels

### DIFF
--- a/assets/preferences.js
+++ b/assets/preferences.js
@@ -46,7 +46,8 @@ function updateNotationToggleLabel() {
   }
   const notation = getGameNumberNotation();
   const label = resolveNotationLabel(notation);
-  notationToggleButton.textContent = `Notation ? ${label}`;
+  // Use a centered dot to separate the label from the current notation, matching the UI spec.
+  notationToggleButton.textContent = `Notation · ${label}`;
   notationToggleButton.setAttribute('aria-label', `Switch number notation (current: ${label})`);
 }
 
@@ -149,7 +150,8 @@ function updateGraphicsModeButton() {
     return;
   }
   const label = resolveGraphicsModeLabel();
-  graphicsModeButton.textContent = `Graphics ? ${label}`;
+  // Mirror the centered dot separator for the graphics button label as well.
+  graphicsModeButton.textContent = `Graphics · ${label}`;
   graphicsModeButton.setAttribute('aria-label', `Switch graphics quality (current: ${label})`);
 }
 

--- a/assets/startupOverlay.js
+++ b/assets/startupOverlay.js
@@ -27,7 +27,8 @@ function activateStartupLoadingSpinner() {
     startupLoading.classList.add('startup-overlay__loading--active');
   });
   if (startupHint) {
-    startupHint.textContent = 'Summoning motes?';
+    // Replace the interrogative hint with an ellipsis to convey ongoing progress.
+    startupHint.textContent = 'Summoning motes…';
   }
 }
 


### PR DESCRIPTION
## Summary
- replace the startup overlay hint question mark with an ellipsis to better convey loading
- switch notation and graphics toggle button separators to centered dots

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_6906a22898a8832a82f2a33862e18b30