### PR TITLE
Speed up elliptical P startup animation

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -5395,7 +5395,7 @@ body.show-glyph-equations .tower-upgrade-variable-equations {
 
 .startup-overlay__loading--active {
   opacity: 1;
-  animation: pEllipticLoading 3.5167s steps(90) infinite; /* Advance through all 91 frames without sliding past the texture. */
+  animation: pEllipticLoading 1.75835s steps(90) infinite; /* Advance through all 91 frames at twice the previous playback speed without sliding past the texture. */
 }
 
 .startup-overlay__hint {


### PR DESCRIPTION
## Summary
- double the playback speed of the startup overlay's elliptical P loading animation so the 91-frame loop completes in half the time

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_6906c7cdabcc832ab42a4881958af245