### PR TITLE
Fix fluid study unlock workflow

### DIFF
--- a/assets/offlinePersistence.js
+++ b/assets/offlinePersistence.js
@@ -339,9 +339,25 @@ export function recordPowderEvent(type, context = {}) {
       break;
     }
     case 'fluid-unlocked': {
-      const { threshold = powderConfig.fluidUnlockSigils || 0 } = context;
-      const unitLabel = threshold === 1 ? 'Glyph' : 'Glyphs';
-      entry = `Fluid resonance unlocked ? Requires ${threshold} ${unitLabel}.`;
+      const reason = context && context.reason === 'sigil' ? 'sigil' : 'purchase';
+      const glyphCostSource =
+        context && Number.isFinite(context.glyphCost)
+          ? context.glyphCost
+          : dependencies.powderConfig?.fluidUnlockGlyphCost || 0;
+      const glyphCost = Math.max(0, Math.floor(Number(glyphCostSource) || 0));
+      if (reason === 'sigil') {
+        const thresholdSource =
+          context && Number.isFinite(context.threshold)
+            ? context.threshold
+            : dependencies.powderConfig?.fluidUnlockSigils || 0;
+        const threshold = Math.max(0, Math.floor(Number(thresholdSource) || 0));
+        const unitLabel = threshold === 1 ? 'Sigil' : 'Sigils';
+        entry = `Fluid resonance unlocked ? ${dependencies.formatWholeNumber(threshold)} ${unitLabel} ascended.`;
+      } else if (glyphCost > 0) {
+        entry = `Fluid resonance unlocked ? ℵ ${dependencies.formatWholeNumber(glyphCost)} tithed.`;
+      } else {
+        entry = 'Fluid resonance unlocked ? Aleph tithe waived.';
+      }
       break;
     }
     default:

--- a/index.html
+++ b/index.html
@@ -1089,14 +1089,6 @@
                   </div>
                 </div>
               </div>
-              <button
-                class="powder-mode-toggle"
-                type="button"
-                id="powder-mode-toggle"
-                aria-controls="panel-fluid"
-              >
-                Enter Fluid Study
-              </button>
             </article>
           </section>
           <section class="panel-grid powder-summary" aria-label="Flux overview reference">
@@ -1177,6 +1169,14 @@
             <p class="powder-gem-inventory-empty" id="powder-gem-empty">No mote gems catalogued yet.</p>
             <button class="action-button ghost powder-crafting-button" type="button" id="open-crafting-menu">
               Crafting Menu
+            </button>
+            <button
+              class="powder-mode-toggle"
+              type="button"
+              id="powder-mode-toggle"
+              aria-controls="panel-fluid"
+            >
+              Unlock Fluid Study
             </button>
           </article>
         </section>


### PR DESCRIPTION
## Summary
- move the Fluid Study unlock control beneath the crafting menu on the Mote Spire panel
- enable the button to spend the aleph glyph tithe (currently zero) and unlock the Fluid Study tab
- refresh powder log messaging to describe unlocks driven by glyph purchases versus sigil thresholds

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_6907d9cabcd0832a8bcfda11133830f0