### PR TITLE
Separate fluid study tower simulation

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -2864,32 +2864,56 @@ body.graphics-mode-low .control-button {
   display: contents;
 }
 
-.powder-simulation--fluid {
+.fluid-simulation-card {
   width: min(340px, 100%);
   min-height: clamp(240px, 46vh, 400px);
   backdrop-filter: blur(4px);
   box-shadow: inset 0 0 0 1px rgba(120, 190, 255, 0.2), 0 16px 48px rgba(4, 15, 28, 0.4);
 }
 
-.powder-basin--fluid {
+.fluid-basin {
   background: radial-gradient(circle at 50% 5%, rgba(126, 196, 255, 0.18), transparent 58%),
-    linear-gradient(180deg, rgba(6, 18, 32, 0.95) 0%, rgba(4, 12, 24, 0.95) 100%);
-  box-shadow: inset 0 0 0 1px rgba(138, 207, 255, 0.18), inset 0 -28px 60px rgba(8, 32, 54, 0.65);
+    linear-gradient(180deg, rgba(20, 28, 36, 0.96) 0%, rgba(12, 18, 26, 0.96) 100%);
+  box-shadow: inset 0 0 0 1px rgba(138, 207, 255, 0.18), inset 0 -28px 60px rgba(10, 28, 48, 0.65);
 }
 
-.powder-basin--fluid::before {
+.fluid-basin::before {
   background: radial-gradient(circle at 50% -10%, rgba(140, 200, 255, 0.24), transparent 60%);
   mix-blend-mode: screen;
 }
 
-.powder-basin--fluid::after {
-  background: linear-gradient(180deg, transparent 65%, rgba(6, 18, 32, 0.85) 100%);
+.fluid-basin::after {
+  background: linear-gradient(180deg, transparent 65%, rgba(10, 22, 36, 0.85) 100%);
 }
 
-.powder-viewport--fluid .powder-glyph-column,
-.powder-viewport--fluid .powder-wall-marker,
-.powder-viewport--fluid .powder-crest-marker {
-  opacity: 0;
+.fluid-viewport {
+  pointer-events: none;
+}
+
+.fluid-wall {
+  background-image: none;
+  background: linear-gradient(180deg, rgba(58, 62, 72, 0.96) 0%, rgba(28, 30, 38, 0.98) 100%);
+  box-shadow: inset 0 0 0 1px rgba(164, 186, 210, 0.18);
+}
+
+.fluid-wall::before {
+  background-image: none;
+  background: linear-gradient(180deg, rgba(70, 74, 86, 0.94) 0%, rgba(34, 36, 44, 0.98) 100%);
+  opacity: 0.9;
+}
+
+.fluid-wall::after {
+  background: radial-gradient(circle at 50% 20%, rgba(164, 192, 220, 0.22), transparent 60%);
+  opacity: 0.6;
+  mix-blend-mode: screen;
+}
+
+.fluid-wall-left {
+  border-right: 1px solid rgba(180, 198, 216, 0.16);
+}
+
+.fluid-wall-right {
+  border-left: 1px solid rgba(180, 198, 216, 0.16);
 }
 
 .fluid-metrics-card,
@@ -2991,7 +3015,7 @@ body.graphics-mode-low .control-button {
     grid-template-columns: 1fr;
   }
 
-  .powder-simulation--fluid {
+  .fluid-simulation-card {
     width: 100%;
   }
 

--- a/index.html
+++ b/index.html
@@ -1191,7 +1191,33 @@
         >
           <header class="panel-header">Fluid Study</header>
           <section class="fluid-grid" aria-label="Fluid Spire Overview">
-            <div class="fluid-simulation-slot" id="fluid-simulation-host"></div>
+            <div class="fluid-simulation-slot" id="fluid-simulation-host">
+              <article class="card powder-simulation fluid-simulation-card" id="fluid-simulation-card">
+                <div class="powder-basin fluid-basin" id="fluid-basin">
+                  <canvas
+                    id="fluid-canvas"
+                    width="240"
+                    height="320"
+                    role="img"
+                    aria-label="Fluid resonance channel"
+                  ></canvas>
+                  <div class="powder-viewport fluid-viewport" id="fluid-viewport">
+                    <div
+                      class="powder-wall-hitbox fluid-wall-hitbox fluid-wall-hitbox-left"
+                      id="fluid-wall-hitbox-left"
+                      aria-hidden="true"
+                    ></div>
+                    <div class="powder-wall fluid-wall fluid-wall-left" id="fluid-wall-left" aria-hidden="true"></div>
+                    <div
+                      class="powder-wall-hitbox fluid-wall-hitbox fluid-wall-hitbox-right"
+                      id="fluid-wall-hitbox-right"
+                      aria-hidden="true"
+                    ></div>
+                    <div class="powder-wall fluid-wall fluid-wall-right" id="fluid-wall-right" aria-hidden="true"></div>
+                  </div>
+                </div>
+              </article>
+            </div>
             <article class="card fluid-metrics-card">
               <h3>Reservoir Metrics</h3>
               <dl class="fluid-metrics">
@@ -1200,24 +1226,16 @@
                   <dd id="fluid-depth">0.00% full</dd>
                 </div>
                 <div>
-                  <dt>Crest Drift</dt>
-                  <dd id="fluid-crest">0.00% span</dd>
-                </div>
-                <div>
-                  <dt>Largest Drop</dt>
-                  <dd id="fluid-largest-drop">0.00 motes</dd>
-                </div>
-                <div>
-                  <dt>Idle Reservoir</dt>
-                  <dd id="fluid-reservoir">0 Motes</dd>
+                  <dt>Idle Drop Reservoir</dt>
+                  <dd id="fluid-reservoir">0 Drops</dd>
                 </div>
                 <div>
                   <dt>Condensation Rate</dt>
-                  <dd id="fluid-drip-rate">0.00 motes/sec</dd>
+                  <dd id="fluid-drip-rate">0.00 drops/sec</dd>
                 </div>
               </dl>
               <p class="fluid-status-note" id="fluid-status-note">
-                Water motes seep from idle reserves and collect within the study.
+                Water drops seep from idle reserves and collect within the study.
               </p>
             </article>
             <article class="card fluid-briefing-card">
@@ -1226,7 +1244,7 @@
                 <span class="fluid-state-label" id="fluid-state-label">Forming</span>
               </h3>
               <p class="fluid-briefing">
-                Observe condensed motes cascading into the spire. Guide the flow to stabilize the lattice and feed the idle
+                Observe condensed drops cascading into the spire. Guide the flow to stabilize the lattice and feed the idle
                 bank.
               </p>
               <button class="action-button ghost fluid-return-button" type="button" id="fluid-return-button">


### PR DESCRIPTION
## Summary
- give the Fluid Study its own simulation canvas with dark grey walls and drop-focused copy
- update fluid metrics, status text, and interactions to reference drops and work with the new layout

## Testing
- not run (web UI change only)

------
https://chatgpt.com/codex/tasks/task_e_6907e5e34154832a85560de3dc240a4f