### PR TITLE
Nest Glyph Trials within Trials campaign sets

### DIFF
--- a/assets/buildInfo.js
+++ b/assets/buildInfo.js
@@ -1,2 +1,2 @@
 ﻿// Build metadata surfaced in the startup overlay so testers can verify the loaded version at a glance.
-export const BUILD_NUMBER = 710; // Increment this value by 1 with every committed change.
+export const BUILD_NUMBER = 711; // Increment this value by 1 with every committed change.

--- a/assets/data/gameplayConfig.json
+++ b/assets/data/gameplayConfig.json
@@ -442,7 +442,7 @@
     {
       "set": "Glyph Trials",
       "id": "Glyph Trial - 1",
-      "campaign": "GlyphTrials",
+      "campaign": "Challenges",
       "title": "Alpha Lattice",
       "path": "Twin α sentinels flank a linear approach—assign glyphs to refine their output.",
       "focus": "Strengthen pre-placed α towers through glyph investment alone.",
@@ -451,7 +451,7 @@
     {
       "set": "Glyph Trials",
       "id": "Glyph Trial - 2",
-      "campaign": "GlyphTrials",
+      "campaign": "Challenges",
       "title": "Beta Weave",
       "path": "A curving corridor guarded by α and β anchors awaiting your symbolic touch.",
       "focus": "Coordinate glyph allocation across α and β towers on a bending lane.",
@@ -460,7 +460,7 @@
     {
       "set": "Glyph Trials",
       "id": "Glyph Trial - 3",
-      "campaign": "GlyphTrials",
+      "campaign": "Challenges",
       "title": "Gamma Surge",
       "path": "Three-tower formation across a zigzag path; γ splash shapes the battlefield.",
       "focus": "Distribute glyphs across α, β, and γ to contain a surging enemy tide.",
@@ -469,7 +469,7 @@
     {
       "set": "Glyph Trials",
       "id": "Glyph Trial - 4",
-      "campaign": "GlyphTrials",
+      "campaign": "Challenges",
       "title": "Full Resonance",
       "path": "Four anchors hold the spiral—master glyph resonance to seal the final proof.",
       "focus": "Achieve full resonance by optimally investing glyphs across all four towers.",


### PR DESCRIPTION
### Motivation
- Glyph Trials were configured as their own campaign key which created a separate campaign tile instead of being a level set under the existing Trials/Challenges campaign, so they need to be nested under Trials.

### Description
- Updated `campaign` for the Glyph Trials entries from `"GlyphTrials"` to `"Challenges"` in `assets/data/gameplayConfig.json` and incremented `BUILD_NUMBER` from `710` to `711` in `assets/buildInfo.js`.

### Testing
- Parsed `assets/data/gameplayConfig.json` with `node -e "JSON.parse(require('fs').readFileSync('assets/data/gameplayConfig.json','utf8'))"` to verify valid JSON and ran `rg -n "GlyphTrials" assets/data/gameplayConfig.json` to confirm no remaining `GlyphTrials` keys; both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6f5a60544832a99847b99275f2f19)